### PR TITLE
feat(gateway): add discord central provider

### DIFF
--- a/apps/gateway/.env.example
+++ b/apps/gateway/.env.example
@@ -8,6 +8,11 @@ PORT="8788"
 # Cohub API 基础地址，用于鉴权和 session 写入
 API_BASE_URL="http://localhost:8787"
 
+# 中心化 Discord 服务地址与鉴权密钥
+DISCORD_CENTRAL_BASE_URL="http://localhost:8790"
+DISCORD_CENTRAL_SECRET="please-change-me"
+DISCORD_CENTRAL_TIMEOUT_MS="10000"
+
 # ==========================================
 # 本地调试模式配置 (仅供本地单测 Gateway 使用)
 # ==========================================

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -1,7 +1,16 @@
 const normalizeBaseUrl = (value: string) => value.replace(/\/$/, "");
+const readPositiveNumber = (value: string | undefined, fallback: number) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
 
 export const gatewayConfig = {
   apiBaseUrl: normalizeBaseUrl(process.env.API_BASE_URL ?? "http://localhost:8787"),
+  discordCentralBaseUrl: normalizeBaseUrl(
+    process.env.DISCORD_CENTRAL_BASE_URL ?? "http://localhost:8790",
+  ),
+  discordCentralSecret: process.env.DISCORD_CENTRAL_SECRET ?? "",
+  discordCentralTimeoutMs: readPositiveNumber(process.env.DISCORD_CENTRAL_TIMEOUT_MS, 10000),
   port: Number(process.env.PORT ?? 8788),
 };
 

--- a/apps/gateway/src/manager/config.ts
+++ b/apps/gateway/src/manager/config.ts
@@ -1,0 +1,119 @@
+import type { DiscordCentralChannelCredentials } from "@cohub/protocol";
+
+interface DiscordChannelConfig {
+  provider: "discord";
+  credentials: {
+    token: string;
+  };
+  externalChatId?: string;
+}
+
+interface DiscordCentralProviderConfig {
+  provider: "discord_central";
+  credentials: DiscordCentralChannelCredentials;
+  externalChatId?: string;
+}
+
+interface FeishuChannelConfig {
+  provider: "feishu";
+  credentials: {
+    appId: string;
+    appSecret: string;
+    brand: "feishu" | "lark";
+  };
+  externalChatId?: string;
+}
+
+export type GatewayNodeChannelConfig =
+  | DiscordChannelConfig
+  | DiscordCentralProviderConfig
+  | FeishuChannelConfig;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const readString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim().length > 0 ? value : null;
+
+const readOptionalString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
+
+const readNullableString = (value: unknown): string | null | undefined => {
+  if (value === null) {
+    return null;
+  }
+  return typeof value === "string" ? value : undefined;
+};
+
+const readDiscordEntryMode = (
+  value: unknown,
+): DiscordCentralChannelCredentials["entryMode"] | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  return value === "dm" || value === "guild" || value === "any" ? value : undefined;
+};
+
+export const parseChannelConfig = (raw: unknown): GatewayNodeChannelConfig | null => {
+  if (!isRecord(raw)) {
+    return null;
+  }
+
+  const provider = readString(raw.provider);
+  const credentials = isRecord(raw.credentials) ? raw.credentials : null;
+  if (!provider || !credentials) {
+    return null;
+  }
+
+  const externalChatId = readOptionalString(raw.externalChatId);
+
+  switch (provider) {
+    case "discord": {
+      const token = readString(credentials.token);
+      if (!token) {
+        return null;
+      }
+      return {
+        provider,
+        credentials: { token },
+        externalChatId,
+      };
+    }
+    case "discord_central": {
+      const discordUserId = readString(credentials.discordUserId);
+      if (!discordUserId) {
+        return null;
+      }
+      return {
+        provider,
+        credentials: {
+          discordUserId,
+          entryMode: readDiscordEntryMode(credentials.entryMode),
+          guildId: readNullableString(credentials.guildId),
+          channelId: readNullableString(credentials.channelId),
+          threadId: readNullableString(credentials.threadId),
+        },
+        externalChatId,
+      };
+    }
+    case "feishu": {
+      const appId = readString(credentials.appId);
+      const appSecret = readString(credentials.appSecret);
+      const brand = credentials.brand === "lark" ? "lark" : "feishu";
+      if (!appId || !appSecret) {
+        return null;
+      }
+      return {
+        provider,
+        credentials: {
+          appId,
+          appSecret,
+          brand,
+        },
+        externalChatId,
+      };
+    }
+    default:
+      return null;
+  }
+};

--- a/apps/gateway/src/manager/index.ts
+++ b/apps/gateway/src/manager/index.ts
@@ -1,14 +1,13 @@
 import os from "node:os";
 import { redisCommandClient } from "../redis.js";
 import { DiscordProvider } from "../providers/discord/index.js";
+import { DiscordCentralProvider } from "../providers/discord-central/index.js";
 import { FeishuProvider } from "../providers/feishu/index.js";
 import type { GatewayProvider } from "../providers/base.js";
-
-interface ChannelConfig {
-  provider: string;
-  credentials: Record<string, string>;
-  externalChatId?: string;
-}
+import {
+  parseChannelConfig,
+  type GatewayNodeChannelConfig,
+} from "./config.js";
 
 export class GatewayManager {
   public readonly nodeId: string;
@@ -46,6 +45,7 @@ export class GatewayManager {
   public async stop() {
     console.log(`[Manager] Stopping Gateway Node: ${this.nodeId}`);
     console.log(`[Manager] Active providers to stop: ${this.providers.size}`);
+    const channelIds = Array.from(this.providers.keys());
 
     if (this.heartbeatInterval) {
       clearInterval(this.heartbeatInterval);
@@ -60,7 +60,7 @@ export class GatewayManager {
     for (const [channelId, provider] of this.providers.entries()) {
       try {
         console.log(`[Manager] Destroying provider for ${channelId}...`);
-        provider.destroy();
+        await provider.destroy();
       } catch (err) {
         console.error(`[Manager] Error destroying provider for ${channelId}:`, err);
       }
@@ -73,7 +73,6 @@ export class GatewayManager {
 
     // 清理本节点的任务列表和 channel 路由
     console.log("[Manager] Cleaning up task assignments...");
-    const channelIds = Array.from(this.providers.keys());
     for (const channelId of channelIds) {
       // 从全局路由表中移除（如果当前节点仍然持有该 channel）
       const currentNode = await redisCommandClient.hget("gateway:channel_routing", channelId);
@@ -132,7 +131,11 @@ export class GatewayManager {
       for (const channelId of toAdd) {
         const configStr = tasksStr[channelId];
         if (configStr) {
-          const config = JSON.parse(configStr);
+          const config = parseChannelConfig(JSON.parse(configStr));
+          if (!config) {
+            console.warn(`[Manager] Invalid or unsupported config for channel ${channelId}`);
+            continue;
+          }
           this.startProvider(channelId, config);
         }
       }
@@ -149,23 +152,25 @@ export class GatewayManager {
     }
   }
 
-  private startProvider(channelId: string, config: ChannelConfig) {
+  private startProvider(channelId: string, config: GatewayNodeChannelConfig) {
     console.log(`[Manager] Starting provider for channel ${channelId} (${config.provider})`);
     try {
       if (config.provider === "discord") {
-        const provider = new DiscordProvider(channelId, config.credentials.token as string);
+        const provider = new DiscordProvider(channelId, config.credentials.token);
         this.providers.set(channelId, provider);
         console.log(`[Manager] Provider for ${channelId} created and added to active providers`);
-      } else if (config.provider === "feishu") {
-        const provider = new FeishuProvider(channelId, {
-          appId: config.credentials.appId as string,
-          appSecret: config.credentials.appSecret as string,
-          brand: (config.credentials.brand as "feishu" | "lark") ?? "feishu",
-        });
+      } else if (config.provider === "discord_central") {
+        const provider = new DiscordCentralProvider(channelId, config.credentials);
         this.providers.set(channelId, provider);
         console.log(`[Manager] Provider for ${channelId} created and added to active providers`);
       } else {
-        console.warn(`[Manager] Unsupported provider: ${config.provider}`);
+        const provider = new FeishuProvider(channelId, {
+          appId: config.credentials.appId,
+          appSecret: config.credentials.appSecret,
+          brand: config.credentials.brand,
+        });
+        this.providers.set(channelId, provider);
+        console.log(`[Manager] Provider for ${channelId} created and added to active providers`);
       }
     } catch (error) {
       console.error(`[Manager] Error starting provider for ${channelId}:`, error);
@@ -177,7 +182,7 @@ export class GatewayManager {
     const provider = this.providers.get(channelId);
     if (provider) {
       try {
-        provider.destroy();
+        await provider.destroy();
         console.log(`[Manager] Provider for ${channelId} destroyed`);
       } catch (error) {
         console.error(`[Manager] Error destroying provider for ${channelId}:`, error);

--- a/apps/gateway/src/providers/base.ts
+++ b/apps/gateway/src/providers/base.ts
@@ -1,5 +1,5 @@
 export interface GatewayProvider {
-  destroy(): void;
+  destroy(): void | Promise<void>;
   handleOutbound(cmd: {
     commandId: string;
     provider: string;

--- a/apps/gateway/src/providers/discord-central/index.ts
+++ b/apps/gateway/src/providers/discord-central/index.ts
@@ -1,0 +1,171 @@
+import type {
+  DiscordCentralChannelCredentials,
+  GatewayOutboundCommand,
+} from "@cohub/protocol";
+import { gatewayConfig } from "../../config.js";
+import type { GatewayProvider } from "../base.js";
+
+const buildHeaders = () => {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (gatewayConfig.discordCentralSecret) {
+    headers["x-discord-central-secret"] = gatewayConfig.discordCentralSecret;
+  }
+
+  return headers;
+};
+
+const requestDiscordCentral = async <T>(input: {
+  path: string;
+  method: "POST" | "DELETE";
+  body?: unknown;
+}): Promise<T> => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), gatewayConfig.discordCentralTimeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetch(`${gatewayConfig.discordCentralBaseUrl}${input.path}`, {
+      method: input.method,
+      headers: buildHeaders(),
+      body: input.body === undefined ? undefined : JSON.stringify(input.body),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(
+        `discord-central ${input.method} ${input.path} timed out after ${gatewayConfig.discordCentralTimeoutMs}ms`,
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    throw new Error(
+      `discord-central ${input.method} ${input.path} failed: ${response.status} ${text}`,
+    );
+  }
+
+  if (response.status === 204) {
+    return null as T;
+  }
+
+  return (await response.json()) as T;
+};
+
+export class DiscordCentralProvider implements GatewayProvider {
+  private readonly channelId: string;
+  private readonly credentials: DiscordCentralChannelCredentials;
+  private registrationPromise?: Promise<void>;
+  private registered = false;
+  private destroyed = false;
+
+  constructor(channelId: string, credentials: DiscordCentralChannelCredentials) {
+    this.channelId = channelId;
+    this.credentials = credentials;
+    void this.ensureRegistered().catch((error) => {
+      console.warn(
+        `[DiscordCentral:${this.channelId}] Initial registration failed:`,
+        error instanceof Error ? error.message : String(error),
+      );
+    });
+  }
+
+  private async register() {
+    await requestDiscordCentral<{ ok: true }>({
+      path: "/internal/channels/upsert",
+      method: "POST",
+      body: {
+        channelId: this.channelId,
+        credentials: this.credentials,
+      },
+    });
+
+    this.registered = true;
+    console.log(`[DiscordCentral:${this.channelId}] Channel registered`);
+  }
+
+  private async ensureRegistered() {
+    if (this.destroyed) {
+      throw new Error("discord-central provider is destroyed");
+    }
+    if (this.registered) {
+      return;
+    }
+    if (this.registrationPromise) {
+      await this.registrationPromise;
+      return;
+    }
+
+    const registrationPromise = this.register()
+      .catch((error) => {
+        this.registered = false;
+        throw error;
+      })
+      .finally(() => {
+        if (this.registrationPromise === registrationPromise) {
+          this.registrationPromise = undefined;
+        }
+      });
+
+    this.registrationPromise = registrationPromise;
+    await registrationPromise;
+  }
+
+  public async handleOutbound(cmd: GatewayOutboundCommand) {
+    try {
+      await this.ensureRegistered();
+      const result = await requestDiscordCentral<{
+        success: boolean;
+        error?: string;
+        externalMessageId?: string;
+      }>({
+        path: "/internal/messages",
+        method: "POST",
+        body: { command: cmd },
+      });
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`[DiscordCentral:${this.channelId}] Outbound failed:`, message);
+      return { success: false as const, error: message };
+    }
+  }
+
+  public async destroy() {
+    this.destroyed = true;
+
+    const unregister = async () => {
+      if (!this.registered) {
+        return false;
+      }
+
+      await requestDiscordCentral<{ ok: true }>({
+        path: `/internal/channels/${this.channelId}`,
+        method: "DELETE",
+      });
+      this.registered = false;
+      return true;
+    };
+
+    const pendingRegistration = this.registrationPromise ?? Promise.resolve();
+
+    try {
+      await pendingRegistration.catch(() => undefined);
+      const didUnregister = await unregister();
+      if (didUnregister) {
+        console.log(`[DiscordCentral:${this.channelId}] Channel unregistered`);
+      }
+    } catch (error) {
+      console.error(
+        `[DiscordCentral:${this.channelId}] Unregister failed:`,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+}

--- a/packages/protocol/src/gateway.ts
+++ b/packages/protocol/src/gateway.ts
@@ -1,4 +1,12 @@
-export type ChannelProvider = "web" | "discord" | "feishu" | "telegram" | "slack";
+export type ChannelProvider =
+  | "web"
+  | "discord"
+  | "discord_central"
+  | "feishu"
+  | "telegram"
+  | "slack";
+
+export type DiscordCentralEntryMode = "dm" | "guild" | "any";
 
 /**
  * 根据入站事件生成来源渠道名称
@@ -14,6 +22,7 @@ export function buildSessionSourceChannel(event: GatewayInboundEvent): string {
 
   switch (provider) {
     case "discord":
+    case "discord_central":
       return buildDiscordSourceChannel(event, meta);
     case "feishu":
       return buildFeishuSourceChannel(event, meta);
@@ -72,7 +81,21 @@ export interface DiscordChannelConfig {
   };
 }
 
-export type ChannelConfig = DiscordChannelConfig | FeishuChannelConfig | Record<string, unknown>;
+export interface DiscordCentralChannelCredentials {
+  discordUserId: string;
+  entryMode?: DiscordCentralEntryMode;
+  guildId?: string | null;
+  channelId?: string | null;
+  threadId?: string | null;
+}
+
+export type DiscordCentralChannelConfig = DiscordChannelConfig;
+
+export type ChannelConfig =
+  | DiscordChannelConfig
+  | DiscordCentralChannelConfig
+  | FeishuChannelConfig
+  | Record<string, unknown>;
 
 export interface FeishuChannelConfig {
   brand?: "feishu" | "lark";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3671,7 +3671,6 @@ packages:
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.6:


### PR DESCRIPTION
## Summary
- add a first-class `discord_central` provider and channel credential model
- add a new `@cohub/discord-central` service for single-bot Discord ingress/egress
- wire gateway config and registration/outbound forwarding to the new service

## Verification
- pnpm --filter @cohub/protocol build
- pnpm --filter @cohub/gateway typecheck
- pnpm --filter @cohub/gateway build
- pnpm --filter @cohub/gateway lint
- pnpm --filter @cohub/discord-central typecheck
- pnpm --filter @cohub/discord-central build
- pnpm --filter @cohub/discord-central lint

## Notes
- local environment warns that the current Node version is v20 while this repo declares >=24, but the listed checks passed in this environment