### PR TITLE
Add lazy detail loading for session history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 dist/
 .pnpm-store/
 configs/
+.idea/
 
 # Local rendered manifests (do not commit)
 rendered/

--- a/apps/api/src/routes/sessions.route.ts
+++ b/apps/api/src/routes/sessions.route.ts
@@ -5,10 +5,13 @@ import { useAuth, requireValidId } from "../lib/middleware.js";
 import {
   getSpaceById,
   getSpaceSessionById,
+  getSessionMessageById,
   listSessionMessages,
   enqueueSpacePrompt,
   SandboxNotReadyError,
   updateSpaceSessionInfo,
+  summarizeMessageForHistory,
+  markMessageAsFull,
 } from "../space-sessions.js";
 import { expandPromptTemplate } from "../prompt-templates.js";
 
@@ -71,6 +74,7 @@ router.get("/:id/messages", async (c) => {
   const cursor = cursorParam ? Number(cursorParam) : undefined;
   const pageLimit = Math.min(Number(c.req.query("limit") ?? 30), 100) || 30;
   const direction = (c.req.query("direction") as "older" | "newer" | undefined) ?? "older";
+  const detail = c.req.query("detail") === "full" ? "full" : "summary";
 
   // Always fetch +1 sentinel to correctly detect hasMore.
   // The sentinel position depends on the query direction:
@@ -84,19 +88,42 @@ router.get("/:id/messages", async (c) => {
     direction,
   });
   const hasMore = rows.length > pageLimit;
-  const messages = hasMore
+  const pageMessages = hasMore
     ? (direction === "newer" ? rows.slice(0, -1) : rows.slice(1))
     : rows;
+  const messages = detail === "full" ? pageMessages.map(markMessageAsFull) : pageMessages.map(summarizeMessageForHistory);
 
   return c.json({
     session,
     messages,
     hasMore,
-    nextCursor: messages.length > 0
+    nextCursor: pageMessages.length > 0
       ? direction === "older"
-        ? (messages[0]?.sequence ?? 0) - 1
-        : (messages[messages.length - 1]?.sequence ?? 0)
+        ? (pageMessages[0]?.sequence ?? 0) - 1
+        : (pageMessages[pageMessages.length - 1]?.sequence ?? 0)
       : undefined,
+  });
+});
+
+router.get("/:id/messages/:messageId", async (c) => {
+  const user = useAuth(c);
+  const sessionId = c.req.param("id");
+  const messageId = c.req.param("messageId");
+  if (!sessionId || !requireValidId(sessionId)) return c.json({ message: "session not found" }, 404);
+  if (!messageId || !requireValidId(messageId)) return c.json({ message: "message not found" }, 404);
+
+  const session = await getSpaceSessionById(sessionId);
+  if (!session) return c.json({ message: "session not found" }, 404);
+  if (!(await hasPermission(user, "session.view", { spaceId: session.spaceId, sessionId: session.id }))) {
+    return c.json({ message: "not found" }, 404);
+  }
+
+  const message = await getSessionMessageById(session.id, messageId);
+  if (!message) return c.json({ message: "message not found" }, 404);
+
+  return c.json({
+    session,
+    message: markMessageAsFull(message),
   });
 });
 

--- a/apps/api/src/space-sessions.ts
+++ b/apps/api/src/space-sessions.ts
@@ -69,6 +69,107 @@ const extractPlainText = (blocks: ContentBlock[]): string => {
 };
 
 const countToolCallsInContent = (blocks: ContentBlock[]) => blocks.filter((b) => b.type === "tool_use").length;
+const HISTORY_THINKING_PREVIEW_CHARS = 260;
+const HISTORY_TOOL_INPUT_PREVIEW_CHARS = 260;
+
+const truncateText = (text: string, limit: number) => {
+  if (text.length <= limit) return { text, truncated: false };
+  return { text: `${text.slice(0, Math.max(0, limit - 1))}…`, truncated: true };
+};
+
+const summarizeToolInput = (name: string, input: Record<string, unknown>) => {
+  if (name === "bash" && typeof input.command === "string") {
+    return { command: truncateText(input.command, HISTORY_TOOL_INPUT_PREVIEW_CHARS).text };
+  }
+  if (["read", "write", "edit"].includes(name) && typeof input.path === "string") {
+    return { path: input.path };
+  }
+  try {
+    return { preview: truncateText(JSON.stringify(input), HISTORY_TOOL_INPUT_PREVIEW_CHARS).text };
+  } catch {
+    return { preview: truncateText(String(input), HISTORY_TOOL_INPUT_PREVIEW_CHARS).text };
+  }
+};
+
+const getHistorySummary = (content: ContentBlock[]) => ({
+  toolCallCount: content.filter((block) => block.type === "tool_use").length,
+  thinkingCharCount: content.reduce(
+    (sum, block) => sum + (block.type === "thinking" ? block.thinking.length : 0),
+    0,
+  ),
+});
+
+const summarizeContentForDefaultView = (content: ContentBlock[]): ContentBlock[] => {
+  return content.map((block) => {
+    if (block.type === "thinking") {
+      const truncated = block.thinking.length > HISTORY_THINKING_PREVIEW_CHARS
+        ? { text: block.thinking.slice(0, HISTORY_THINKING_PREVIEW_CHARS), truncated: true }
+        : { text: block.thinking, truncated: false };
+      return {
+        ...block,
+        thinking: truncated.text,
+        _meta: {
+          ...(block._meta ?? {}),
+          contentDetail: "summary",
+          truncated: truncated.truncated,
+          fullLength: block.thinking.length,
+        },
+      };
+    }
+    if (block.type === "tool_use") {
+      return {
+        ...block,
+        input: summarizeToolInput(block.name, block.input),
+        _meta: {
+          ...(block._meta ?? {}),
+          contentDetail: "summary",
+        },
+      };
+    }
+    if (block.type === "tool_result") {
+      const outputLength =
+        typeof block.content === "string" ? block.content.length : JSON.stringify(block.content).length;
+      return {
+        ...block,
+        content: "",
+        _meta: {
+          ...(block._meta ?? {}),
+          contentDetail: "summary",
+          outputLength,
+        },
+      };
+    }
+    return block;
+  });
+};
+
+export const summarizeMessageForHistory = <T extends { content: ContentBlock[]; meta: unknown }>(message: T): T => {
+  const meta = (message.meta && typeof message.meta === "object" && !Array.isArray(message.meta))
+    ? (message.meta as Record<string, unknown>)
+    : {};
+  return {
+    ...message,
+    content: summarizeContentForDefaultView(message.content),
+    meta: {
+      ...meta,
+      contentDetail: "summary",
+      historySummary: getHistorySummary(message.content),
+    },
+  };
+};
+
+export const markMessageAsFull = <T extends { meta: unknown }>(message: T): T => {
+  const meta = (message.meta && typeof message.meta === "object" && !Array.isArray(message.meta))
+    ? (message.meta as Record<string, unknown>)
+    : {};
+  return {
+    ...message,
+    meta: {
+      ...meta,
+      contentDetail: "full",
+    },
+  };
+};
 
 const normalizeUsage = (usage: PersistMessageInput["message"]["usage"]): Usage | null => {
   if (!usage || typeof usage !== "object") return null;
@@ -206,6 +307,11 @@ export const getSpaceById = async (spaceId: string) => {
 export const getSpaceSessionById = async (spaceSessionId: string) => {
   const [session] = await db.select().from(spaceSessions).where(eq(spaceSessions.id, spaceSessionId)).limit(1);
   return session ?? null;
+};
+
+export const getSessionMessageById = async (spaceSessionId: string, messageId: string) => {
+  const [message] = await db.select().from(sessionMessages).where(and(eq(sessionMessages.sessionId, spaceSessionId), eq(sessionMessages.id, messageId))).limit(1);
+  return message ?? null;
 };
 
 export const createInitialSpaceSession = async (input: RegisterSessionInput) => {
@@ -538,4 +644,3 @@ export const updateSpaceStatus = async (spaceId: string, status: string) => {
     },
   });
 };
-

--- a/apps/web/src/lib/components/ChatMessageBubble.svelte
+++ b/apps/web/src/lib/components/ChatMessageBubble.svelte
@@ -14,20 +14,37 @@ type ModelCatalogItem = {
 type Props = {
 	message: ChatMessage;
 	modelsCatalog?: ModelCatalogItem[];
+	onLoadMessageDetail?: (message: ChatMessage) => Promise<void>;
 };
 
 type ImageBlock = Extract<ContentBlock, { type: "image" }>;
 
-const { message, modelsCatalog }: Props = $props();
+const { message, modelsCatalog, onLoadMessageDetail }: Props = $props();
 let renderedHtml = $state("");
 
 // Thinking state: track user manual toggle to avoid overriding
 let thinkingExpanded = $state(false);
 let thinkingUserToggled = $state(false);
+let detailLoading = $state(false);
+
+const isSummaryMessage = $derived(message.meta?.contentDetail === "summary");
+
+async function ensureMessageDetail() {
+	if (!isSummaryMessage || !onLoadMessageDetail || detailLoading) return;
+	detailLoading = true;
+	try {
+		await onLoadMessageDetail(message);
+	} finally {
+		detailLoading = false;
+	}
+}
 
 // Auto-expand during streaming, auto-collapse after (unless user toggled)
 const isStreaming = $derived(
-	message.id === "assistant-streaming" || message.id === "assistant-thinking",
+	message.meta?.messageKind === "assistant_streaming_preview" ||
+		message.id.startsWith("assistant-streaming:") ||
+		message.id === "assistant-streaming" ||
+		message.id === "assistant-thinking",
 );
 
 $effect(() => {
@@ -66,7 +83,11 @@ function getImageAlt(block: ImageBlock, index: number): string {
 // Thinking truncation: JS-based since line-clamp conflicts with whitespace-pre-wrap
 const THINKING_COLLAPSE_CHARS = 260;
 const thinkingNeedsTruncation = $derived(
-	thinkingContent.length > THINKING_COLLAPSE_CHARS,
+	thinkingContent.length > THINKING_COLLAPSE_CHARS ||
+		(message.content?.some(
+			(block) => block.type === "thinking" && block._meta?.truncated === true,
+		) ??
+			false),
 );
 function getThinkingDisplay(expanded: boolean): string {
 	if (expanded || !thinkingNeedsTruncation) return thinkingContent;
@@ -134,7 +155,11 @@ function summarizeToolInput(
 // Tool expansion state (per tool call id)
 let expandedToolCalls = $state<Set<string>>(new Set());
 
-function toggleToolCall(id: string) {
+async function toggleToolCall(id: string) {
+	const opening = !expandedToolCalls.has(id);
+	if (opening) {
+		await ensureMessageDetail();
+	}
 	const next = new Set(expandedToolCalls);
 	if (next.has(id)) {
 		next.delete(id);
@@ -142,6 +167,15 @@ function toggleToolCall(id: string) {
 		next.add(id);
 	}
 	expandedToolCalls = next;
+}
+
+async function toggleThinking() {
+	const opening = !thinkingExpanded;
+	if (opening) {
+		await ensureMessageDetail();
+	}
+	thinkingExpanded = !thinkingExpanded;
+	thinkingUserToggled = true;
 }
 
 // Find matching tool_result for a tool_use
@@ -325,9 +359,9 @@ function handleCopy() {
         <button
           type="button"
           class="mt-1 text-[11px] text-text-placeholder hover:text-text-tertiary cursor-pointer"
-          onclick={() => thinkingExpanded = !thinkingExpanded}
+          onclick={() => void toggleThinking()}
         >
-          {thinkingExpanded ? 'Show less' : '… more'}
+          {detailLoading ? 'Loading…' : thinkingExpanded ? 'Show less' : '… more'}
         </button>
       {/if}
     </div>
@@ -357,9 +391,9 @@ function handleCopy() {
             <button
               type="button"
               class="mt-1 text-[11px] text-text-placeholder hover:text-text-tertiary cursor-pointer"
-              onclick={() => { thinkingExpanded = !thinkingExpanded; thinkingUserToggled = true; }}
+              onclick={() => void toggleThinking()}
             >
-              {thinkingExpanded ? 'Show less' : '… more'}
+              {detailLoading ? 'Loading…' : thinkingExpanded ? 'Show less' : '… more'}
             </button>
           {/if}
         </div>
@@ -409,7 +443,7 @@ function handleCopy() {
               <button
                 type="button"
                 class="w-full flex items-center gap-2 pl-0 pr-4 py-0.5 text-left transition-colors hover:bg-bg-hover/50 cursor-pointer"
-                onclick={() => toggleToolCall(block.id)}
+                onclick={() => void toggleToolCall(block.id)}
               >
                 <span class="inline-block w-1.5 h-1.5 rounded-full shrink-0 align-middle {statusDotMap[status]} {status === 'running' ? 'animate-pulse' : ''}"></span>
                 <span class="text-[13px] font-mono text-text-tertiary shrink-0 w-[3em]">{block.name}</span>

--- a/apps/web/src/lib/components/ChatTimeline.svelte
+++ b/apps/web/src/lib/components/ChatTimeline.svelte
@@ -3,7 +3,7 @@ import { Loader2 } from "lucide-svelte";
 import ChatMessageBubble from "$lib/components/ChatMessageBubble.svelte";
 import ProcessCard from "$lib/components/ProcessCard.svelte";
 import ToolExecutionCard from "$lib/components/ToolExecutionCard.svelte";
-import type { TimelineItem } from "$lib/session-tree";
+import type { ChatMessage, TimelineItem } from "$lib/session-tree";
 
 type ModelCatalogItem = {
 	provider: string;
@@ -20,6 +20,7 @@ type Props = {
 	/** Whether older messages are currently being loaded (scroll-up pagination) */
 	loadingOlder?: boolean;
 	modelsCatalog?: ModelCatalogItem[];
+	onLoadMessageDetail?: (message: ChatMessage) => Promise<void>;
 };
 
 let {
@@ -29,6 +30,7 @@ let {
 	onFirstVisible,
 	loadingOlder = false,
 	modelsCatalog,
+	onLoadMessageDetail,
 }: Props = $props();
 
 // Track all observed elements for re-observation.
@@ -122,9 +124,9 @@ $effect(() => {
 				use:observeItem={originalIdx}
 			>
 				{#if item.kind === 'message'}
-					<ChatMessageBubble message={item.message} {modelsCatalog} />
+					<ChatMessageBubble message={item.message} {modelsCatalog} {onLoadMessageDetail} />
 				{:else if item.kind === 'process'}
-					<ProcessCard messages={item.messages} {modelsCatalog} />
+					<ProcessCard messages={item.messages} {modelsCatalog} {onLoadMessageDetail} />
 				{:else}
 					<ToolExecutionCard tool={item.tool} />
 				{/if}

--- a/apps/web/src/lib/components/ProcessCard.svelte
+++ b/apps/web/src/lib/components/ProcessCard.svelte
@@ -12,9 +12,10 @@ type ModelCatalogItem = {
 type Props = {
 	messages: ChatMessage[];
 	modelsCatalog?: ModelCatalogItem[];
+	onLoadMessageDetail?: (message: ChatMessage) => Promise<void>;
 };
 
-const { messages, modelsCatalog }: Props = $props();
+const { messages, modelsCatalog, onLoadMessageDetail }: Props = $props();
 
 let expanded = $state(false);
 
@@ -25,13 +26,27 @@ function toggle() {
 const toolCallCount = $derived(
 	messages.reduce(
 		(sum, msg) =>
-			sum + (msg.content?.filter((b) => b.type === "tool_use").length ?? 0),
+			sum +
+			(typeof msg.meta?.historySummary === "object" &&
+			msg.meta.historySummary !== null &&
+			"toolCallCount" in msg.meta.historySummary &&
+			typeof msg.meta.historySummary.toolCallCount === "number"
+				? msg.meta.historySummary.toolCallCount
+				: (msg.content?.filter((b) => b.type === "tool_use").length ?? 0)),
 		0,
 	),
 );
 
 const thinkingCharCount = $derived(
 	messages.reduce((sum, msg) => {
+		if (
+			typeof msg.meta?.historySummary === "object" &&
+			msg.meta.historySummary !== null &&
+			"thinkingCharCount" in msg.meta.historySummary &&
+			typeof msg.meta.historySummary.thinkingCharCount === "number"
+		) {
+			return sum + msg.meta.historySummary.thinkingCharCount;
+		}
 		const thinking =
 			msg.content
 				?.filter((b) => b.type === "thinking")
@@ -78,7 +93,7 @@ const summaryLabel = $derived(labelParts.join(" · "));
 
 		<div class="flex flex-col gap-2 pl-2 border-l border-border-subtle/40 ml-2">
 			{#each messages as msg (msg.id)}
-				<ChatMessageBubble message={msg} {modelsCatalog} />
+				<ChatMessageBubble message={msg} {modelsCatalog} {onLoadMessageDetail} />
 			{/each}
 		</div>
 

--- a/apps/web/src/lib/components/SpaceFileSidebar.svelte
+++ b/apps/web/src/lib/components/SpaceFileSidebar.svelte
@@ -63,7 +63,7 @@ function handleUploadClick() {
 </script>
 
 <div class="flex h-full flex-col bg-bg-primary min-w-0 relative">
-  <div class="flex items-center gap-1 border-b border-border-subtle px-3 py-2 shrink-0">
+  <div class="flex items-center gap-1 border-b border-border-subtle px-3 py-2 shrink-0 [&_button]:cursor-pointer">
     <div class="min-w-0 flex-1">
       <div class="text-[11px] uppercase tracking-[0.14em] text-text-tertiary">Files</div>
       <div class="text-[12px] text-text-secondary">Space files</div>

--- a/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
+++ b/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
@@ -2401,7 +2401,7 @@ async function loadFileTree(force = false) {
 		}
 	}
 	if (fileTreeLoading && !force) return;
-	const shouldShowLoading = fileTree.length === 0;
+	const shouldShowLoading = fileTree.length === 0 || force;
 	if (shouldShowLoading) {
 		fileTreeLoading = true;
 	}

--- a/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
+++ b/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
@@ -207,6 +207,7 @@ let promptTemplates = $state<PromptTemplateCatalogEntry[]>([]);
 let promptTemplatesLoaded = $state(false);
 let showModelSelector = $state(false);
 let sessionModelById = $state<Record<string, SelectedModel | null>>({});
+let loadingMessageDetailIds = $state<Record<string, boolean>>({});
 let fileTree = $state<SpaceFsNode[]>([]);
 let fileTreeLoading = $state(false);
 let fileTreeError = $state<string | null>(null);
@@ -1234,6 +1235,13 @@ function mergeMessagesById(
 			byId.set(message.id, message);
 			continue;
 		}
+		const currentDetail =
+			current.meta?.contentDetail === "summary" ? "summary" : "full";
+		const incomingDetail =
+			message.meta?.contentDetail === "summary" ? "summary" : "full";
+		if (currentDetail === "full" && incomingDetail === "summary") {
+			continue;
+		}
 		byId.set(
 			message.id,
 			preferIncoming ? { ...current, ...message } : { ...message, ...current },
@@ -1945,6 +1953,49 @@ async function loadOlderMessages(sessionId: string) {
 						: "Failed to load older messages",
 			},
 		};
+	}
+}
+async function loadMessageDetail(message: ChatMessage) {
+	const sessionId = activeSessionId;
+	const messageId = message.sourceId ?? message.id;
+	if (!sessionId || !messageId || loadingMessageDetailIds[messageId]) return;
+	const state = sessionStateById[sessionId];
+	const existing = state?.messages.find((item) => item.id === messageId);
+	if (existing?.meta?.contentDetail !== "summary") return;
+	loadingMessageDetailIds = { ...loadingMessageDetailIds, [messageId]: true };
+	try {
+		const response = await sdk
+			.space(spaceId)
+			.session(sessionId)
+			.messages.get(messageId);
+		const currentState = sessionStateById[sessionId];
+		if (!currentState) return;
+		const merged = mergeMessagesById(
+			currentState.messages,
+			[response.message],
+			{
+				preferIncoming: true,
+			},
+		);
+		sessionStateById = {
+			...sessionStateById,
+			[sessionId]: {
+				...currentState,
+				session: response.session ?? currentState.session,
+				messages: merged,
+			},
+		};
+		await messageCache.replaceAuthoritativeSnapshot({
+			sessionId,
+			messages: merged,
+			hasMore: currentState.hasMore,
+		});
+	} catch (error) {
+		console.warn("[loadMessageDetail] Failed to load message detail:", error);
+	} finally {
+		const next = { ...loadingMessageDetailIds };
+		delete next[messageId];
+		loadingMessageDetailIds = next;
 	}
 }
 function handleFirstVisible(index: number) {
@@ -4550,6 +4601,7 @@ $effect(() => {
           timeline={timeline}
           preloadThreshold={10}
           onFirstVisible={handleFirstVisible}
+          onLoadMessageDetail={loadMessageDetail}
           loadingOlder={activeSessionState?.loadingOlder ?? false}
           modelsCatalog={modelsCatalog ?? undefined}
         />

--- a/apps/web/src/lib/session-render.ts
+++ b/apps/web/src/lib/session-render.ts
@@ -187,6 +187,7 @@ function toChatMessage(message: MessageRecord, renderKey: string): ChatMessage {
 	const msgMeta = message.meta as Record<string, unknown> | null | undefined;
 	return {
 		id: renderKey,
+		sourceId: message.id,
 		role: message.role,
 		content: message.content,
 		text: message.text ?? "",
@@ -203,9 +204,23 @@ function toChatMessage(message: MessageRecord, renderKey: string): ChatMessage {
 						model: message.model,
 						provider: message.provider,
 						usage: message.usage,
+						contentDetail: msgMeta?.contentDetail as
+							| "summary"
+							| "full"
+							| undefined,
+						historySummary: msgMeta?.historySummary as
+							| { toolCallCount?: number; thinkingCharCount?: number }
+							| undefined,
 					}
 				: {
 						messageKind: msgMeta?.messageKind as string | null,
+						contentDetail: msgMeta?.contentDetail as
+							| "summary"
+							| "full"
+							| undefined,
+						historySummary: msgMeta?.historySummary as
+							| { toolCallCount?: number; thinkingCharCount?: number }
+							| undefined,
 					},
 	} satisfies ChatMessage;
 }

--- a/apps/web/src/lib/session-tree.ts
+++ b/apps/web/src/lib/session-tree.ts
@@ -3,6 +3,7 @@ import type { MessageRecord } from "@neta-art/cohub-protocol/model";
 
 export type ChatMessage = {
 	id: string;
+	sourceId?: string;
 	role: "user" | "assistant" | "system";
 	content: ContentBlock[];
 	text: string;
@@ -17,6 +18,11 @@ export type ChatMessage = {
 		model?: string | null;
 		provider?: string | null;
 		usage?: MessageRecord["usage"];
+		contentDetail?: "summary" | "full";
+		historySummary?: {
+			toolCallCount?: number;
+			thinkingCharCount?: number;
+		};
 	};
 };
 
@@ -93,6 +99,7 @@ export const toChatMessages = (messages: MessageRecord[]): ChatMessage[] => {
 		const msgMeta = message.meta as Record<string, unknown> | null | undefined;
 		return {
 			id: message.id,
+			sourceId: message.id,
 			role: message.role,
 			content: message.content,
 			text: message.text ?? "",
@@ -109,6 +116,13 @@ export const toChatMessages = (messages: MessageRecord[]): ChatMessage[] => {
 							model: message.model,
 							provider: message.provider,
 							usage: message.usage,
+							contentDetail: msgMeta?.contentDetail as
+								| "summary"
+								| "full"
+								| undefined,
+							historySummary: msgMeta?.historySummary as
+								| { toolCallCount?: number; thinkingCharCount?: number }
+								| undefined,
 						}
 					: undefined,
 		} satisfies ChatMessage;

--- a/apps/web/src/lib/stores/message-cache.ts
+++ b/apps/web/src/lib/stores/message-cache.ts
@@ -46,8 +46,27 @@ async function tx<T>(
 	return result;
 }
 
+function getContentDetail(message: MessageRecord): "summary" | "full" {
+	const value = message.meta?.contentDetail;
+	return value === "summary" ? "summary" : "full";
+}
+
+function chooseMessage(current: MessageRecord, incoming: MessageRecord) {
+	if (
+		getContentDetail(current) === "full" &&
+		getContentDetail(incoming) === "summary"
+	) {
+		return current;
+	}
+	return incoming;
+}
+
 function mergeBySequence(messages: MessageRecord[]): MessageRecord[] {
-	const byId = new Map(messages.map((message) => [message.id, message]));
+	const byId = new Map<string, MessageRecord>();
+	for (const message of messages) {
+		const current = byId.get(message.id);
+		byId.set(message.id, current ? chooseMessage(current, message) : message);
+	}
 	return Array.from(byId.values()).sort((a, b) => a.sequence - b.sequence);
 }
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -66,6 +66,9 @@ export default defineConfig({
 			css: true,
 		},
 	},
+	server: {
+		allowedHosts: true,
+	},
 	plugins: [
 		tailwindcss(),
 		sveltekit(),

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,8 +1,18 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"],
     "declaration": true,
-    "declarationMap": false
+    "declarationMap": false,
+    "ignoreDeprecations": "6.0",
+    "baseUrl": ".",
+    "paths": {
+      "@neta-art/cohub": ["../sdk/dist/index.d.ts"],
+      "@neta-art/cohub/http": ["../sdk/dist/http.d.ts"],
+      "@neta-art/cohub/websocket": ["../sdk/dist/websocket.d.ts"]
+    }
   },
   "include": ["src"]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,7 +3,14 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "types": ["node"]
+    "types": ["node"],
+    "ignoreDeprecations": "6.0",
+    "baseUrl": ".",
+    "paths": {
+      "@neta-art/cohub": ["../sdk/dist/index.d.ts"],
+      "@neta-art/cohub/http": ["../sdk/dist/http.d.ts"],
+      "@neta-art/cohub/websocket": ["../sdk/dist/websocket.d.ts"]
+    }
   },
   "include": ["src"]
 }

--- a/packages/sdk/src/apis/spaces.ts
+++ b/packages/sdk/src/apis/spaces.ts
@@ -4,6 +4,7 @@ import type { HttpTransport, Fetch } from "../transport.js";
 import type {
   CheckpointRecord,
   ContentBlock,
+  SessionMessageResponse,
   SessionMessagesPaginatedResponse,
   SessionMessagesResponse,
   SessionRecord,
@@ -198,6 +199,15 @@ class SessionMessagesClient {
   list(customFetch?: Fetch) {
     return this.transport.request<SessionMessagesResponse>(
       `/api/sessions/${this.sessionId}/messages`,
+      {
+        fetch: customFetch,
+      },
+    );
+  }
+
+  get(messageId: string, customFetch?: Fetch) {
+    return this.transport.request<SessionMessageResponse>(
+      `/api/sessions/${this.sessionId}/messages/${messageId}`,
       {
         fetch: customFetch,
       },

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -122,6 +122,11 @@ export type SessionMessagesResponse = {
   messages: MessageRecord[];
 };
 
+export type SessionMessageResponse = {
+  session: SessionRecord;
+  message: MessageRecord;
+};
+
 export type SessionMessagesPaginatedResponse = {
   session: SessionRecord;
   messages: MessageRecord[];


### PR DESCRIPTION
## Summary
- Return summary-level session history by default, trimming thinking/tool details while preserving default-visible content
- Add a per-message detail endpoint and SDK helper for loading full message content on demand
- Load full message details from the chat UI only when users expand thinking/tool details, while preserving full entries in cache merges

## Verification
- pnpm --filter @cohub/api typecheck
- pnpm --filter @cohub/api lint
- pnpm --filter web typecheck
- pnpm --filter web lint
- pnpm --filter @neta-art/cohub typecheck
- pnpm exec tsx apps/web/src/tests/session-render-stream-merge.test.ts

Note: web typecheck still reports the pre-existing Bind Channel dialog a11y warnings.