### PR TITLE
Add support for message summary loading and display

### DIFF
--- a/apps/api/src/routes/sessions.route.ts
+++ b/apps/api/src/routes/sessions.route.ts
@@ -91,7 +91,9 @@ router.get("/:id/messages", async (c) => {
   const pageMessages = hasMore
     ? (direction === "newer" ? rows.slice(0, -1) : rows.slice(1))
     : rows;
-  const messages = detail === "full" ? pageMessages.map(markMessageAsFull) : pageMessages.map(summarizeMessageForHistory);
+  const messages = detail === "full"
+    ? pageMessages.map(markMessageAsFull)
+    : pageMessages.map((message) => summarizeMessageForHistory(message));
 
   return c.json({
     session,
@@ -120,10 +122,13 @@ router.get("/:id/messages/:messageId", async (c) => {
 
   const message = await getSessionMessageById(session.id, messageId);
   if (!message) return c.json({ message: "message not found" }, 404);
+  const detail = c.req.query("detail") === "summary" ? "summary" : "full";
 
   return c.json({
     session,
-    message: markMessageAsFull(message),
+    message: detail === "summary"
+      ? summarizeMessageForHistory(message, { placeholderIntermediate: false })
+      : markMessageAsFull(message),
   });
 });
 

--- a/apps/api/src/space-sessions.ts
+++ b/apps/api/src/space-sessions.ts
@@ -144,20 +144,31 @@ const summarizeContentForDefaultView = (content: ContentBlock[]): ContentBlock[]
   });
 };
 
-export const summarizeMessageForHistory = <T extends { content: ContentBlock[]; meta: unknown }>(message: T): T => {
+export const summarizeMessageForHistory = <T extends { content: ContentBlock[]; meta: unknown }>(
+  message: T,
+  options?: { placeholderIntermediate?: boolean },
+): T => {
   const meta = (message.meta && typeof message.meta === "object" && !Array.isArray(message.meta))
     ? (message.meta as Record<string, unknown>)
     : {};
-  const isIntermediate = meta.messageKind === "assistant_intermediate";
+  const isIntermediate = meta.messageKind === "assistant_intermediate" && options?.placeholderIntermediate !== false;
+  const historySummary = getHistorySummary(message.content);
+  const summaryMeta = isIntermediate
+    ? {
+        messageKind: "assistant_intermediate",
+        contentDetail: "summary",
+        contentPlaceholder: "assistant_intermediate",
+        historySummary,
+      }
+    : {
+        ...meta,
+        contentDetail: "summary",
+        historySummary,
+      };
   return {
     ...message,
     content: isIntermediate ? [] : summarizeContentForDefaultView(message.content),
-    meta: {
-      ...meta,
-      contentDetail: "summary",
-      contentPlaceholder: isIntermediate ? "assistant_intermediate" : undefined,
-      historySummary: getHistorySummary(message.content),
-    },
+    meta: summaryMeta,
   };
 };
 

--- a/apps/web/src/lib/components/ChatMessageBubble.svelte
+++ b/apps/web/src/lib/components/ChatMessageBubble.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { ContentBlock } from "@neta-art/cohub-protocol/core";
-import { Check, ChevronDown, ChevronRight, Copy } from "lucide-svelte";
+import { Check, ChevronDown, ChevronRight, Copy, Loader2 } from "lucide-svelte";
 import { tick } from "svelte";
 import { mediaLightbox } from "$lib/components/media-lightbox.svelte";
 import { renderMarkdown } from "$lib/markdown";
@@ -35,15 +35,24 @@ let renderedHtml = $state("");
 let thinkingExpanded = $state(false);
 let thinkingUserToggled = $state(false);
 let detailLoading = $state(false);
+let detailLoadPromise: Promise<void> | null = null;
 
 const isSummaryMessage = $derived(message.meta?.contentDetail === "summary");
 
 async function ensureMessageDetail() {
-	if (!isSummaryMessage || !onLoadMessageDetail || detailLoading) return;
+	if (!isSummaryMessage || !onLoadMessageDetail) return;
+	if (detailLoadPromise) {
+		await detailLoadPromise;
+		return;
+	}
 	detailLoading = true;
-	try {
+	detailLoadPromise = (async () => {
 		await onLoadMessageDetail(message);
+	})();
+	try {
+		await detailLoadPromise;
 	} finally {
+		detailLoadPromise = null;
 		detailLoading = false;
 	}
 }
@@ -385,7 +394,11 @@ function handleCopy() {
     disabled={detailLoading}
     onclick={() => void ensureMessageDetail()}
   >
-    <span class="inline-block h-1.5 w-1.5 rounded-full bg-text-placeholder/60"></span>
+    {#if detailLoading}
+      <Loader2 class="h-3 w-3 shrink-0 animate-spin text-text-placeholder/70" />
+    {:else}
+      <span class="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-text-placeholder/60"></span>
+    {/if}
     <span>{detailLoading ? 'Loading details...' : 'Load process step details'}</span>
   </button>
 {:else if message.role === 'system' && message.content?.some(b => b.type === 'thinking')}
@@ -403,10 +416,13 @@ function handleCopy() {
       {#if !isStreaming && thinkingNeedsTruncation}
         <button
           type="button"
-          class="mt-1 text-[11px] text-text-placeholder hover:text-text-tertiary cursor-pointer"
+          class="mt-1 inline-flex items-center gap-1 text-[11px] text-text-placeholder hover:text-text-tertiary cursor-pointer"
           onclick={() => void toggleThinking()}
         >
-          {detailLoading ? 'Loading…' : thinkingExpanded ? 'Show less' : '… more'}
+          {#if detailLoading}
+            <Loader2 class="h-3 w-3 animate-spin" />
+          {/if}
+          <span>{detailLoading ? 'Loading…' : thinkingExpanded ? 'Show less' : '… more'}</span>
         </button>
       {/if}
     </div>
@@ -435,10 +451,13 @@ function handleCopy() {
           {#if thinkingNeedsTruncation}
             <button
               type="button"
-              class="mt-1 text-[11px] text-text-placeholder hover:text-text-tertiary cursor-pointer"
+              class="mt-1 inline-flex items-center gap-1 text-[11px] text-text-placeholder hover:text-text-tertiary cursor-pointer"
               onclick={() => void toggleThinking()}
             >
-              {detailLoading ? 'Loading…' : thinkingExpanded ? 'Show less' : '… more'}
+              {#if detailLoading}
+                <Loader2 class="h-3 w-3 animate-spin" />
+              {/if}
+              <span>{detailLoading ? 'Loading…' : thinkingExpanded ? 'Show less' : '… more'}</span>
             </button>
           {/if}
         </div>
@@ -501,7 +520,9 @@ function handleCopy() {
                 <span class="text-[13px] font-mono text-text-tertiary shrink-0 w-[3em]">{block.name}</span>
                 <span class="min-w-0 text-[13px] font-mono text-text-placeholder truncate">{summarizeToolInput(block.name, block.input)}</span>
                 <span class="ml-auto text-text-tertiary shrink-0">
-                  {#if expandedToolCalls.has(block.id)}
+                  {#if detailLoading && isSummaryMessage}
+                    <Loader2 class="w-3.5 h-3.5 animate-spin text-text-placeholder" />
+                  {:else if expandedToolCalls.has(block.id)}
                     <ChevronDown class="w-3.5 h-3.5" />
                   {:else}
                     <ChevronRight class="w-3.5 h-3.5" />

--- a/apps/web/src/lib/components/ChatTimeline.svelte
+++ b/apps/web/src/lib/components/ChatTimeline.svelte
@@ -21,6 +21,7 @@ type Props = {
 	loadingOlder?: boolean;
 	modelsCatalog?: ModelCatalogItem[];
 	onLoadMessageDetail?: (message: ChatMessage) => Promise<void>;
+	onLoadMessageSummary?: (message: ChatMessage) => Promise<void>;
 	onMarkdownRenderStart?: (message: ChatMessage) => void;
 	onMarkdownRendered?: (message: ChatMessage) => void;
 };
@@ -33,6 +34,7 @@ let {
 	loadingOlder = false,
 	modelsCatalog,
 	onLoadMessageDetail,
+	onLoadMessageSummary,
 	onMarkdownRenderStart,
 	onMarkdownRendered,
 }: Props = $props();
@@ -130,7 +132,7 @@ $effect(() => {
 					{#if item.kind === 'message'}
 						<ChatMessageBubble message={item.message} {modelsCatalog} {onLoadMessageDetail} {onMarkdownRenderStart} {onMarkdownRendered} />
 					{:else if item.kind === 'process'}
-						<ProcessCard messages={item.messages} {modelsCatalog} {onLoadMessageDetail} {onMarkdownRenderStart} {onMarkdownRendered} />
+						<ProcessCard messages={item.messages} {modelsCatalog} {onLoadMessageDetail} {onLoadMessageSummary} {onMarkdownRenderStart} {onMarkdownRendered} />
 				{:else}
 					<ToolExecutionCard tool={item.tool} />
 				{/if}

--- a/apps/web/src/lib/components/ProcessCard.svelte
+++ b/apps/web/src/lib/components/ProcessCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { ChevronDown, ChevronRight } from "lucide-svelte";
+import { ChevronDown, ChevronRight, Loader2 } from "lucide-svelte";
 import ChatMessageBubble from "$lib/components/ChatMessageBubble.svelte";
 import type { ChatMessage } from "$lib/session-tree";
 
@@ -13,6 +13,7 @@ type Props = {
 	messages: ChatMessage[];
 	modelsCatalog?: ModelCatalogItem[];
 	onLoadMessageDetail?: (message: ChatMessage) => Promise<void>;
+	onLoadMessageSummary?: (message: ChatMessage) => Promise<void>;
 	onMarkdownRenderStart?: (message: ChatMessage) => void;
 	onMarkdownRendered?: (message: ChatMessage) => void;
 };
@@ -21,13 +22,43 @@ const {
 	messages,
 	modelsCatalog,
 	onLoadMessageDetail,
+	onLoadMessageSummary,
 	onMarkdownRenderStart,
 	onMarkdownRendered,
 }: Props = $props();
 
 let expanded = $state(false);
+let loadingSummaries = $state(false);
+let summaryLoadPromise: Promise<void> | null = null;
 
-function toggle() {
+const placeholderMessages = $derived(
+	messages.filter(
+		(message) => message.meta?.contentPlaceholder === "assistant_intermediate",
+	),
+);
+
+async function ensureSummaries() {
+	if (placeholderMessages.length === 0 || !onLoadMessageSummary) return;
+	if (summaryLoadPromise) {
+		await summaryLoadPromise;
+		return;
+	}
+	loadingSummaries = true;
+	summaryLoadPromise = Promise.all(
+		placeholderMessages.map((message) => onLoadMessageSummary(message)),
+	).then(() => undefined);
+	try {
+		await summaryLoadPromise;
+	} finally {
+		summaryLoadPromise = null;
+		loadingSummaries = false;
+	}
+}
+
+async function toggle() {
+	if (!expanded) {
+		await ensureSummaries();
+	}
 	expanded = !expanded;
 }
 
@@ -82,10 +113,15 @@ const summaryLabel = $derived(labelParts.join(" · "));
 {#if !expanded}
 	<button
 		type="button"
-		class="flex w-full items-center gap-2 px-4 py-2 text-left transition-colors hover:bg-bg-hover/50 cursor-pointer rounded-md"
-		onclick={toggle}
+		class="flex w-full items-center gap-2 px-4 py-2 text-left transition-colors hover:bg-bg-hover/50 cursor-pointer rounded-md disabled:cursor-wait disabled:opacity-75"
+		disabled={loadingSummaries}
+		onclick={() => void toggle()}
 	>
-		<ChevronRight class="w-3.5 h-3.5 text-text-tertiary shrink-0" />
+		{#if loadingSummaries}
+			<Loader2 class="w-3.5 h-3.5 text-text-tertiary shrink-0 animate-spin" />
+		{:else}
+			<ChevronRight class="w-3.5 h-3.5 text-text-tertiary shrink-0" />
+		{/if}
 		<span class="text-[13px] text-text-tertiary">{summaryLabel}</span>
 	</button>
 {:else}
@@ -93,7 +129,7 @@ const summaryLabel = $derived(labelParts.join(" · "));
 		<button
 			type="button"
 			class="flex w-full items-center gap-2 px-4 py-2 text-left transition-colors hover:bg-bg-hover/50 cursor-pointer rounded-md"
-			onclick={toggle}
+			onclick={() => void toggle()}
 		>
 			<ChevronDown class="w-3.5 h-3.5 text-text-tertiary shrink-0" />
 			<span class="text-[13px] text-text-tertiary">{summaryLabel}</span>
@@ -108,7 +144,7 @@ const summaryLabel = $derived(labelParts.join(" · "));
 		<button
 			type="button"
 			class="flex items-center gap-1.5 px-4 py-1.5 text-left transition-colors hover:bg-bg-hover/50 cursor-pointer text-text-placeholder hover:text-text-tertiary rounded-md self-start"
-			onclick={toggle}
+			onclick={() => void toggle()}
 		>
 			<ChevronRight class="w-3 h-3" />
 			<span class="text-[11px]">Collapse</span>

--- a/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
+++ b/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
@@ -1958,6 +1958,54 @@ async function loadOlderMessages(sessionId: string) {
 		};
 	}
 }
+async function loadMessageSummary(message: ChatMessage) {
+	const sessionId = activeSessionId;
+	const messageId = message.sourceId ?? message.id;
+	if (!sessionId || !messageId || loadingMessageDetailIds[messageId]) return;
+	const state = sessionStateById[sessionId];
+	const existing = state?.messages.find((item) => item.id === messageId);
+	if (
+		existing?.meta?.contentDetail !== "summary" ||
+		existing.meta?.contentPlaceholder !== "assistant_intermediate"
+	) {
+		return;
+	}
+	loadingMessageDetailIds = { ...loadingMessageDetailIds, [messageId]: true };
+	try {
+		const response = await sdk
+			.space(spaceId)
+			.session(sessionId)
+			.messages.get(messageId, { detail: "summary" });
+		const currentState = sessionStateById[sessionId];
+		if (!currentState) return;
+		const merged = mergeMessagesById(
+			currentState.messages,
+			[response.message],
+			{
+				preferIncoming: true,
+			},
+		);
+		sessionStateById = {
+			...sessionStateById,
+			[sessionId]: {
+				...currentState,
+				session: response.session ?? currentState.session,
+				messages: merged,
+			},
+		};
+		await messageCache.replaceAuthoritativeSnapshot({
+			sessionId,
+			messages: merged,
+			hasMore: currentState.hasMore,
+		});
+	} catch (error) {
+		console.warn("[loadMessageSummary] Failed to load message summary:", error);
+	} finally {
+		const next = { ...loadingMessageDetailIds };
+		delete next[messageId];
+		loadingMessageDetailIds = next;
+	}
+}
 async function loadMessageDetail(message: ChatMessage) {
 	const sessionId = activeSessionId;
 	const messageId = message.sourceId ?? message.id;
@@ -4725,6 +4773,7 @@ $effect(() => {
           preloadThreshold={10}
           onFirstVisible={handleFirstVisible}
           onLoadMessageDetail={loadMessageDetail}
+          onLoadMessageSummary={loadMessageSummary}
           onMarkdownRenderStart={handleTimelineMarkdownRenderStart}
           onMarkdownRendered={handleTimelineMarkdownRendered}
           loadingOlder={activeSessionState?.loadingOlder ?? false}

--- a/packages/sdk/src/apis/spaces.ts
+++ b/packages/sdk/src/apis/spaces.ts
@@ -205,11 +205,20 @@ class SessionMessagesClient {
     );
   }
 
-  get(messageId: string, customFetch?: Fetch) {
+  get(
+    messageId: string,
+    optionsOrFetch?: { detail?: "summary" | "full" } | Fetch,
+    customFetch?: Fetch,
+  ) {
+    const options = typeof optionsOrFetch === "function" ? undefined : optionsOrFetch;
+    const fetch = typeof optionsOrFetch === "function" ? optionsOrFetch : customFetch;
+    const params = new URLSearchParams();
+    if (options?.detail) params.set("detail", options.detail);
+    const query = params.toString();
     return this.transport.request<SessionMessageResponse>(
-      `/api/sessions/${this.sessionId}/messages/${messageId}`,
+      `/api/sessions/${this.sessionId}/messages/${messageId}${query ? `?${query}` : ""}`,
       {
-        fetch: customFetch,
+        fetch,
       },
     );
   }


### PR DESCRIPTION
- Added `onLoadMessageSummary` prop to `ProcessCard` and `ChatTimeline` components.
- Updated `summarizeMessageForHistory` to include an option for placeholder intermediate messages.
- Modified `SpaceWorkspacePage` to handle message summary loading.
- Enhanced `ChatMessageBubble` and `ProcessCard` to show loading state for summaries.