### PR TITLE
fix(worker): handle empty git repo imports

### DIFF
--- a/apps/worker/src/tasks/create-space-task.ts
+++ b/apps/worker/src/tasks/create-space-task.ts
@@ -173,12 +173,26 @@ const buildCloneUrl = (repoUrl: string, token?: string) => {
   return url.toString();
 };
 
+const hasHeadCommit = async (workspaceDir: string) =>
+  runGit(["rev-parse", "--verify", "HEAD"], workspaceDir)
+    .then(() => true)
+    .catch(() => false);
+
 const pushExistingHistory = async (input: {
   workspaceDir: string;
   authenticatedRemoteUrl: string;
 }) => {
   await runGit(["remote", "remove", "origin"], input.workspaceDir).catch(() => undefined);
   await runGit(["remote", "add", "origin", input.authenticatedRemoteUrl], input.workspaceDir);
+
+  if (!(await hasHeadCommit(input.workspaceDir))) {
+    return commitAllAndPush({
+      workspaceDir: input.workspaceDir,
+      authenticatedRemoteUrl: input.authenticatedRemoteUrl,
+      branch: "main",
+      message: "chore: initialize space",
+    });
+  }
 
   // Resolve current branch; if detached HEAD (e.g. checked out a specific commit), create main
   const branchResult = await runGitWithOutput(["rev-parse", "--abbrev-ref", "HEAD"], input.workspaceDir);


### PR DESCRIPTION
## Summary
- detect git repo imports that clone successfully but have no HEAD commit
- initialize an empty Cohub storage repo on main instead of failing on git rev-parse HEAD
- keeps existing-history import behavior unchanged when the source repo has commits

## Root cause
The Gitea source repo can clone as an empty repository. In that state Git has no HEAD commit, so create_space failed in pushExistingHistory when running rev-parse --abbrev-ref HEAD, surfacing the ambiguous HEAD error from Git.

## Verification
- pnpm --filter @cohub/worker typecheck
- pnpm --filter @cohub/worker lint
- local empty-repo git simulation: initialized and pushed main successfully

## Note
- pnpm -r typecheck is still blocked by existing web env declarations: PUBLIC_API_ORIGIN and PUBLIC_GATEWAY_ORIGIN are missing from /static/public during apps/web typecheck.