### PR TITLE
[codex] add Kling generation support

### DIFF
--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -10,6 +10,9 @@
       "@cohub/core/permissions": [
         "../../packages/core/dist/permissions/index.d.ts"
       ],
+      "@cohub/core/content/sanitize": [
+        "../../packages/core/dist/content/sanitize.d.ts"
+      ],
       "@cohub/protocol": [
         "../../packages/protocol/dist/index.d.ts"
       ],

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -10,6 +10,9 @@
       "@cohub/core/permissions": [
         "../../packages/core/src/permissions/index.ts"
       ],
+      "@cohub/core/content/sanitize": [
+        "../../packages/core/src/content/sanitize.ts"
+      ],
       "@cohub/protocol": [
         "../../packages/protocol/src/index.ts"
       ],

--- a/apps/worker/src/generations/kling-video-adapter.ts
+++ b/apps/worker/src/generations/kling-video-adapter.ts
@@ -1,0 +1,396 @@
+import {
+  GenerationProviderError,
+  GenerationTimeoutError,
+  GenerationValidationError,
+  mergeTextBlocks,
+  type GenerationAdapterInput,
+  type GenerationContentBlock,
+} from "@neta-art/generation";
+
+const REQUEST_TIMEOUT_MS = 60_000;
+const DEFAULT_POLL_INTERVAL_SEC = 5;
+const DEFAULT_MAX_WAIT_SEC = 900;
+
+type KlingImageMode = "none" | "single" | "omni" | "multi";
+
+const KLING_MODELS: Record<
+  string,
+  {
+    submitPath: string;
+    defaultModelName: string;
+    imageMode: KlingImageMode;
+    allowMultiShotWithoutPrompt?: boolean;
+  }
+> = {
+  "kling-text-to-video": {
+    submitPath: "/kling/v1/videos/text2video",
+    defaultModelName: "kling-v3",
+    imageMode: "none",
+  },
+  "kling-image-to-video": {
+    submitPath: "/kling/v1/videos/image2video",
+    defaultModelName: "kling-v3",
+    imageMode: "single",
+  },
+  "kling-omni-video": {
+    submitPath: "/kling/v1/videos/omni-video",
+    defaultModelName: "kling-v3-omni",
+    imageMode: "omni",
+    allowMultiShotWithoutPrompt: true,
+  },
+  "kling-multi-image-to-video": {
+    submitPath: "/kling/v1/videos/multi-image2video",
+    defaultModelName: "kling-v1-6",
+    imageMode: "multi",
+  },
+};
+
+type CreateTaskResponse = {
+  id?: unknown;
+  task_id?: unknown;
+  status?: unknown;
+  data?: {
+    id?: unknown;
+    task_id?: unknown;
+    status?: unknown;
+    task_status?: unknown;
+  };
+};
+
+type TaskStatusResponse = {
+  code?: unknown;
+  message?: unknown;
+  status?: unknown;
+  task_status?: unknown;
+  video_url?: unknown;
+  result_url?: unknown;
+  url?: unknown;
+  progress?: unknown;
+  error?: {
+    message?: unknown;
+  };
+  metadata?: {
+    url?: unknown;
+  };
+  data?: {
+    status?: unknown;
+    task_status?: unknown;
+    task_status_msg?: unknown;
+    result_url?: unknown;
+    video_url?: unknown;
+    url?: unknown;
+    progress?: unknown;
+    task_result?: {
+      videos?: Array<{ url?: unknown; duration?: unknown }>;
+    };
+    data?: {
+      status?: unknown;
+      content?: { video_url?: unknown; first_frame?: unknown };
+      progress?: unknown;
+      task_result?: {
+        videos?: Array<{ url?: unknown; duration?: unknown }>;
+      };
+    };
+  };
+};
+
+type ResolvedImage = {
+  url: string;
+  role?: string;
+};
+
+type OmniImageReference = {
+  image_url: string;
+  type?: string;
+};
+
+type MultiImageReference = {
+  image: string;
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asInteger(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) ? value : fallback;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function compactObject(input: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(input).filter(([, value]) => value !== undefined));
+}
+
+function providerMeta(input: Record<string, unknown>): Record<string, unknown> {
+  const rest = { ...input };
+  delete rest.cohub;
+  return rest;
+}
+
+function normalizeStatus(value: unknown): string {
+  const status = String(value ?? "").trim().toLowerCase();
+  if (status === "success" || status === "succeed" || status === "succeeded" || status === "completed") {
+    return "succeeded";
+  }
+  if (status === "queued" || status === "processing" || status === "in_progress" || status === "not_start" || status === "submitted") {
+    return "processing";
+  }
+  if (status === "failure" || status === "failed" || status === "error") return "failed";
+  if (status === "cancelled" || status === "canceled") return "cancelled";
+  return status || "unknown";
+}
+
+function resolveAspectRatio(parameters: Record<string, unknown>): string {
+  const size = asString(parameters.size);
+  if (size === "720x1280" || size === "1080x1920") return "9:16";
+  if (size === "1024x1024" || size === "512x512") return "1:1";
+  const aspectRatio = asString(parameters.aspect_ratio);
+  return aspectRatio ?? "16:9";
+}
+
+function getImageRole(block: Extract<GenerationContentBlock, { type: "image" }>): string | undefined {
+  const role = block.meta?.role;
+  return typeof role === "string" && role.trim() ? role.trim() : undefined;
+}
+
+async function resolveImages(input: GenerationAdapterInput): Promise<ResolvedImage[]> {
+  const imageBlocks = input.request.content.filter(
+    (block): block is Extract<GenerationContentBlock, { type: "image" }> => block.type === "image",
+  );
+  return Promise.all(
+    imageBlocks.map(async (block) => ({
+      url: await input.context.resolveSource(block.source),
+      role: getImageRole(block),
+    })),
+  );
+}
+
+function hasOfficialOmniMedia(meta: Record<string, unknown>): boolean {
+  return ["image_list", "element_list", "video_list"].some((key) => meta[key] !== undefined);
+}
+
+function hasPlainImagePayload(meta: Record<string, unknown>): boolean {
+  return typeof meta.image === "string";
+}
+
+function hasMultiImagePayload(meta: Record<string, unknown>): boolean {
+  return Array.isArray(meta.image_list);
+}
+
+function isMultiShotPayload(meta: Record<string, unknown>): boolean {
+  const value = meta.multi_shot;
+  return value === true || (typeof value === "string" && value.trim().toLowerCase() === "true");
+}
+
+function omniImageType(image: ResolvedImage, index: number): string | undefined {
+  if (image.role === "first_frame" || image.role === "end_frame") return image.role;
+  if (image.role === "last_frame") return "end_frame";
+  if (!image.role) return index === 0 ? "first_frame" : "end_frame";
+  return undefined;
+}
+
+function buildOmniImageList(images: ResolvedImage[]): OmniImageReference[] {
+  return images.map((image, index) => {
+    const type = omniImageType(image, index);
+    return type ? { image_url: image.url, type } : { image_url: image.url };
+  });
+}
+
+function buildMultiImageList(images: ResolvedImage[]): MultiImageReference[] {
+  return images.map((image) => ({ image: image.url }));
+}
+
+function resolveKlingModel(input: GenerationAdapterInput) {
+  const model = KLING_MODELS[input.declaration.model];
+  if (!model) throw new GenerationValidationError(`Unsupported Kling generation model: ${input.declaration.model}`);
+  return model;
+}
+
+function buildPayload(
+  input: GenerationAdapterInput,
+  model: (typeof KLING_MODELS)[string],
+  prompt: string,
+  images: ResolvedImage[],
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    ...providerMeta(input.meta),
+    model_name: model.defaultModelName,
+    prompt,
+  };
+
+  if (!payload.model_name) payload.model_name = model.defaultModelName;
+  if (!payload.duration) payload.duration = String(asInteger(input.parameters.duration, 5));
+  if (!payload.mode) payload.mode = asString(input.parameters.mode) ?? "std";
+  if (payload.cfg_scale === undefined) payload.cfg_scale = asNumber(input.parameters.cfg_scale) ?? 0.5;
+  if (!payload.aspect_ratio) payload.aspect_ratio = resolveAspectRatio(input.parameters);
+  if (payload.camera_control === undefined && isRecord(input.parameters.camera_control)) {
+    payload.camera_control = input.parameters.camera_control;
+  }
+  if (payload.negative_prompt === undefined && asString(input.parameters.negative_prompt)) {
+    payload.negative_prompt = input.parameters.negative_prompt;
+  }
+  if (payload.sound === undefined && asString(input.parameters.sound)) payload.sound = input.parameters.sound;
+  if (payload.watermark_info === undefined && isRecord(input.parameters.watermark_info)) {
+    payload.watermark_info = input.parameters.watermark_info;
+  }
+  if (payload.multi_shot === undefined && asBoolean(input.parameters.multi_shot) !== undefined) {
+    payload.multi_shot = input.parameters.multi_shot;
+  }
+
+  if (model.imageMode === "single" && images[0] && !hasPlainImagePayload(payload)) {
+    payload.image = images[0].url;
+    if (images[1] && payload.image_tail === undefined) payload.image_tail = images[1].url;
+  }
+  if (model.imageMode === "omni" && images.length > 0 && !hasOfficialOmniMedia(payload) && !hasPlainImagePayload(payload)) {
+    payload.image_list = buildOmniImageList(images);
+  }
+  if (model.imageMode === "multi" && images.length > 0 && !hasMultiImagePayload(payload)) {
+    payload.image_list = buildMultiImageList(images);
+  }
+  if (payload.seed === undefined && input.parameters.seed !== undefined) payload.seed = input.parameters.seed;
+
+  return payload;
+}
+
+function extractTaskId(response: CreateTaskResponse): string {
+  const taskId = asString(response.task_id) ?? asString(response.id) ?? asString(response.data?.task_id) ?? asString(response.data?.id);
+  if (!taskId) {
+    throw new GenerationProviderError("Kling video provider did not return a task id", { details: { response } });
+  }
+  return taskId;
+}
+
+function extractStatus(response: TaskStatusResponse) {
+  const wrapper = response.data;
+  const native = wrapper?.data;
+  const status = normalizeStatus(native?.status ?? wrapper?.task_status ?? wrapper?.status ?? response.task_status ?? response.status);
+  const firstVideo = wrapper?.task_result?.videos?.[0] ?? native?.task_result?.videos?.[0];
+  const videoUrl =
+    asString(firstVideo?.url) ??
+    asString(wrapper?.result_url) ??
+    asString(wrapper?.video_url) ??
+    asString(wrapper?.url) ??
+    asString(native?.content?.video_url) ??
+    asString(response.metadata?.url) ??
+    asString(response.result_url) ??
+    asString(response.video_url) ??
+    asString(response.url);
+  const message = asString(wrapper?.task_status_msg) ?? asString(response.error?.message) ?? asString(response.message);
+  return {
+    status,
+    videoUrl,
+    message,
+    metadata: compactObject({
+      progress: wrapper?.progress ?? native?.progress ?? response.progress,
+      duration: firstVideo?.duration,
+      task_status_msg: message,
+      code: response.code,
+    }),
+  };
+}
+
+async function requestJson(input: GenerationAdapterInput, path: string, init: RequestInit): Promise<unknown> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await input.context.fetch(`${input.context.baseUrl.replace(/\/+$/, "")}${path}`, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${input.context.apiKey}`,
+        "Content-Type": "application/json",
+        ...init.headers,
+      },
+    });
+    const body = await response.text();
+    let parsed: unknown = {};
+    try {
+      parsed = body ? JSON.parse(body) : {};
+    } catch {
+      throw new GenerationProviderError("Kling video provider returned invalid JSON", { status: response.status, body });
+    }
+    if (!response.ok) {
+      throw new GenerationProviderError("Kling video provider request failed", {
+        status: response.status,
+        body,
+        details: isRecord(parsed) ? parsed : undefined,
+      });
+    }
+    return parsed;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function klingVideoGenerationsAdapter(input: GenerationAdapterInput): Promise<GenerationContentBlock[]> {
+  const model = resolveKlingModel(input);
+  const prompt = mergeTextBlocks(input.declaration, input.request.content);
+  const images = await resolveImages(input);
+  const meta = providerMeta(input.meta);
+  if (!prompt && !model.allowMultiShotWithoutPrompt) {
+    throw new GenerationValidationError("Prompt text is required");
+  }
+  if (!prompt && model.allowMultiShotWithoutPrompt && !hasPlainImagePayload(meta) && !isMultiShotPayload(meta)) {
+    throw new GenerationValidationError("Prompt text is required for Kling Omni unless multi_shot meta is provided");
+  }
+  if (model.imageMode === "single" && images.length === 0 && !hasPlainImagePayload(meta)) {
+    throw new GenerationValidationError("Image input is required");
+  }
+  if (model.imageMode === "multi" && images.length === 0 && !hasMultiImagePayload(meta)) {
+    throw new GenerationValidationError("Multi-image input is required");
+  }
+
+  const task = (await requestJson(input, model.submitPath, {
+    method: "POST",
+    body: JSON.stringify(buildPayload(input, model, prompt, images)),
+  })) as CreateTaskResponse;
+  const taskId = extractTaskId(task);
+  const pollIntervalSec = asInteger(input.parameters.poll_interval, DEFAULT_POLL_INTERVAL_SEC);
+  const maxWaitSec = asInteger(input.parameters.max_wait, DEFAULT_MAX_WAIT_SEC);
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt <= maxWaitSec * 1000) {
+    await sleep(pollIntervalSec * 1000);
+    const rawStatus = (await requestJson(input, `${model.submitPath}/${encodeURIComponent(taskId)}`, {
+      method: "GET",
+    })) as TaskStatusResponse;
+    const status = extractStatus(rawStatus);
+
+    if (status.status === "succeeded") {
+      if (!status.videoUrl) {
+        throw new GenerationProviderError("Kling video generation succeeded but returned no video URL", {
+          details: { taskId, rawStatus, metadata: status.metadata },
+        });
+      }
+      return [
+        {
+          type: "video",
+          source: { type: "url", url: status.videoUrl },
+          meta: { task_id: taskId, status: status.status, ...status.metadata },
+        },
+      ];
+    }
+    if (status.status === "failed" || status.status === "cancelled" || status.status === "expired") {
+      throw new GenerationProviderError(`Kling video generation ${status.status}`, {
+        details: { taskId, message: status.message, rawStatus },
+      });
+    }
+  }
+
+  throw new GenerationTimeoutError("Timed out waiting for Kling video generation", { taskId });
+}

--- a/apps/worker/src/tasks/generation-task.ts
+++ b/apps/worker/src/tasks/generation-task.ts
@@ -10,6 +10,7 @@ import { createGenerationDeclarationLoader } from "@cohub/infra/config-runtime/g
 import { GENERATION_TASK_TYPE, type GenerationTaskData, type GenerationTaskResult } from "@cohub/protocol/generation";
 import type { TaskPayload } from "@cohub/protocol/task";
 import { config } from "../config.js";
+import { klingVideoGenerationsAdapter } from "../generations/kling-video-adapter.js";
 import { redisCommandClient } from "../redis.js";
 import { registerTask } from "./registry.js";
 
@@ -136,6 +137,9 @@ registerTask(GENERATION_TASK_TYPE, async (job: Job, context) => {
       models: [declaration],
       includeBuiltinModels: false,
       apiKey: getNetaRouterApiKey(),
+      adapters: {
+        "kling.videoGenerations": klingVideoGenerationsAdapter,
+      },
     }).generate({
       model: data.model,
       content: data.content,

--- a/apps/worker/tests/kling-video-adapter.test.ts
+++ b/apps/worker/tests/kling-video-adapter.test.ts
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { GenerationAdapterInput, GenerationContentBlock } from "@neta-art/generation";
+import { klingVideoGenerationsAdapter } from "../src/generations/kling-video-adapter.js";
+
+type CapturedRequest = {
+  url: string;
+  method: string;
+  headers: Headers;
+  body: Record<string, unknown> | undefined;
+};
+
+function createInput(input: {
+  model: string;
+  content: GenerationContentBlock[];
+  parameters?: Record<string, unknown>;
+  meta?: Record<string, unknown>;
+}) {
+  const requests: CapturedRequest[] = [];
+  const fetch: typeof globalThis.fetch = async (url, init) => {
+    const body = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : undefined;
+    requests.push({
+      url: String(url),
+      method: init?.method ?? "GET",
+      headers: new Headers(init?.headers),
+      body,
+    });
+
+    if (requests.length === 1) {
+      return new Response(JSON.stringify({ data: { task_id: "task-1" } }), { status: 200 });
+    }
+    return new Response(
+      JSON.stringify({
+        status: "completed",
+        progress: 100,
+        metadata: { url: "https://example.com/output.mp4" },
+      }),
+      { status: 200 },
+    );
+  };
+
+  const parameters = { poll_interval: 0, ...(input.parameters ?? {}) };
+  return {
+    requests,
+    adapterInput: {
+      declaration: {
+        schema: "neta.generation.model.v1",
+        model: input.model,
+        adapter: { type: "kling.videoGenerations" },
+        content: {
+          input: [
+            { type: "text", required: false, merge: "newline" },
+            { type: "image", required: false, max: 2, sources: ["url"] },
+          ],
+        },
+      },
+      request: {
+        model: input.model,
+        content: input.content,
+        parameters,
+        meta: input.meta,
+      },
+      parameters,
+      meta: input.meta ?? {},
+      context: {
+        apiKey: "sk-test",
+        baseUrl: "https://router.example",
+        fetch,
+        resolveSource: (source) => {
+          if (source.type === "url") return source.url;
+          return `data:${source.mediaType};base64,${source.data}`;
+        },
+      },
+    } satisfies GenerationAdapterInput,
+  };
+}
+
+function textBlock(text: string): GenerationContentBlock {
+  return { type: "text", text };
+}
+
+function imageBlock(url: string, meta?: Record<string, unknown>): GenerationContentBlock {
+  return {
+    type: "image",
+    source: { type: "url", url },
+    ...(meta ? { meta } : {}),
+  };
+}
+
+test("posts latest Kling text-to-video payload", async () => {
+  const { adapterInput, requests } = createInput({
+    model: "kling-text-to-video",
+    content: [textBlock("paper boat on calm water")],
+    parameters: {
+      duration: 10,
+      aspect_ratio: "9:16",
+      mode: "pro",
+      cfg_scale: 0.7,
+      negative_prompt: "blurry",
+    },
+    meta: { cohub: { taskRunId: "internal" } },
+  });
+
+  const output = await klingVideoGenerationsAdapter(adapterInput);
+
+  assert.equal(requests[0]?.url, "https://router.example/kling/v1/videos/text2video");
+  assert.equal(requests[0]?.method, "POST");
+  assert.equal(requests[0]?.headers.get("authorization"), "Bearer sk-test");
+  assert.equal(requests[1]?.url, "https://router.example/kling/v1/videos/text2video/task-1");
+  assert.deepEqual(requests[0]?.body, {
+    model_name: "kling-v3",
+    prompt: "paper boat on calm water",
+    duration: "10",
+    mode: "pro",
+    cfg_scale: 0.7,
+    aspect_ratio: "9:16",
+    negative_prompt: "blurry",
+  });
+  assert.deepEqual(output, [
+    {
+      type: "video",
+      source: { type: "url", url: "https://example.com/output.mp4" },
+      meta: { task_id: "task-1", status: "succeeded", progress: 100 },
+    },
+  ]);
+});
+
+test("posts latest Kling image-to-video payload", async () => {
+  const { adapterInput, requests } = createInput({
+    model: "kling-image-to-video",
+    content: [
+      textBlock("gently turn toward the camera"),
+      imageBlock("https://example.com/first.png"),
+      imageBlock("https://example.com/last.png"),
+    ],
+  });
+
+  await klingVideoGenerationsAdapter(adapterInput);
+
+  assert.equal(requests[0]?.url, "https://router.example/kling/v1/videos/image2video");
+  assert.deepEqual(requests[0]?.body, {
+    model_name: "kling-v3",
+    prompt: "gently turn toward the camera",
+    duration: "5",
+    mode: "std",
+    cfg_scale: 0.5,
+    aspect_ratio: "16:9",
+    image: "https://example.com/first.png",
+    image_tail: "https://example.com/last.png",
+  });
+});
+
+test("posts latest Kling Omni-Video payload", async () => {
+  const { adapterInput, requests } = createInput({
+    model: "kling-omni-video",
+    content: [
+      textBlock("<<<image_1>>> moves toward <<<image_2>>>"),
+      imageBlock("https://example.com/first.png", { role: "first_frame" }),
+      imageBlock("https://example.com/last.png", { role: "last_frame" }),
+    ],
+    parameters: { sound: "on" },
+  });
+
+  await klingVideoGenerationsAdapter(adapterInput);
+
+  assert.equal(requests[0]?.url, "https://router.example/kling/v1/videos/omni-video");
+  assert.equal(requests[0]?.body?.image, undefined);
+  assert.deepEqual(requests[0]?.body, {
+    model_name: "kling-v3-omni",
+    prompt: "<<<image_1>>> moves toward <<<image_2>>>",
+    duration: "5",
+    mode: "std",
+    cfg_scale: 0.5,
+    aspect_ratio: "16:9",
+    sound: "on",
+    image_list: [
+      { image_url: "https://example.com/first.png", type: "first_frame" },
+      { image_url: "https://example.com/last.png", type: "end_frame" },
+    ],
+  });
+});
+
+test("preserves official Omni media meta arrays", async () => {
+  const imageList = [{ image_url: "https://example.com/ref.png", type: "first_frame" }];
+  const elementList = [{ element_id: "subject" }];
+  const { adapterInput, requests } = createInput({
+    model: "kling-omni-video",
+    content: [textBlock("<<<image_1>>> cinematic motion"), imageBlock("https://example.com/ignored.png")],
+    meta: {
+      image_list: imageList,
+      element_list: elementList,
+      cohub: { taskRunId: "internal" },
+    },
+  });
+
+  await klingVideoGenerationsAdapter(adapterInput);
+
+  assert.equal(requests[0]?.body?.image, undefined);
+  assert.deepEqual(requests[0]?.body, {
+    model_name: "kling-v3-omni",
+    prompt: "<<<image_1>>> cinematic motion",
+    image_list: imageList,
+    element_list: elementList,
+    duration: "5",
+    mode: "std",
+    cfg_scale: 0.5,
+    aspect_ratio: "16:9",
+  });
+});
+
+test("posts latest Kling multi-image reference video payload", async () => {
+  const { adapterInput, requests } = createInput({
+    model: "kling-multi-image-to-video",
+    content: [
+      textBlock("combine the references into one cinematic shot"),
+      imageBlock("https://example.com/ref-1.png"),
+      imageBlock("https://example.com/ref-2.png"),
+    ],
+  });
+
+  await klingVideoGenerationsAdapter(adapterInput);
+
+  assert.equal(requests[0]?.url, "https://router.example/kling/v1/videos/multi-image2video");
+  assert.deepEqual(requests[0]?.body, {
+    model_name: "kling-v1-6",
+    prompt: "combine the references into one cinematic shot",
+    duration: "5",
+    mode: "std",
+    cfg_scale: 0.5,
+    aspect_ratio: "16:9",
+    image_list: [
+      { image: "https://example.com/ref-1.png" },
+      { image: "https://example.com/ref-2.png" },
+    ],
+  });
+});

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -124,6 +124,7 @@
     }
   },
   "include": [
-    "src"
+    "src",
+    "tests"
   ]
 }

--- a/docs/examples/generations/kling-image-to-video.yaml
+++ b/docs/examples/generations/kling-image-to-video.yaml
@@ -1,0 +1,89 @@
+schema: neta.generation.model.v1
+model: kling-image-to-video
+title: Kling Image To Video
+description: Kling image-to-video generation through Neta Router. Uses the latest upstream model_name kling-v3.
+adapter:
+  type: kling.videoGenerations
+content:
+  input:
+    - type: text
+      required: true
+      max: 16
+      merge: newline
+      description: Video prompt.
+    - type: image
+      required: true
+      max: 2
+      sources:
+        - url
+        - base64
+      description: First frame and optional tail frame image input.
+parameters:
+  duration:
+    type: integer
+    optional: true
+    default: 5
+    min: 5
+    max: 10
+    description: Video duration in seconds.
+  aspect_ratio:
+    type: string
+    optional: true
+    default: "16:9"
+    enum: ["16:9", "9:16", "1:1"]
+    description: Output aspect ratio.
+  size:
+    type: string
+    optional: true
+    default: 1280x720
+    enum: [1280x720, 720x1280, 1024x1024]
+    description: OpenAI-compatible video size used to derive Kling aspect ratio.
+  mode:
+    type: string
+    optional: true
+    default: std
+    enum: [std, pro]
+    description: Kling generation mode.
+  cfg_scale:
+    type: number
+    optional: true
+    default: 0.5
+    min: 0
+    max: 1
+    description: Prompt adherence scale.
+  negative_prompt:
+    type: string
+    optional: true
+    description: Negative prompt.
+  seed:
+    type: integer
+    optional: true
+    description: Random seed for reproducibility.
+  poll_interval:
+    type: integer
+    optional: true
+    default: 5
+    min: 1
+    max: 30
+    description: Seconds between task status checks.
+  max_wait:
+    type: integer
+    optional: true
+    default: 900
+    min: 30
+    max: 1800
+    description: Maximum seconds to wait for task completion.
+examples:
+  - title: Image to video
+    request:
+      model: kling-image-to-video
+      content:
+        - type: text
+          text: gently turn toward the camera with soft natural motion
+        - type: image
+          source:
+            type: url
+            url: https://example.com/input.png
+      parameters:
+        duration: 5
+        aspect_ratio: "16:9"

--- a/docs/examples/generations/kling-multi-image-to-video.yaml
+++ b/docs/examples/generations/kling-multi-image-to-video.yaml
@@ -1,0 +1,93 @@
+schema: neta.generation.model.v1
+model: kling-multi-image-to-video
+title: Kling Multi-Image Reference To Video
+description: Kling multi-image reference video generation through Neta Router. Uses the latest upstream model_name kling-v1-6 for this endpoint.
+adapter:
+  type: kling.videoGenerations
+content:
+  input:
+    - type: text
+      required: true
+      max: 16
+      merge: newline
+      description: Video prompt.
+    - type: image
+      required: true
+      max: 4
+      sources:
+        - url
+        - base64
+      description: Reference image inputs.
+parameters:
+  duration:
+    type: integer
+    optional: true
+    default: 5
+    min: 5
+    max: 10
+    description: Video duration in seconds.
+  aspect_ratio:
+    type: string
+    optional: true
+    default: "16:9"
+    enum: ["16:9", "9:16", "1:1"]
+    description: Output aspect ratio.
+  size:
+    type: string
+    optional: true
+    default: 1280x720
+    enum: [1280x720, 720x1280, 1024x1024]
+    description: OpenAI-compatible video size used to derive Kling aspect ratio.
+  mode:
+    type: string
+    optional: true
+    default: std
+    enum: [std, pro]
+    description: Kling generation mode.
+  cfg_scale:
+    type: number
+    optional: true
+    default: 0.5
+    min: 0
+    max: 1
+    description: Prompt adherence scale.
+  negative_prompt:
+    type: string
+    optional: true
+    description: Negative prompt.
+  seed:
+    type: integer
+    optional: true
+    description: Random seed for reproducibility.
+  poll_interval:
+    type: integer
+    optional: true
+    default: 5
+    min: 1
+    max: 30
+    description: Seconds between task status checks.
+  max_wait:
+    type: integer
+    optional: true
+    default: 900
+    min: 30
+    max: 1800
+    description: Maximum seconds to wait for task completion.
+examples:
+  - title: Multi-image reference to video
+    request:
+      model: kling-multi-image-to-video
+      content:
+        - type: text
+          text: combine the references into one cinematic shot
+        - type: image
+          source:
+            type: url
+            url: https://example.com/reference-1.png
+        - type: image
+          source:
+            type: url
+            url: https://example.com/reference-2.png
+      parameters:
+        duration: 5
+        aspect_ratio: "16:9"

--- a/docs/examples/generations/kling-omni-video.yaml
+++ b/docs/examples/generations/kling-omni-video.yaml
@@ -1,0 +1,106 @@
+schema: neta.generation.model.v1
+model: kling-omni-video
+title: Kling Omni Video
+description: Kling Omni-Video generation through Neta Router. Uses the latest upstream model_name kling-v3-omni.
+adapter:
+  type: kling.videoGenerations
+content:
+  input:
+    - type: text
+      required: false
+      max: 16
+      merge: newline
+      description: Video prompt. Use Kling Omni placeholders such as <<<image_1>>> when passing image_list in meta.
+    - type: image
+      required: false
+      max: 2
+      sources:
+        - url
+        - base64
+      description: Optional simple image input. Official Omni image_list payloads belong in request meta.
+parameters:
+  duration:
+    type: integer
+    optional: true
+    default: 5
+    min: 5
+    max: 15
+    description: Video duration in seconds.
+  aspect_ratio:
+    type: string
+    optional: true
+    default: "16:9"
+    enum: ["16:9", "9:16", "1:1"]
+    description: Output aspect ratio.
+  size:
+    type: string
+    optional: true
+    default: 1280x720
+    enum: [1280x720, 720x1280, 1024x1024]
+    description: OpenAI-compatible video size used to derive Kling aspect ratio.
+  mode:
+    type: string
+    optional: true
+    default: std
+    enum: [std, pro]
+    description: Kling generation mode.
+  cfg_scale:
+    type: number
+    optional: true
+    default: 0.5
+    min: 0
+    max: 1
+    description: Prompt adherence scale.
+  sound:
+    type: string
+    optional: true
+    enum: [on, off]
+    description: Enable or disable generated sound when supported.
+  poll_interval:
+    type: integer
+    optional: true
+    default: 5
+    min: 1
+    max: 30
+    description: Seconds between task status checks.
+  max_wait:
+    type: integer
+    optional: true
+    default: 900
+    min: 30
+    max: 1800
+    description: Maximum seconds to wait for task completion.
+meta:
+  fields:
+    multi_shot:
+      type: boolean
+      optional: true
+      description: Enable Kling multi-shot mode.
+    shot_type:
+      type: string
+      optional: true
+      description: Kling shot type.
+examples:
+  - title: Text to video
+    request:
+      model: kling-omni-video
+      content:
+        - type: text
+          text: a small paper boat floating on calm water, cinematic motion
+      parameters:
+        duration: 5
+        aspect_ratio: "16:9"
+        mode: std
+  - title: Omni image to video
+    request:
+      model: kling-omni-video
+      content:
+        - type: text
+          text: <<<image_1>>> gently turns toward the camera with soft natural motion
+      parameters:
+        duration: 5
+        aspect_ratio: "16:9"
+      meta:
+        image_list:
+          - image_url: https://example.com/input.png
+            type: first_frame

--- a/docs/examples/generations/kling-text-to-video.yaml
+++ b/docs/examples/generations/kling-text-to-video.yaml
@@ -1,0 +1,79 @@
+schema: neta.generation.model.v1
+model: kling-text-to-video
+title: Kling Text To Video
+description: Kling text-to-video generation through Neta Router. Uses the latest upstream model_name kling-v3.
+adapter:
+  type: kling.videoGenerations
+content:
+  input:
+    - type: text
+      required: true
+      max: 16
+      merge: newline
+      description: Video prompt.
+parameters:
+  duration:
+    type: integer
+    optional: true
+    default: 5
+    min: 5
+    max: 10
+    description: Video duration in seconds.
+  aspect_ratio:
+    type: string
+    optional: true
+    default: "16:9"
+    enum: ["16:9", "9:16", "1:1"]
+    description: Output aspect ratio.
+  size:
+    type: string
+    optional: true
+    default: 1280x720
+    enum: [1280x720, 720x1280, 1024x1024]
+    description: OpenAI-compatible video size used to derive Kling aspect ratio.
+  mode:
+    type: string
+    optional: true
+    default: std
+    enum: [std, pro]
+    description: Kling generation mode.
+  cfg_scale:
+    type: number
+    optional: true
+    default: 0.5
+    min: 0
+    max: 1
+    description: Prompt adherence scale.
+  negative_prompt:
+    type: string
+    optional: true
+    description: Negative prompt.
+  seed:
+    type: integer
+    optional: true
+    description: Random seed for reproducibility.
+  poll_interval:
+    type: integer
+    optional: true
+    default: 5
+    min: 1
+    max: 30
+    description: Seconds between task status checks.
+  max_wait:
+    type: integer
+    optional: true
+    default: 900
+    min: 30
+    max: 1800
+    description: Maximum seconds to wait for task completion.
+examples:
+  - title: Text to video
+    request:
+      model: kling-text-to-video
+      content:
+        - type: text
+          text: a small paper boat floating on calm water, cinematic motion
+      parameters:
+        duration: 5
+        aspect_ratio: "16:9"
+        mode: std

--- a/docs/generations.md
+++ b/docs/generations.md
@@ -86,9 +86,15 @@ See the full examples:
 
 - [`docs/examples/generations/gpt-image-2.yaml`](./examples/generations/gpt-image-2.yaml)
 - [`docs/examples/generations/gemini-3.1-flash-image-preview.yaml`](./examples/generations/gemini-3.1-flash-image-preview.yaml)
+- [`docs/examples/generations/kling-text-to-video.yaml`](./examples/generations/kling-text-to-video.yaml)
+- [`docs/examples/generations/kling-image-to-video.yaml`](./examples/generations/kling-image-to-video.yaml)
+- [`docs/examples/generations/kling-omni-video.yaml`](./examples/generations/kling-omni-video.yaml)
+- [`docs/examples/generations/kling-multi-image-to-video.yaml`](./examples/generations/kling-multi-image-to-video.yaml)
 - [`docs/examples/generations/seedance-2-0-fast.yaml`](./examples/generations/seedance-2-0-fast.yaml)
 - [`docs/examples/generations/seedance-2-0.yaml`](./examples/generations/seedance-2-0.yaml)
 - [`docs/examples/generations/suno_music.yaml`](./examples/generations/suno_music.yaml)
+
+Kling declarations use the `kling.videoGenerations` worker adapter and call Neta Router's Kling-compatible video endpoints. Install the desired Kling YAML files into `platform/.cohub/generations` to enable them for all users. Only the latest upstream model for each supported Kling capability is exposed. `kling-v1-5` is intentionally not included. For Kling Omni and multi-image models, provider-native fields such as `image_list`, `element_list`, `video_list`, and `multi_prompt` belong in request `meta` and are passed through unchanged.
 
 ## CLI
 
@@ -115,6 +121,27 @@ cohub generate "a cat playing piano in a cozy jazz club" \
   --model seedance-2-0-fast \
   --param duration=5 \
   --param resolution=720p
+
+cohub generate "a small paper boat floating on calm water, cinematic motion" \
+  --model kling-text-to-video \
+  --param duration=5 \
+  --param aspect_ratio=16:9
+
+cohub generate "gently turn toward the camera with soft natural motion" \
+  --model kling-image-to-video \
+  --image ./input.png \
+  --param duration=5
+
+cohub generate "<<<image_1>>> gently turns toward the camera with soft natural motion" \
+  --model kling-omni-video \
+  --meta '{"image_list":[{"image_url":"https://example.com/input.png","type":"first_frame"}]}' \
+  --param duration=5
+
+cohub generate "combine these references into one cinematic shot" \
+  --model kling-multi-image-to-video \
+  --image ./reference-1.png \
+  --image ./reference-2.png \
+  --param duration=5
 
 cohub generate "uplifting cinematic pop with warm piano and clear chorus" \
   --model suno_music \

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -8,7 +8,13 @@
       "@cohub/db": ["../db/dist/index.d.ts"],
       "@cohub/db/schema": ["../db/dist/index.d.ts"],
       "@cohub/db/schema-v2": ["../db/dist/schema-v2.d.ts"],
+      "@cohub/protocol": ["../protocol/dist/index.d.ts"],
       "@cohub/protocol/core": ["../protocol/dist/core/index.d.ts"],
+      "@cohub/protocol/fs": ["../protocol/dist/fs/index.d.ts"],
+      "@cohub/protocol/generation": ["../protocol/dist/generation/index.d.ts"],
+      "@cohub/protocol/model": ["../protocol/dist/model/session.d.ts"],
+      "@cohub/protocol/sandbox": ["../protocol/dist/sandbox/index.d.ts"],
+      "@cohub/protocol/task": ["../protocol/dist/task/index.d.ts"],
       "@cohub/sandbox-controller": ["../sandbox-controller/dist/index.d.ts"]
     },
     "declaration": true,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -8,8 +8,13 @@
       "@cohub/db": ["../db/src/index.ts"],
       "@cohub/db/schema": ["../db/src/index.ts"],
       "@cohub/db/schema-v2": ["../db/src/schema-v2.ts"],
+      "@cohub/protocol": ["../protocol/src/index.ts"],
       "@cohub/protocol/core": ["../protocol/src/core/index.ts"],
+      "@cohub/protocol/fs": ["../protocol/src/fs/index.ts"],
       "@cohub/protocol/generation": ["../protocol/src/generation/index.ts"],
+      "@cohub/protocol/model": ["../protocol/src/model/session.ts"],
+      "@cohub/protocol/sandbox": ["../protocol/src/sandbox/index.ts"],
+      "@cohub/protocol/task": ["../protocol/src/task/index.ts"],
       "@cohub/sandbox-controller": ["../sandbox-controller/src/index.ts"]
     }
   },

--- a/packages/infra/tsconfig.build.json
+++ b/packages/infra/tsconfig.build.json
@@ -4,7 +4,10 @@
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,
-    "declarationMap": false
+    "declarationMap": false,
+    "paths": {
+      "@cohub/protocol/generation": ["../protocol/dist/generation/index.d.ts"]
+    }
   },
   "include": [
     "src"

--- a/packages/infra/tsconfig.json
+++ b/packages/infra/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
-    "rootDir": "./src"
+    "rootDir": "../..",
+    "paths": {
+      "@cohub/protocol/generation": ["../protocol/src/generation/index.ts"]
+    }
   },
   "include": ["src"]
 }

--- a/packages/protocol/tsconfig.json
+++ b/packages/protocol/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "paths": {
+      "@cohub/protocol/gateway": ["./src/gateway/index.ts"]
+    }
   },
   "include": ["src"]
 }

--- a/packages/sandbox-controller/tsconfig.build.json
+++ b/packages/sandbox-controller/tsconfig.build.json
@@ -10,6 +10,9 @@
     "sourceMap": true,
     "paths": {
       "@cohub/db": ["../db/dist/index.d.ts"],
+      "@cohub/protocol/core": ["../protocol/dist/core/index.d.ts"],
+      "@cohub/protocol/model": ["../protocol/dist/model/session.d.ts"],
+      "@cohub/protocol/task": ["../protocol/dist/task/index.d.ts"],
       "@cohub/protocol/sandbox": ["../protocol/dist/sandbox/index.d.ts"]
     }
   },

--- a/packages/sandbox-controller/tsconfig.json
+++ b/packages/sandbox-controller/tsconfig.json
@@ -6,6 +6,9 @@
     "types": ["node"],
     "paths": {
       "@cohub/db": ["../db/src/index.ts"],
+      "@cohub/protocol/core": ["../protocol/src/core/index.ts"],
+      "@cohub/protocol/model": ["../protocol/src/model/session.ts"],
+      "@cohub/protocol/task": ["../protocol/src/task/index.ts"],
       "@cohub/protocol/sandbox": ["../protocol/src/sandbox/index.ts"]
     }
   },


### PR DESCRIPTION
## Summary
- add a `kling.videoGenerations` worker adapter for Neta Router Kling-compatible video endpoints
- expose only four Kling capability declarations: `kling-text-to-video`, `kling-image-to-video`, `kling-omni-video`, and `kling-multi-image-to-video`
- map those declarations to the latest upstream `model_name` values: `kling-v3`, `kling-v3`, `kling-v3-omni`, and `kling-v1-6` for multi-image
- wire the adapter into worker generation tasks and fix existing tsconfig path aliases needed by full typecheck

## Notes
- `kling-v1-5` is intentionally not included.
- Cohub model ids are stable capability entries, not version-number entries.
- Provider-native Omni and multi-image fields such as `image_list`, `element_list`, `video_list`, and `multi_prompt` are passed through as request `meta`.

## Validation
- `git diff --check`
- `pnpm exec tsx apps/worker/tests/kling-video-adapter.test.ts`
- Kling declaration parse smoke: `kling-image-to-video`, `kling-multi-image-to-video`, `kling-omni-video`, `kling-text-to-video`
- `pnpm --filter @cohub/worker typecheck`
- `pnpm --filter @cohub/worker lint`
- `pnpm -r typecheck`