### PR TITLE
Add Feishu document tool and media parsing

### DIFF
--- a/apps/agent/src/api.ts
+++ b/apps/agent/src/api.ts
@@ -419,6 +419,25 @@ export async function getSpaceSandbox(input: { spaceId: string }) {
   } | null>;
 }
 
+export async function getSpaceCapabilities(input: { spaceId: string }) {
+  const url = `${INTERNAL_API_BASE_URL}/internal/spaces/${input.spaceId}/capabilities`;
+  const response = await fetch(url, {
+    method: "GET",
+    headers: internalHeaders(),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Get space capabilities failed ${response.status}: ${text}`);
+  }
+
+  return response.json().catch(() => null) as Promise<{
+    capabilities: {
+      feishu?: boolean;
+    };
+  } | null>;
+}
+
 export async function getSpace(input: { spaceId: string }) {
   const url = `${INTERNAL_API_BASE_URL}/internal/spaces/${input.spaceId}`;
   const response = await fetch(url, {
@@ -437,6 +456,44 @@ export async function getSpace(input: { spaceId: string }) {
       userUuid: string;
       name: string;
     } | null;
+  } | null>;
+}
+
+export async function fetchFeishuDoc(input: {
+  spaceId: string;
+  sessionId: string;
+  docId: string;
+  offset?: number;
+  limit?: number;
+}) {
+  const url = `${INTERNAL_API_BASE_URL}/internal/spaces/${input.spaceId}/sessions/${input.sessionId}/tools/feishu-fetch-doc`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: internalHeaders(),
+    body: JSON.stringify({
+      doc_id: input.docId,
+      offset: input.offset,
+      limit: input.limit,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Fetch Feishu doc failed ${response.status}: ${text}`);
+  }
+
+  return response.json().catch(() => null) as Promise<{
+    ok: true;
+    document: {
+      type: string;
+      token: string;
+      url: string | null;
+      content: string;
+      offset: number;
+      limit: number;
+      totalLength: number;
+      hasMore: boolean;
+    };
   } | null>;
 }
 

--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -27,7 +27,7 @@ import {
   recoverProcessingQueueOnStartup,
   sendOutput,
 } from "./redis.js";
-import { getSpace, getSpaceSandbox } from "./api.js";
+import { getSpace, getSpaceCapabilities, getSpaceSandbox } from "./api.js";
 import { createSandboxCodingTools } from "./sandbox/tools.js";
 import {
   disconnectSandboxWsClient,
@@ -395,8 +395,6 @@ async function main() {
   startOwnerRenewLoop();
   await recoverProcessingQueueOnStartup();
 
-  const tools = createSandboxCodingTools();
-
   console.log("[Agent] Listening for owner-routed input.");
 
   const agentTracer = getAgentTracer();
@@ -447,6 +445,13 @@ async function main() {
           const requestedModelInput = (requestedProvider && requestedModel)
             ? { provider: requestedProvider, id: requestedModel }
             : undefined;
+          const capabilities = await getSpaceCapabilities({ spaceId: inputEntry.spaceId }).catch((error) => {
+            console.warn(`[Agent] Failed to resolve capabilities for ${inputEntry.spaceId}; using base tools`, error);
+            return null;
+          });
+          const tools = createSandboxCodingTools({
+            feishu: capabilities?.capabilities?.feishu === true,
+          });
 
           const handle = await loadOrCreateSessionHandle({
             spaceId: inputEntry.spaceId,

--- a/apps/agent/src/runtime/session-runtime.ts
+++ b/apps/agent/src/runtime/session-runtime.ts
@@ -23,7 +23,7 @@ export type CohubAgentSession = {
   enqueueSteer(text: string, images?: ImageContent[]): void;
   waitForIdle(): Promise<void>;
   setModel(model: Model<Api>): Promise<void>;
-  reload(): Promise<void>;
+  reload(tools?: ToolLike[]): Promise<void>;
   abort(): Promise<void>;
   dispose(): void;
   subscribe(listener: (event: CohubAgentSessionEvent) => void): () => void;
@@ -165,6 +165,7 @@ function toolSnippets(toolName: string): string | undefined {
     case "grep": return "Search file contents";
     case "find": return "Search files by glob pattern";
     case "ls": return "List directory contents";
+    case "feishu_fetch_doc": return "Fetch text from Feishu/Lark document URLs or tokens when the session comes from a Feishu channel";
     default: return undefined;
   }
 }
@@ -324,7 +325,8 @@ export async function createCohubAgentSession(options: CreateCohubAgentSessionOp
       agent.state.model = nextModel;
       options.sessionManager.appendModelChange(nextModel.provider, nextModel.id);
     },
-    async reload() {
+    async reload(nextTools) {
+      if (nextTools) options.tools = nextTools;
       const nextPrompt = buildCohubSystemPrompt({
         cwd: options.cwd,
         userId: options.userId,

--- a/apps/agent/src/sandbox/tools.ts
+++ b/apps/agent/src/sandbox/tools.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { Type, type Static } from "@mariozechner/pi-ai";
+import type { AgentTool } from "@mariozechner/pi-agent-core";
 import {
   createBashTool,
   createEditTool,
@@ -20,6 +22,7 @@ import {
   truncateHead,
   truncateLine,
 } from "../runtime/tools/index.js";
+import { fetchFeishuDoc } from "../api.js";
 
 const GREP_MAX_LINE_LENGTH = 500;
 import type { RpcMethod, RpcRequestMap } from "@cohub/agent-sandbox-protocol";
@@ -657,6 +660,54 @@ function createRemoteGrepTool() {
   };
 }
 
+function createFeishuFetchDocTool(): AgentTool {
+  const parameters = Type.Object({
+    doc_id: Type.String({ description: "Feishu/Lark docx or wiki URL, or a docx/wiki token" }),
+    offset: Type.Optional(Type.Number({ description: "Character offset for pagination. Defaults to 0." })),
+    limit: Type.Optional(Type.Number({ description: "Maximum characters to return. Defaults to 24000." })),
+  });
+
+  return {
+    name: "feishu_fetch_doc",
+    label: "feishu_fetch_doc",
+    description: "Fetch readable text from a Feishu/Lark document URL or token. Only works in sessions that are bound to a Feishu channel.",
+    parameters,
+    async execute(_toolCallId, rawParams) {
+      const params = rawParams as Static<typeof parameters>;
+      const ctx = getCurrentToolExecutionContext();
+      if (!ctx?.spaceId || !ctx.sessionId) {
+        throw new Error("feishu_fetch_doc requires a space/session execution context");
+      }
+      incrementToolCallCount(ctx.metrics);
+      const result = await fetchFeishuDoc({
+        spaceId: ctx.spaceId,
+        sessionId: ctx.sessionId,
+        docId: params.doc_id,
+        offset: params.offset,
+        limit: params.limit,
+      });
+      if (!result?.document) throw new Error("Feishu document response was empty");
+
+      const doc = result.document;
+      const more = doc.hasMore
+        ? `\n\n[Showing characters ${doc.offset}-${doc.offset + doc.content.length} of ${doc.totalLength}. Call feishu_fetch_doc with offset=${doc.offset + doc.content.length} to continue.]`
+        : "";
+      const title = `Feishu document ${doc.url ?? doc.token}`;
+      return {
+        content: [{ type: "text", text: `${title}\n\n${doc.content}${more}` }],
+        details: {
+          token: doc.token,
+          type: doc.type,
+          url: doc.url,
+          offset: doc.offset,
+          totalLength: doc.totalLength,
+          hasMore: doc.hasMore,
+        },
+      };
+    },
+  };
+}
+
 /** Format a file path as relative, matching native grep behavior. */
 function formatRelativePath(absolutePath: string, searchPath: string | undefined): string {
   // Reconstruct the sandbox-internal search path to compute relative output.
@@ -712,10 +763,14 @@ async function tracedRpcAbortProcess(processId: string) {
   }
 }
 
-export function createSandboxCodingTools() {
+export type SandboxToolCapabilities = {
+  feishu?: boolean;
+};
+
+export function createSandboxCodingTools(capabilities: SandboxToolCapabilities = {}) {
   const toolCwd = SANDBOX_WORKSPACE_PATH;
 
-  return [
+  const tools = [
     createReadTool(toolCwd, { operations: createRemoteReadOperations() }),
     createBashTool(toolCwd, { operations: createRemoteBashOperations() }),
     createEditTool(toolCwd, { operations: createRemoteEditOperations() }),
@@ -724,4 +779,7 @@ export function createSandboxCodingTools() {
     createFindTool(toolCwd, { operations: createRemoteFindOperations() }),
     createRemoteGrepTool(),
   ];
+
+  if (capabilities.feishu) tools.push(createFeishuFetchDocTool());
+  return tools;
 }

--- a/apps/agent/src/session.ts
+++ b/apps/agent/src/session.ts
@@ -38,6 +38,7 @@ export type SessionHandle = {
   sessionKey: string;
   sessionId: string;
   session: CohubAgentSession;
+  toolNames: string[];
   sessionManager: SessionManager;
   turnTracer: ReturnType<typeof getAgentTracer>;
   currentTurnId?: string | null;
@@ -594,9 +595,14 @@ export async function loadOrCreateSessionHandle(input: {
   });
 
   const sessionKey = getSessionKey(input.spaceId, input.sessionId);
+  const toolNames = input.tools.map((tool) => tool.name);
   const existing = input.sessionHandles.get(sessionKey);
   if (existing) {
     console.log(`[Session] reuse sessionId=${input.sessionId} spaceId=${input.spaceId}`);
+    if (existing.toolNames.join("\0") !== toolNames.join("\0")) {
+      existing.toolNames = toolNames;
+      await existing.session.reload(input.tools);
+    }
     return existing;
   }
 
@@ -679,6 +685,7 @@ export async function loadOrCreateSessionHandle(input: {
     sessionKey,
     sessionId: input.sessionId,
     session,
+    toolNames,
     sessionManager,
     turnTracer: getAgentTracer(),
     currentTurnId: null,

--- a/apps/agent/src/tests/sandbox-tools.test.ts
+++ b/apps/agent/src/tests/sandbox-tools.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+
+process.env.SESSIONS_NAMESPACE ??= "test";
+process.env.REDIS_URL ??= "redis://localhost:6379";
+process.env.WORKSPACE_ROOT ??= "/tmp";
+process.env.SESSIONS_DIR ??= "/tmp";
+process.env.PLATFORM_CONFIG_ROOT ??= "/tmp";
+process.env.ENV ??= "dev";
+process.env.AGENT_INSTANCE_ID ??= "test-agent";
+
+const { createSandboxCodingTools } = await import("../sandbox/tools.js");
+
+assert.equal(
+  createSandboxCodingTools().some((tool) => tool.name === "feishu_fetch_doc"),
+  false,
+  "base sandbox tools should not include feishu_fetch_doc",
+);
+
+assert.equal(
+  createSandboxCodingTools({ feishu: true }).some((tool) => tool.name === "feishu_fetch_doc"),
+  true,
+  "Feishu-capable spaces should include feishu_fetch_doc",
+);
+
+console.log("sandbox tool capability checks passed");
+process.exit(0);

--- a/apps/agent/src/tests/session-stream-integration.test.ts
+++ b/apps/agent/src/tests/session-stream-integration.test.ts
@@ -78,6 +78,7 @@ function createHandle(session: FakeSession): SessionHandle {
     sessionKey: "space-1:session-1",
     sessionId: "session-1",
     session: session as unknown as SessionHandle["session"],
+    toolNames: [],
     sessionManager: {} as SessionHandle["sessionManager"],
     turnTracer: getAgentTracer(),
     currentTurnId: null,

--- a/apps/api/src/routes/internal/spaces.route.ts
+++ b/apps/api/src/routes/internal/spaces.route.ts
@@ -19,7 +19,10 @@ import {
 } from "../../space-sessions.js";
 import { interruptSessionTurn } from "../../session-turns.js";
 import { getSpaceSandboxBySpaceId, updateSpaceSandbox } from "../../space-sandboxes.js";
+import { db } from "../../db/index.js";
+import { spaceSessionBindings, spaceChannels, userChannels } from "../../db/schema-v2.js";
 import { isSandboxReportTokenValid } from "../../crypto.js";
+import { and, eq } from "drizzle-orm";
 import {
   ensureInternalRequest,
   getRequestRemoteAddress,
@@ -58,6 +61,144 @@ function sanitizeSandboxMeta(input: Record<string, unknown> | null | undefined) 
 }
 
 const router = new Hono();
+const MAX_FEISHU_DOCUMENT_CHARS = 24_000;
+const FEISHU_OPEN_API_BASE_URL = "https://open.feishu.cn";
+const LARK_OPEN_API_BASE_URL = "https://open.larksuite.com";
+
+type FeishuDocumentRef = {
+  url?: string | null;
+  type: "docx" | "wiki";
+  token: string;
+};
+
+class FeishuDocumentInputError extends Error {
+  readonly status = 400 as const;
+}
+
+class FeishuUpstreamError extends Error {
+  readonly status = 502 as const;
+}
+
+function extractFeishuDocumentRef(input: string): FeishuDocumentRef {
+  const value = input.trim();
+  let url: URL | null = null;
+  try {
+    url = new URL(value);
+  } catch {
+    url = null;
+  }
+
+  if (url) {
+    if (!/(^|\.)(feishu\.cn|larksuite\.com|larkoffice\.com)$/.test(url.hostname)) {
+      throw new FeishuDocumentInputError("doc_id must be a Feishu/Lark document URL or token");
+    }
+    const pathMatch = url.pathname.match(/\/(docx|wiki|docs)\/([A-Za-z0-9]+)/);
+    if (!pathMatch?.[1] || !pathMatch[2]) {
+      throw new FeishuDocumentInputError("unsupported Feishu document URL; expected /docx/ or /wiki/; legacy /docs/ URLs are not supported");
+    }
+    if (pathMatch[1] === "docs") {
+      throw new FeishuDocumentInputError("legacy Feishu /docs/ URLs are not supported by feishu_fetch_doc; use a /docx/ or /wiki/ URL");
+    }
+    return {
+      url: value,
+      type: pathMatch[1] as "docx" | "wiki",
+      token: pathMatch[2],
+    };
+  }
+
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) {
+    throw new FeishuDocumentInputError("doc_id must be a Feishu/Lark document URL or token");
+  }
+  return { type: value.startsWith("wiki") ? "wiki" : "docx", token: value };
+}
+
+async function resolveFeishuCredentialsForSession(input: { spaceId: string; sessionId: string }) {
+  const [row] = await db
+    .select({ credentials: userChannels.credentials })
+    .from(spaceSessionBindings)
+    .innerJoin(spaceChannels, eq(spaceChannels.id, spaceSessionBindings.spaceChannelId))
+    .innerJoin(userChannels, eq(userChannels.id, spaceChannels.channelId))
+    .where(and(
+      eq(spaceSessionBindings.spaceId, input.spaceId),
+      eq(spaceSessionBindings.spaceSessionId, input.sessionId),
+      eq(spaceSessionBindings.provider, "feishu"),
+      eq(spaceSessionBindings.status, "active"),
+      eq(userChannels.provider, "feishu"),
+      eq(userChannels.status, "active"),
+    ))
+    .limit(1);
+
+  const credentials = row?.credentials as Record<string, unknown> | undefined;
+  const appId = typeof credentials?.appId === "string" ? credentials.appId.trim() : "";
+  const appSecret = typeof credentials?.appSecret === "string" ? credentials.appSecret.trim() : "";
+  const brand: "feishu" | "lark" = credentials?.brand === "lark" ? "lark" : "feishu";
+  if (!appId || !appSecret) return null;
+  return { appId, appSecret, brand };
+}
+
+function getFeishuOpenApiBaseUrl(brand: "feishu" | "lark") {
+  return brand === "lark" ? LARK_OPEN_API_BASE_URL : FEISHU_OPEN_API_BASE_URL;
+}
+
+async function requestFeishuJson(input: {
+  brand: "feishu" | "lark";
+  path: string;
+  method?: "GET" | "POST";
+  token?: string;
+  body?: Record<string, unknown>;
+  query?: Record<string, string>;
+}) {
+  const baseUrl = getFeishuOpenApiBaseUrl(input.brand);
+  const url = new URL(input.path, baseUrl);
+  for (const [key, value] of Object.entries(input.query ?? {})) {
+    url.searchParams.set(key, value);
+  }
+
+  const response = await fetch(url, {
+    method: input.method ?? "GET",
+    headers: {
+      "content-type": "application/json",
+      ...(input.token ? { authorization: `Bearer ${input.token}` } : {}),
+    },
+    body: input.body ? JSON.stringify(input.body) : undefined,
+  });
+  const data = await response.json().catch(() => null) as Record<string, unknown> | null;
+  const code = typeof data?.code === "number" ? data.code : 0;
+  if (!response.ok || code !== 0) {
+    const message = typeof data?.msg === "string" ? data.msg : response.statusText;
+    throw new FeishuUpstreamError(`Feishu API ${input.path} failed: ${message || response.status}`);
+  }
+  return data;
+}
+
+async function getFeishuTenantAccessToken(credentials: { appId: string; appSecret: string; brand: "feishu" | "lark" }) {
+  const data = await requestFeishuJson({
+    brand: credentials.brand,
+    path: "/open-apis/auth/v3/tenant_access_token/internal",
+    method: "POST",
+    body: { app_id: credentials.appId, app_secret: credentials.appSecret },
+  });
+  const token = typeof data?.tenant_access_token === "string" ? data.tenant_access_token : "";
+  if (!token) throw new FeishuUpstreamError("Feishu API did not return tenant_access_token");
+  return token;
+}
+
+async function resolveFeishuWikiRef(credentials: { brand: "feishu" | "lark" }, token: string, ref: FeishuDocumentRef): Promise<FeishuDocumentRef> {
+  if (ref.type !== "wiki") return ref;
+  const res = await requestFeishuJson({
+    brand: credentials.brand,
+    token,
+    path: "/open-apis/wiki/v2/spaces/get_node",
+    query: { token: ref.token },
+  });
+  const data = res?.data as Record<string, unknown> | undefined;
+  const node = data?.node as Record<string, unknown> | undefined;
+  const objToken = typeof node?.obj_token === "string" ? node.obj_token : "";
+  const objType = typeof node?.obj_type === "string" ? node.obj_type : "";
+  if (!objToken) throw new FeishuUpstreamError("failed to resolve wiki token");
+  if (objType !== "docx") throw new FeishuDocumentInputError(`wiki object type ${objType || "unknown"} is not supported by feishu_fetch_doc`);
+  return { ...ref, type: "docx", token: objToken };
+}
 
 // GET /internal/spaces/:id
 router.get("/:id", async (c) => {
@@ -188,6 +329,34 @@ router.get("/:id/sandbox", async (c) => {
   return c.json({ sandbox: attachSandboxPublicEndpoints(sandbox) });
 });
 
+// GET /internal/spaces/:id/capabilities
+router.get("/:id/capabilities", async (c) => {
+  const forbidden = ensureInternalRequest(c);
+  if (forbidden) return forbidden;
+
+  const spaceId = c.req.param("id");
+  if (!requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
+  const space = await getSpaceById(spaceId);
+  if (!space) return c.json({ message: "space not found" }, 404);
+
+  const [feishuChannel] = await db
+    .select({ id: spaceChannels.id })
+    .from(spaceChannels)
+    .innerJoin(userChannels, eq(userChannels.id, spaceChannels.channelId))
+    .where(and(
+      eq(spaceChannels.spaceId, spaceId),
+      eq(userChannels.provider, "feishu"),
+      eq(userChannels.status, "active"),
+    ))
+    .limit(1);
+
+  return c.json({
+    capabilities: {
+      feishu: Boolean(feishuChannel),
+    },
+  });
+});
+
 // POST /internal/spaces/:id/sessions
 router.post("/:id/sessions", async (c) => {
   const forbidden = ensureInternalRequest(c);
@@ -304,6 +473,70 @@ router.post("/:spaceId/sessions/:sessionId/turns/:turnId/interrupt", async (c) =
 
   const turn = await interruptSessionTurn({ spaceId, sessionId, turnId, interruptedByTurnId });
   return c.json({ ok: true, turn });
+});
+
+// POST /internal/spaces/:spaceId/sessions/:sessionId/tools/feishu-fetch-doc
+router.post("/:spaceId/sessions/:sessionId/tools/feishu-fetch-doc", async (c) => {
+  const forbidden = ensureInternalRequest(c);
+  if (forbidden) return forbidden;
+
+  const spaceId = c.req.param("spaceId");
+  const sessionId = c.req.param("sessionId");
+  if (!requireValidId(spaceId) || !requireValidId(sessionId)) return c.json({ message: "session not found" }, 404);
+
+  const session = await getSpaceSessionById(sessionId);
+  if (!session || session.spaceId !== spaceId) return c.json({ message: "session not found" }, 404);
+
+  const credentials = await resolveFeishuCredentialsForSession({ spaceId, sessionId });
+  if (!credentials) return c.json({ message: "feishu_fetch_doc is only available for sessions bound to a Feishu channel" }, 403);
+
+  const body = await c.req.json<{ doc_id?: string; offset?: number; limit?: number }>().catch(() => null);
+  const docId = body?.doc_id?.trim();
+  if (!docId) return c.json({ message: "doc_id is required" }, 400);
+
+  const offset = Number.isInteger(body?.offset) && (body?.offset ?? 0) > 0 ? body?.offset ?? 0 : 0;
+  const limit = Number.isInteger(body?.limit) && (body?.limit ?? 0) > 0
+    ? Math.min(body?.limit ?? MAX_FEISHU_DOCUMENT_CHARS, MAX_FEISHU_DOCUMENT_CHARS)
+    : MAX_FEISHU_DOCUMENT_CHARS;
+
+  try {
+    const rawRef = extractFeishuDocumentRef(docId);
+    const tenantAccessToken = await getFeishuTenantAccessToken(credentials);
+    const ref = await resolveFeishuWikiRef(credentials, tenantAccessToken, rawRef);
+    if (ref.type !== "docx") return c.json({ message: `document type ${ref.type} is not supported by feishu_fetch_doc` }, 400);
+
+    const res = await requestFeishuJson({
+      brand: credentials.brand,
+      token: tenantAccessToken,
+      path: `/open-apis/docx/v1/documents/${ref.token}/raw_content`,
+    });
+    const data = res?.data as Record<string, unknown> | undefined;
+    const content = typeof data?.content === "string" ? data.content : "";
+    const safeOffset = Math.min(offset, content.length);
+    const page = content.slice(safeOffset, safeOffset + limit);
+
+    return c.json({
+      ok: true,
+      document: {
+        type: ref.type,
+        token: ref.token,
+        url: rawRef.url ?? null,
+        content: page,
+        offset: safeOffset,
+        limit,
+        totalLength: content.length,
+        hasMore: safeOffset + limit < content.length,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const status: 400 | 502 = error instanceof FeishuDocumentInputError
+      ? error.status
+      : error instanceof FeishuUpstreamError
+        ? error.status
+        : 502;
+    return c.json({ message }, status);
+  }
 });
 
 // POST /internal/spaces/:spaceId/sessions/:sessionId/prompt

--- a/apps/gateway/src/providers/feishu/index.ts
+++ b/apps/gateway/src/providers/feishu/index.ts
@@ -10,8 +10,13 @@ import { buildFeishuDeliveryPlan } from "../../session-output-planner.js";
 import {
   resolveReceiveIdType,
   buildFeishuBindingKey,
-  resolveAtMentions,
 } from "./utils.js";
+import { parseFeishuMessageContent, type FeishuInboundResource, type FeishuParsedMessageBlock } from "./parse.js";
+import {
+  FEISHU_INBOUND_IMAGE_MAX_BYTES,
+  FEISHU_INBOUND_IMAGE_MAX_COUNT,
+  readFeishuResourceBuffer,
+} from "./media.js";
 
 // Detect image MIME type from magic bytes (first 4 bytes)
 function detectMimeType(buffer: Buffer): string | null {
@@ -180,13 +185,11 @@ export class FeishuProvider implements GatewayProvider {
       }
     }
 
-    // Parse message content (may contain image key placeholders)
-    const { blocks: rawBlocks, imageKeys } = this.parseMessageContent(msg);
+    const parsedContent = parseFeishuMessageContent(msg);
 
-    // Download any images and replace placeholders with proper image ContentBlocks
-    const contentBlocks = imageKeys.length > 0
-      ? await this.resolveImagePlaceholders(rawBlocks, msg.message_id)
-      : rawBlocks;
+    const contentBlocks = parsedContent.resources.length > 0
+      ? await this.resolveParsedBlocks(parsedContent.blocks, msg.message_id, FEISHU_INBOUND_IMAGE_MAX_COUNT)
+      : parsedContent.blocks.map((block) => ({ type: "text", text: block.type === "text" ? block.text : block.fallbackText }) satisfies ContentBlock);
 
     const threadId = msg.thread_id || msg.root_id || null;
     const parentMessageId = msg.root_id || msg.parent_id || null;
@@ -287,13 +290,13 @@ export class FeishuProvider implements GatewayProvider {
 
   // Download image from Feishu by image_key and return as base64 ContentBlock.
   // Returns null on failure — caller decides whether to use a text fallback.
-  private async downloadImageBlock(imageKey: string, _messageId: string): Promise<ContentBlock | null> {
+  private async downloadImageBlock(imageKey: string, messageId: string): Promise<ContentBlock | null> {
     try {
-      const res = await this.client.im.image.get({
-        path: { image_key: imageKey },
+      const res = await this.client.im.messageResource.get({
+        path: { message_id: messageId, file_key: imageKey },
+        params: { type: "image" },
       });
-      // The Lark SDK returns the binary in rawData
-      const buffer = (res as { rawData?: Buffer }).rawData;
+      const buffer = await readFeishuResourceBuffer(res, { maxBytes: FEISHU_INBOUND_IMAGE_MAX_BYTES });
       if (!buffer || buffer.length === 0) {
         console.warn(`[Feishu:${this.channelId}] Image download returned empty: ${imageKey}`);
         return null;
@@ -315,125 +318,29 @@ export class FeishuProvider implements GatewayProvider {
     }
   }
 
-  // Parse message content into ContentBlocks.
-  // Returns { blocks, imageKeys } — imageKeys need to be downloaded and interleaved
-  // by the caller. This separation avoids making parsing fully async in one pass.
-  private parseMessageContent(msg: {
-    message_type: string;
-    content: string;
-    mentions?: Array<{ id: { open_id?: string }; name: string }>;
-  }): { blocks: ContentBlock[]; imageKeys: string[] } {
-    const blocks: ContentBlock[] = [];
-    const imageKeys: string[] = [];
-
-    if (msg.message_type === "text") {
-      // Feishu text messages wrap content in JSON: {"text":"hello"}
-      let text: string;
-      try {
-        const parsed = JSON.parse(msg.content);
-        text = typeof parsed.text === "string" ? parsed.text : msg.content;
-      } catch {
-        text = msg.content;
-      }
-      text = resolveAtMentions(text);
-      if (text.trim()) blocks.push({ type: "text", text });
-    } else if (msg.message_type === "post") {
-      // Post messages are rich text with mixed elements (text, images, links, etc.)
-      // Parse into multiple ContentBlocks: text accumulates, images become separate blocks
-      try {
-        const parsed = JSON.parse(msg.content);
-        const locale = parsed.zh_cn ?? parsed.en_us ?? Object.values(parsed)[0] as Record<string, unknown>;
-        const textParts: string[] = [];
-
-        const flushText = () => {
-          const joined = resolveAtMentions(textParts.join("\n"));
-          if (joined.trim()) {
-            blocks.push({ type: "text", text: joined });
-          }
-          textParts.length = 0;
-        };
-
-        for (const row of ((locale?.content as unknown[] | undefined) ?? [])) {
-          for (const item of (row as Array<Record<string, string>> | undefined) ?? []) {
-            if (item.tag === "text" || item.tag === "md") {
-              textParts.push(item.text ?? "");
-            } else if (item.tag === "at") {
-              // @mention — already handled by resolveAtMentions, but post format
-              // stores mentions as { tag: "at", user_name: "..." } not <at> tags
-              textParts.push(item.user_name ? `@${item.user_name}` : "");
-            } else if (item.tag === "a") {
-              textParts.push(item.text ?? item.href ?? "[link]");
-            } else if (item.tag === "img") {
-              // Flush any accumulated text before inserting the image block
-              flushText();
-              // Record the image key for async download after parsing
-              if (item.image_key) {
-                imageKeys.push(item.image_key);
-                // Use a temporary text placeholder (will be replaced by image block)
-                blocks.push({ type: "text", text: `__FEISHU_IMAGE:${item.image_key}__` });
-              }
-            } else if (item.tag === "media") {
-              textParts.push(`[media:${item.file_key ?? "unknown"}]`);
-            } else if (item.tag === "file") {
-              textParts.push(`[file:${item.file_key ?? "unknown"}]`);
-            }
-          }
-        }
-        flushText();
-      } catch {
-        blocks.push({ type: "text", text: msg.content });
-      }
-    } else if (msg.message_type === "image") {
-      try {
-        const parsed = JSON.parse(msg.content);
-        const imageKey = parsed.image_key;
-        if (imageKey) {
-          imageKeys.push(imageKey);
-          blocks.push({ type: "text", text: `__FEISHU_IMAGE:${imageKey}__` });
-        } else {
-          blocks.push({ type: "text", text: "[image]" });
-        }
-      } catch {
-        blocks.push({ type: "text", text: "[image]" });
-      }
-    } else if (msg.message_type === "file") {
-      try {
-        const parsed = JSON.parse(msg.content);
-        blocks.push({ type: "text", text: `[file: ${parsed.file_name ?? parsed.file_key ?? "unknown"}]` });
-      } catch {
-        blocks.push({ type: "text", text: "[file]" });
-      }
-    } else {
-      blocks.push({ type: "text", text: `[${msg.message_type} message]` });
-    }
-
-    return { blocks, imageKeys };
+  private async resolveInboundResource(resource: FeishuInboundResource, messageId: string): Promise<ContentBlock | null> {
+    if (resource.type === "image") return this.downloadImageBlock(resource.fileKey, messageId);
+    return null;
   }
 
-  // Replace __FEISHU_IMAGE:key__ placeholder blocks with downloaded image ContentBlocks.
-  // Preserves ordering: text, image, text, image, ...
-  private async resolveImagePlaceholders(blocks: ContentBlock[], messageId: string): Promise<ContentBlock[]> {
-    const IMAGE_KEY_REGEX = /^__FEISHU_IMAGE:(.+)__$/;
+  private async resolveParsedBlocks(blocks: FeishuParsedMessageBlock[], messageId: string, maxResources: number): Promise<ContentBlock[]> {
     const resolved: ContentBlock[] = [];
+    let resourceCount = 0;
 
     for (const block of blocks) {
-      if (block.type !== "text" || typeof block.text !== "string") {
-        resolved.push(block);
+      if (block.type === "text") {
+        resolved.push({ type: "text", text: block.text });
         continue;
       }
-      const match = block.text.match(IMAGE_KEY_REGEX);
-      if (!match) {
-        resolved.push(block);
+
+      resourceCount += 1;
+      if (resourceCount > maxResources) {
+        resolved.push({ type: "text", text: `[image: ${block.resource.fileKey} skipped: too many images]` });
         continue;
       }
-      const imageKey = match[1] as string;
-      const imageBlock = await this.downloadImageBlock(imageKey, messageId);
-      if (imageBlock) {
-        resolved.push(imageBlock);
-      } else {
-        // Download failed — keep a readable fallback
-        resolved.push({ type: "text", text: `[image: ${imageKey}]` });
-      }
+
+      const resourceBlock = await this.resolveInboundResource(block.resource, messageId);
+      resolved.push(resourceBlock ?? { type: "text", text: block.fallbackText });
     }
     return resolved;
   }

--- a/apps/gateway/src/providers/feishu/media.ts
+++ b/apps/gateway/src/providers/feishu/media.ts
@@ -1,0 +1,63 @@
+import { Readable } from "node:stream";
+
+export const FEISHU_INBOUND_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
+export const FEISHU_INBOUND_IMAGE_TIMEOUT_MS = 15_000;
+export const FEISHU_INBOUND_IMAGE_MAX_COUNT = 8;
+
+function getReadableStream(response: unknown): Readable {
+  if (!response || typeof response !== "object") {
+    throw new Error("Feishu resource response is empty");
+  }
+
+  const candidate = response as { getReadableStream?: unknown };
+  if (typeof candidate.getReadableStream !== "function") {
+    throw new Error("Feishu resource response does not expose getReadableStream()");
+  }
+
+  const stream = candidate.getReadableStream() as unknown;
+  if (!(stream instanceof Readable)) {
+    throw new Error("Feishu resource stream is not a Node.js Readable");
+  }
+
+  return stream;
+}
+
+async function readStreamWithLimit(stream: Readable, maxBytes: number): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+
+  for await (const chunk of stream as AsyncIterable<Buffer | Uint8Array | string>) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buffer.length;
+    if (total > maxBytes) {
+      stream.destroy(new Error(`Feishu resource exceeds ${maxBytes} bytes`));
+      throw new Error(`Feishu resource exceeds ${maxBytes} bytes`);
+    }
+    chunks.push(buffer);
+  }
+
+  return Buffer.concat(chunks, total);
+}
+
+export async function readFeishuResourceBuffer(
+  response: unknown,
+  options: { maxBytes?: number; timeoutMs?: number } = {},
+): Promise<Buffer> {
+  const maxBytes = options.maxBytes ?? FEISHU_INBOUND_IMAGE_MAX_BYTES;
+  const timeoutMs = options.timeoutMs ?? FEISHU_INBOUND_IMAGE_TIMEOUT_MS;
+  const stream = getReadableStream(response);
+
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      stream.destroy(new Error(`Feishu resource download timed out after ${timeoutMs}ms`));
+      reject(new Error(`Feishu resource download timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([readStreamWithLimit(stream, maxBytes), timeoutPromise]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}

--- a/apps/gateway/src/providers/feishu/parse.ts
+++ b/apps/gateway/src/providers/feishu/parse.ts
@@ -1,0 +1,174 @@
+import { resolveAtMentions } from "./utils.js";
+
+export type FeishuInboundResource = {
+  type: "image";
+  fileKey: string;
+};
+
+export type FeishuParsedMessageBlock =
+  | { type: "text"; text: string }
+  | { type: "resource"; resource: FeishuInboundResource; fallbackText: string };
+
+export type FeishuParsedMessageContent = {
+  blocks: FeishuParsedMessageBlock[];
+  resources: FeishuInboundResource[];
+};
+
+type FeishuPostBody = {
+  content?: unknown;
+};
+
+type FeishuPostItem = Record<string, unknown>;
+
+const FEISHU_IMAGE_REFERENCE_RE = /\[image:\s*(img_v3_[a-zA-Z0-9_-]+)\]|!\[[^\]]*\]\((img_v3_[a-zA-Z0-9_-]+)\)/g;
+
+function readJsonObject(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : null;
+  } catch {
+    return null;
+  }
+}
+
+function appendResource(
+  output: FeishuParsedMessageContent,
+  resource: FeishuInboundResource,
+  fallbackText = `![image](${resource.fileKey})`,
+) {
+  output.resources.push(resource);
+  output.blocks.push({ type: "resource", resource, fallbackText });
+}
+
+function appendTextWithImageReferences(output: FeishuParsedMessageContent, text: string) {
+  let lastIndex = 0;
+  let matched = false;
+
+  for (const match of text.matchAll(FEISHU_IMAGE_REFERENCE_RE)) {
+    matched = true;
+    const index = match.index ?? 0;
+    if (index > lastIndex) {
+      const before = text.slice(lastIndex, index);
+      if (before.trim()) output.blocks.push({ type: "text", text: before });
+    }
+
+    const imageKey = match[1] ?? match[2];
+    if (imageKey) appendResource(output, { type: "image", fileKey: imageKey });
+    lastIndex = index + match[0].length;
+  }
+
+  if (!matched) {
+    if (text.trim()) output.blocks.push({ type: "text", text });
+    return;
+  }
+
+  const rest = text.slice(lastIndex);
+  if (rest.trim()) output.blocks.push({ type: "text", text: rest });
+}
+
+function resolvePostBody(parsed: Record<string, unknown>): FeishuPostBody | null {
+  if (Array.isArray(parsed.content)) return parsed as FeishuPostBody;
+
+  const preferred = [parsed.zh_cn, parsed.en_us];
+  for (const candidate of preferred) {
+    if (candidate && typeof candidate === "object" && Array.isArray((candidate as FeishuPostBody).content)) {
+      return candidate as FeishuPostBody;
+    }
+  }
+
+  for (const candidate of Object.values(parsed)) {
+    if (candidate && typeof candidate === "object" && Array.isArray((candidate as FeishuPostBody).content)) {
+      return candidate as FeishuPostBody;
+    }
+  }
+
+  return null;
+}
+
+function itemText(item: FeishuPostItem, key: string) {
+  const value = item[key];
+  return typeof value === "string" ? value : "";
+}
+
+function parsePostContent(content: string, output: FeishuParsedMessageContent) {
+  const parsed = readJsonObject(content);
+  if (!parsed) {
+    appendTextWithImageReferences(output, content);
+    return;
+  }
+
+  const body = resolvePostBody(parsed);
+  if (!body || !Array.isArray(body.content)) {
+    appendTextWithImageReferences(output, content);
+    return;
+  }
+
+  const textParts: string[] = [];
+  const flushText = () => {
+    const joined = resolveAtMentions(textParts.join(""));
+    if (joined.trim()) appendTextWithImageReferences(output, joined);
+    textParts.length = 0;
+  };
+
+  for (let rowIndex = 0; rowIndex < body.content.length; rowIndex += 1) {
+    const row = body.content[rowIndex];
+    if (!Array.isArray(row)) continue;
+    if (rowIndex > 0) textParts.push("\n");
+
+    for (const rawItem of row) {
+      if (!rawItem || typeof rawItem !== "object") continue;
+      const item = rawItem as FeishuPostItem;
+      const tag = itemText(item, "tag");
+
+      if (tag === "text" || tag === "md") {
+        textParts.push(itemText(item, "text"));
+      } else if (tag === "at") {
+        const name = itemText(item, "user_name") || itemText(item, "text");
+        if (name) textParts.push(`@${name}`);
+      } else if (tag === "a") {
+        const href = itemText(item, "href");
+        const text = itemText(item, "text") || href || "link";
+        textParts.push(href ? `[${text}](${href})` : text);
+      } else if (tag === "img" || tag === "image") {
+        flushText();
+        const imageKey = itemText(item, "image_key") || itemText(item, "file_key");
+        if (imageKey) appendResource(output, { type: "image", fileKey: imageKey });
+      } else if (tag === "media") {
+        textParts.push(`[media:${itemText(item, "file_key") || "unknown"}]`);
+      } else if (tag === "file") {
+        textParts.push(`[file:${itemText(item, "file_key") || "unknown"}]`);
+      }
+    }
+  }
+
+  flushText();
+}
+
+export function parseFeishuMessageContent(msg: {
+  message_type: string;
+  content: string;
+}): FeishuParsedMessageContent {
+  const output: FeishuParsedMessageContent = { blocks: [], resources: [] };
+
+  if (msg.message_type === "text") {
+    const parsed = readJsonObject(msg.content);
+    const text = resolveAtMentions(typeof parsed?.text === "string" ? parsed.text : msg.content);
+    appendTextWithImageReferences(output, text);
+  } else if (msg.message_type === "post") {
+    parsePostContent(msg.content, output);
+  } else if (msg.message_type === "image") {
+    const parsed = readJsonObject(msg.content);
+    const imageKey = typeof parsed?.image_key === "string" ? parsed.image_key : "";
+    if (imageKey) appendResource(output, { type: "image", fileKey: imageKey });
+    else output.blocks.push({ type: "text", text: "[image]" });
+  } else if (msg.message_type === "file") {
+    const parsed = readJsonObject(msg.content);
+    const fileName = typeof parsed?.file_name === "string" ? parsed.file_name : null;
+    const fileKey = typeof parsed?.file_key === "string" ? parsed.file_key : null;
+    output.blocks.push({ type: "text", text: `[file: ${fileName ?? fileKey ?? "unknown"}]` });
+  } else {
+    output.blocks.push({ type: "text", text: `[${msg.message_type} message]` });
+  }
+
+  return output;
+}


### PR DESCRIPTION
## Summary
- parse Feishu image/rich-text messages into resource descriptors and download images via the official SDK stream API
- add space-level Feishu capability registration for the agent-side feishu_fetch_doc tool
- add internal Feishu doc fetch endpoint with docx/wiki support and explicit legacy /docs/ rejection

## Verification
- pnpm --filter @cohub/api typecheck
- pnpm --filter @cohub/agent typecheck
- pnpm --filter @cohub/gateway typecheck
- pnpm exec biome lint apps/api/src/routes/internal/spaces.route.ts apps/agent/src/api.ts apps/agent/src/index.ts apps/agent/src/session.ts apps/agent/src/sandbox/tools.ts apps/agent/src/runtime/session-runtime.ts apps/agent/src/tests/session-stream-integration.test.ts apps/agent/src/tests/sandbox-tools.test.ts apps/gateway/src/providers/feishu/index.ts apps/gateway/src/providers/feishu/media.ts apps/gateway/src/providers/feishu/parse.ts apps/gateway/src/providers/feishu/utils.ts
- pnpm exec tsx apps/agent/src/tests/sandbox-tools.test.ts