### PR TITLE
Optimize web chunk splitting for markdown and editors

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,8 @@
 		"@lezer/highlight": "^1.2.3",
 		"@logto/browser": "^3.0.13",
 		"@neta-art/cohub": "workspace:*",
+		"@shikijs/langs": "^4.2.0",
+		"@shikijs/themes": "^4.2.0",
 		"codemirror": "^6.0.2",
 		"isomorphic-dompurify": "3.15.0",
 		"lucide-svelte": "^1.0.1",
@@ -50,7 +52,7 @@
 		"@biomejs/biome": "2.4.16",
 		"@sveltejs/adapter-cloudflare": "7.2.8",
 		"@sveltejs/kit": "^2.61.1",
-		"@sveltejs/vite-plugin-svelte": "^7.1.2",
+		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.3.0",
 		"@types/node": "25.9.1",
@@ -60,7 +62,7 @@
 		"tailwindcss": "^4.3.0",
 		"tw-animate-css": "^1.4.0",
 		"typescript": "^6.0.3",
-		"vite": "^8.0.14",
+		"vite": "^7.3.3",
 		"vite-plugin-pwa": "^1.3.0",
 		"wrangler": "4.95.0"
 	}

--- a/apps/web/src/lib/components/CodeEditor.svelte
+++ b/apps/web/src/lib/components/CodeEditor.svelte
@@ -6,14 +6,6 @@ import {
 	historyKeymap,
 	indentWithTab,
 } from "@codemirror/commands";
-import { css } from "@codemirror/lang-css";
-import { html } from "@codemirror/lang-html";
-import { javascript } from "@codemirror/lang-javascript";
-import { json } from "@codemirror/lang-json";
-import { markdown } from "@codemirror/lang-markdown";
-import { python } from "@codemirror/lang-python";
-import { xml } from "@codemirror/lang-xml";
-import { yaml } from "@codemirror/lang-yaml";
 import {
 	bracketMatching,
 	foldGutter,
@@ -63,33 +55,69 @@ let view: EditorView | undefined = $state();
 const langConf = new Compartment();
 const themeConf = new Compartment();
 const readOnlyConf = new Compartment();
+let languageLoadId = 0;
 
-function getLanguageExtension(lang: string) {
+async function getLanguageExtension(lang: string): Promise<Extension> {
 	const l = lang.toLowerCase();
-	const map: Record<string, () => import("@codemirror/state").Extension> = {
-		js: () => javascript({ typescript: false, jsx: false }),
-		javascript: () => javascript({ typescript: false, jsx: false }),
-		ts: () => javascript({ typescript: true, jsx: false }),
-		typescript: () => javascript({ typescript: true, jsx: false }),
-		jsx: () => javascript({ typescript: false, jsx: true }),
-		tsx: () => javascript({ typescript: true, jsx: true }),
-		py: () => python(),
-		python: () => python(),
-		json: () => json(),
-		jsonc: () => json(),
-		html: () => html(),
-		htm: () => html(),
-		svelte: () => html(),
-		css: () => css(),
-		scss: () => css(),
-		md: () => markdown(),
-		markdown: () => markdown(),
-		yaml: () => yaml(),
-		yml: () => yaml(),
-		xml: () => xml(),
-		svg: () => xml(),
+	const map: Record<string, () => Promise<Extension>> = {
+		js: async () =>
+			(await import("@codemirror/lang-javascript")).javascript({
+				typescript: false,
+				jsx: false,
+			}),
+		javascript: async () =>
+			(await import("@codemirror/lang-javascript")).javascript({
+				typescript: false,
+				jsx: false,
+			}),
+		ts: async () =>
+			(await import("@codemirror/lang-javascript")).javascript({
+				typescript: true,
+				jsx: false,
+			}),
+		typescript: async () =>
+			(await import("@codemirror/lang-javascript")).javascript({
+				typescript: true,
+				jsx: false,
+			}),
+		jsx: async () =>
+			(await import("@codemirror/lang-javascript")).javascript({
+				typescript: false,
+				jsx: true,
+			}),
+		tsx: async () =>
+			(await import("@codemirror/lang-javascript")).javascript({
+				typescript: true,
+				jsx: true,
+			}),
+		py: async () => (await import("@codemirror/lang-python")).python(),
+		python: async () => (await import("@codemirror/lang-python")).python(),
+		json: async () => (await import("@codemirror/lang-json")).json(),
+		jsonc: async () => (await import("@codemirror/lang-json")).json(),
+		html: async () => (await import("@codemirror/lang-html")).html(),
+		htm: async () => (await import("@codemirror/lang-html")).html(),
+		svelte: async () => (await import("@codemirror/lang-html")).html(),
+		css: async () => (await import("@codemirror/lang-css")).css(),
+		scss: async () => (await import("@codemirror/lang-css")).css(),
+		md: async () => (await import("@codemirror/lang-markdown")).markdown(),
+		markdown: async () =>
+			(await import("@codemirror/lang-markdown")).markdown(),
+		yaml: async () => (await import("@codemirror/lang-yaml")).yaml(),
+		yml: async () => (await import("@codemirror/lang-yaml")).yaml(),
+		xml: async () => (await import("@codemirror/lang-xml")).xml(),
+		svg: async () => (await import("@codemirror/lang-xml")).xml(),
 	};
-	return map[l]?.() ?? [];
+	return (await map[l]?.()) ?? [];
+}
+
+async function reconfigureLanguage(lang: string) {
+	if (!view) return;
+	const loadId = ++languageLoadId;
+	const extension = await getLanguageExtension(lang);
+	if (!view || loadId !== languageLoadId) return;
+	view.dispatch({
+		effects: langConf.reconfigure(extension),
+	});
 }
 
 function isMobile(): boolean {
@@ -284,9 +312,7 @@ let currentTheme = $state(resolveTheme());
 
 $effect(() => {
 	if (!view) return;
-	view.dispatch({
-		effects: langConf.reconfigure(getLanguageExtension(currentLanguage)),
-	});
+	void reconfigureLanguage(currentLanguage);
 });
 
 $effect(() => {
@@ -356,7 +382,7 @@ onMount(() => {
 					...foldKeymap,
 					indentWithTab,
 				]),
-				langConf.of(getLanguageExtension(language)),
+				langConf.of([]),
 				themeConf.of(getThemeExtension(theme)),
 				readOnlyConf.of([
 					EditorView.editable.of(!readonly),
@@ -374,6 +400,7 @@ onMount(() => {
 		}),
 		parent: container,
 	});
+	void reconfigureLanguage(language);
 
 	const themeObserver = new MutationObserver(() => reconfigureTheme());
 	themeObserver.observe(document.documentElement, {

--- a/apps/web/src/lib/components/MarkdownView.svelte
+++ b/apps/web/src/lib/components/MarkdownView.svelte
@@ -3,7 +3,6 @@ import type { ContentBlock } from "@cohub/protocol/core";
 import { onDestroy, untrack } from "svelte";
 import MarkdownFrontmatter from "$lib/components/MarkdownFrontmatter.svelte";
 import MarkdownSurface from "$lib/components/MarkdownSurface.svelte";
-import { renderMarkdown } from "$lib/markdown";
 import { parseMarkdownFrontmatter } from "$lib/markdown-frontmatter";
 import { StreamingMarkdownController } from "$lib/streaming-markdown-controller";
 
@@ -66,7 +65,8 @@ function destroyController() {
 function renderFullMarkdown(markdownSource: string) {
 	const seq = ++renderSeq;
 	untrack(() => onStart?.());
-	void renderMarkdown(markdownSource)
+	void import("$lib/markdown")
+		.then(({ renderMarkdown }) => renderMarkdown(markdownSource))
 		.then((html) => {
 			if (seq !== renderSeq) return;
 			renderedHtml = html;

--- a/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
+++ b/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
@@ -95,15 +95,12 @@ import { ensureCovasExtension, isCovasFile } from "$lib/canvas/canvas-file";
 import type { CovasDocument } from "$lib/canvas/canvas-schema";
 import { pollCheckpointJob } from "$lib/checkpoints";
 import ChatTimeline from "$lib/components/ChatTimeline.svelte";
-import CodeEditor from "$lib/components/CodeEditor.svelte";
-import CanvasPanel from "$lib/components/canvas/CanvasPanel.svelte";
 import Dialog from "$lib/components/Dialog.svelte";
 import FileUploadPane from "$lib/components/FileUploadPane.svelte";
 import MobileRightDrawer from "$lib/components/MobileRightDrawer.svelte";
 import ModelSelector from "$lib/components/ModelSelector.svelte";
 import PageHeader from "$lib/components/PageHeader.svelte";
 import PortPreview from "$lib/components/PortPreview.svelte";
-import RenderedFilePreview from "$lib/components/RenderedFilePreview.svelte";
 import ResourceLabelPicker from "$lib/components/ResourceLabelPicker.svelte";
 import SessionComposer from "$lib/components/SessionComposer.svelte";
 import SessionTaskTray, {
@@ -8329,24 +8326,39 @@ $effect(() => {
             </div>
             <div class="flex-1 min-h-0">
               {#if fileEdit}
-                <CodeEditor
-                  value={openFileDraft}
-                  language={openFileExt}
-                  onInput={(v) => openFileDraft = v}
-                  readonly={!canEditFiles}
-                />
+                {#await import("$lib/components/CodeEditor.svelte") then editorModule}
+                  {@const LazyCodeEditor = editorModule.default}
+                  <LazyCodeEditor
+                    value={openFileDraft}
+                    language={openFileExt}
+                    onInput={(v) => openFileDraft = v}
+                    readonly={!canEditFiles}
+                  />
+                {:catch}
+                  <div class="flex h-full items-center justify-center text-[12px] text-error-soft">Editor failed to load.</div>
+                {/await}
               {:else if openFileHasRenderedPreview}
-                <RenderedFilePreview
-                  name={openFile.name}
-                  source={openFileDraft}
-                  type={openFileIsMarkdown ? "markdown" : "html"}
-                />
+                {#await import("$lib/components/RenderedFilePreview.svelte") then previewModule}
+                  {@const LazyRenderedFilePreview = previewModule.default}
+                  <LazyRenderedFilePreview
+                    name={openFile.name}
+                    source={openFileDraft}
+                    type={openFileIsMarkdown ? "markdown" : "html"}
+                  />
+                {:catch}
+                  <div class="flex h-full items-center justify-center text-[12px] text-error-soft">Preview failed to load.</div>
+                {/await}
               {:else}
-                <CodeEditor
-                  value={openFileDraft}
-                  language={openFileExt}
-                  readonly={true}
-                />
+                {#await import("$lib/components/CodeEditor.svelte") then editorModule}
+                  {@const LazyCodeEditor = editorModule.default}
+                  <LazyCodeEditor
+                    value={openFileDraft}
+                    language={openFileExt}
+                    readonly={true}
+                  />
+                {:catch}
+                  <div class="flex h-full items-center justify-center text-[12px] text-error-soft">Editor failed to load.</div>
+                {/await}
               {/if}
             </div>
           {:else if openFileIsImage && openFileDataUrl}
@@ -9062,15 +9074,30 @@ $effect(() => {
           </div>
           <div class="flex-1 min-h-0">
             {#if inlineFileEdit}
-              <CodeEditor value={inlineFile.draft} language={inlineFileExt} onInput={(v) => { if (inlineFile) inlineFile.draft = v; }} readonly={!canEditFiles || activeFsReadonly} />
+              {#await import("$lib/components/CodeEditor.svelte") then editorModule}
+                {@const LazyCodeEditor = editorModule.default}
+                <LazyCodeEditor value={inlineFile.draft} language={inlineFileExt} onInput={(v) => { if (inlineFile) inlineFile.draft = v; }} readonly={!canEditFiles || activeFsReadonly} />
+              {:catch}
+                <div class="flex h-full items-center justify-center text-[12px] text-error-soft">Editor failed to load.</div>
+              {/await}
             {:else if inlineFileHasRenderedPreview}
-              <RenderedFilePreview
-                name={inlineFile.response.name}
-                source={inlineFile.draft}
-                type={inlineFileIsMarkdown ? "markdown" : "html"}
-              />
+              {#await import("$lib/components/RenderedFilePreview.svelte") then previewModule}
+                {@const LazyRenderedFilePreview = previewModule.default}
+                <LazyRenderedFilePreview
+                  name={inlineFile.response.name}
+                  source={inlineFile.draft}
+                  type={inlineFileIsMarkdown ? "markdown" : "html"}
+                />
+              {:catch}
+                <div class="flex h-full items-center justify-center text-[12px] text-error-soft">Preview failed to load.</div>
+              {/await}
             {:else}
-              <CodeEditor value={inlineFile.draft} language={inlineFileExt} readonly={true} />
+              {#await import("$lib/components/CodeEditor.svelte") then editorModule}
+                {@const LazyCodeEditor = editorModule.default}
+                <LazyCodeEditor value={inlineFile.draft} language={inlineFileExt} readonly={true} />
+              {:catch}
+                <div class="flex h-full items-center justify-center text-[12px] text-error-soft">Editor failed to load.</div>
+              {/await}
             {/if}
           </div>
         {:else if inlineFileIsImage && inlineFileDataUrl}
@@ -9223,24 +9250,39 @@ $effect(() => {
             </div>
             <div class="flex-1 min-h-0">
               {#if inlineFileEdit}
-                <CodeEditor
-                  value={inlineFile.draft}
-                  language={inlineFileExt}
-                  onInput={(v) => { if (inlineFile) inlineFile.draft = v; }}
-                  readonly={!canEditFiles}
-                />
+                {#await import("$lib/components/CodeEditor.svelte") then editorModule}
+                  {@const LazyCodeEditor = editorModule.default}
+                  <LazyCodeEditor
+                    value={inlineFile.draft}
+                    language={inlineFileExt}
+                    onInput={(v) => { if (inlineFile) inlineFile.draft = v; }}
+                    readonly={!canEditFiles}
+                  />
+                {:catch}
+                  <div class="flex h-full items-center justify-center text-[12px] text-error-soft">Editor failed to load.</div>
+                {/await}
               {:else if inlineFileHasRenderedPreview}
-                <RenderedFilePreview
-                  name={inlineFile.response.name}
-                  source={inlineFile.draft}
-                  type={inlineFileIsMarkdown ? "markdown" : "html"}
-                />
+                {#await import("$lib/components/RenderedFilePreview.svelte") then previewModule}
+                  {@const LazyRenderedFilePreview = previewModule.default}
+                  <LazyRenderedFilePreview
+                    name={inlineFile.response.name}
+                    source={inlineFile.draft}
+                    type={inlineFileIsMarkdown ? "markdown" : "html"}
+                  />
+                {:catch}
+                  <div class="flex h-full items-center justify-center text-[12px] text-error-soft">Preview failed to load.</div>
+                {/await}
               {:else}
-                <CodeEditor
-                  value={inlineFile.draft}
-                  language={inlineFileExt}
-                  readonly={true}
-                />
+                {#await import("$lib/components/CodeEditor.svelte") then editorModule}
+                  {@const LazyCodeEditor = editorModule.default}
+                  <LazyCodeEditor
+                    value={inlineFile.draft}
+                    language={inlineFileExt}
+                    readonly={true}
+                  />
+                {:catch}
+                  <div class="flex h-full items-center justify-center text-[12px] text-error-soft">Editor failed to load.</div>
+                {/await}
               {/if}
             </div>
           {:else if inlineFileIsImage && inlineFileDataUrl}
@@ -9362,15 +9404,26 @@ $effect(() => {
           <div class="m-4 rounded-lg border border-error-soft/30 bg-error-bg p-4 text-sm text-error-soft">{inlineCanvas.error}</div>
         </div>
       {:else if inlineCanvas.document}
-        <CanvasPanel
-          path={inlineCanvas.path}
-          document={inlineCanvas.document}
-          saving={inlineCanvas.saving}
-          focused={previewFocusMode}
-          onToggleFocus={isMobile ? undefined : togglePreviewFocusMode}
-          onCommit={(document, ops) => commitInlineCanvas(document, ops)}
-          onClose={closeInlineCanvas}
-        />
+        {#await import("$lib/components/canvas/CanvasPanel.svelte") then canvasPanelModule}
+          {@const LazyCanvasPanel = canvasPanelModule.default}
+          <LazyCanvasPanel
+            path={inlineCanvas.path}
+            document={inlineCanvas.document}
+            saving={inlineCanvas.saving}
+            focused={previewFocusMode}
+            onToggleFocus={isMobile ? undefined : togglePreviewFocusMode}
+            onCommit={(document, ops) => commitInlineCanvas(document, ops)}
+            onClose={closeInlineCanvas}
+          />
+        {:catch}
+          <div class="flex h-full min-w-0 flex-col bg-bg-content">
+            <div class="flex h-10 items-center gap-2 border-b border-border-subtle px-3">
+              <span class="min-w-0 flex-1 truncate text-xs text-text-secondary">{inlineCanvas.path}</span>
+              <button type="button" class="icon-btn" onclick={closeInlineCanvas} title="Close canvas"><X class="w-4 h-4" /></button>
+            </div>
+            <div class="m-4 rounded-lg border border-error-soft/30 bg-error-bg p-4 text-sm text-error-soft">Canvas failed to load.</div>
+          </div>
+        {/await}
       {:else}
         <div class="flex h-full min-w-0 flex-col bg-bg-content">
           <div class="flex h-10 items-center gap-2 border-b border-border-subtle px-3">

--- a/apps/web/src/lib/markdown.ts
+++ b/apps/web/src/lib/markdown.ts
@@ -2,11 +2,11 @@ import DOMPurify from "isomorphic-dompurify";
 import { marked, type Token, type Tokens } from "marked";
 import remend from "remend";
 import {
-	type BundledLanguage,
-	type BundledTheme,
-	createHighlighter,
-	type HighlighterGeneric,
-} from "shiki";
+	createHighlighterCore,
+	type HighlighterCore,
+	type LanguageRegistration,
+} from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
 const MARKDOWN_RENDER_CACHE_LIMIT = 256;
 const markdownRenderCache = new Map<string, Promise<string>>();
@@ -30,51 +30,151 @@ function cacheMarkdownRender(key: string, render: () => Promise<string>) {
 }
 
 // Shiki highlighter — singleton, lazily initialized
-let highlighterPromise: Promise<
-	HighlighterGeneric<BundledLanguage, BundledTheme>
-> | null = null;
+let highlighterPromise: Promise<HighlighterCore> | null = null;
+type ShikiLanguageLoader = () => Promise<{ default: LanguageRegistration[] }>;
+
+const shikiLanguageLoaders = {
+	bash: () => import("@shikijs/langs/bash"),
+	c: () => import("@shikijs/langs/c"),
+	cpp: () => import("@shikijs/langs/cpp"),
+	css: () => import("@shikijs/langs/css"),
+	diff: () => import("@shikijs/langs/diff"),
+	dockerfile: () => import("@shikijs/langs/dockerfile"),
+	go: () => import("@shikijs/langs/go"),
+	graphql: () => import("@shikijs/langs/graphql"),
+	html: () => import("@shikijs/langs/html"),
+	ini: () => import("@shikijs/langs/ini"),
+	java: () => import("@shikijs/langs/java"),
+	javascript: () => import("@shikijs/langs/javascript"),
+	json: () => import("@shikijs/langs/json"),
+	jsx: () => import("@shikijs/langs/jsx"),
+	markdown: () => import("@shikijs/langs/markdown"),
+	mermaid: () => import("@shikijs/langs/mermaid"),
+	protobuf: () => import("@shikijs/langs/protobuf"),
+	python: () => import("@shikijs/langs/python"),
+	rust: () => import("@shikijs/langs/rust"),
+	shellscript: () => import("@shikijs/langs/shellscript"),
+	sql: () => import("@shikijs/langs/sql"),
+	toml: () => import("@shikijs/langs/toml"),
+	tsx: () => import("@shikijs/langs/tsx"),
+	typescript: () => import("@shikijs/langs/typescript"),
+	xml: () => import("@shikijs/langs/xml"),
+	yaml: () => import("@shikijs/langs/yaml"),
+} satisfies Record<string, ShikiLanguageLoader>;
+
+type SupportedShikiLanguage = keyof typeof shikiLanguageLoaders;
+
+const shikiLanguageAliases = new Map<string, SupportedShikiLanguage>([
+	["bash", "bash"],
+	["c++", "cpp"],
+	["cpp", "cpp"],
+	["cxx", "cpp"],
+	["c", "c"],
+	["css", "css"],
+	["diff", "diff"],
+	["docker", "dockerfile"],
+	["dockerfile", "dockerfile"],
+	["go", "go"],
+	["golang", "go"],
+	["graphql", "graphql"],
+	["gql", "graphql"],
+	["html", "html"],
+	["ini", "ini"],
+	["java", "java"],
+	["javascript", "javascript"],
+	["js", "javascript"],
+	["json", "json"],
+	["jsx", "jsx"],
+	["markdown", "markdown"],
+	["md", "markdown"],
+	["mdx", "markdown"],
+	["mermaid", "mermaid"],
+	["proto", "protobuf"],
+	["protobuf", "protobuf"],
+	["py", "python"],
+	["python", "python"],
+	["rs", "rust"],
+	["rust", "rust"],
+	["sh", "shellscript"],
+	["shell", "shellscript"],
+	["shellscript", "shellscript"],
+	["sql", "sql"],
+	["toml", "toml"],
+	["tsx", "tsx"],
+	["ts", "typescript"],
+	["typescript", "typescript"],
+	["xml", "xml"],
+	["yaml", "yaml"],
+	["yml", "yaml"],
+]);
+
+const loadedShikiLanguages = new Set<SupportedShikiLanguage>();
+
+function normalizeShikiLanguage(rawLang: string) {
+	return shikiLanguageAliases.get(rawLang.toLowerCase()) ?? null;
+}
+
+function collectCodeTokenLanguages(
+	tokens: Token[],
+	languages = new Set<SupportedShikiLanguage>(),
+) {
+	for (const token of tokens) {
+		if (token.type === "code" && "lang" in token && token.lang) {
+			const rawLang = token.lang.split(" ")[0];
+			if (rawLang) {
+				const lang = normalizeShikiLanguage(rawLang);
+				if (lang) languages.add(lang);
+			}
+		}
+
+		if ("tokens" in token && Array.isArray(token.tokens)) {
+			collectCodeTokenLanguages(token.tokens, languages);
+		}
+	}
+
+	return languages;
+}
+
+async function createMarkdownHighlighter() {
+	return createHighlighterCore({
+		engine: createJavaScriptRegexEngine(),
+		themes: [
+			import("@shikijs/themes/github-light"),
+			import("@shikijs/themes/github-dark"),
+			import("@shikijs/themes/solarized-light"),
+			import("@shikijs/themes/solarized-dark"),
+		],
+		langs: [],
+	});
+}
 
 function getHighlighter() {
 	if (!highlighterPromise) {
-		highlighterPromise = createHighlighter({
-			themes: [
-				"github-light",
-				"github-dark",
-				"solarized-light",
-				"solarized-dark",
-			],
-			langs: [
-				"typescript",
-				"javascript",
-				"python",
-				"bash",
-				"shell",
-				"json",
-				"yaml",
-				"yml",
-				"html",
-				"css",
-				"sql",
-				"rust",
-				"go",
-				"java",
-				"c",
-				"cpp",
-				"tsx",
-				"jsx",
-				"toml",
-				"ini",
-				"diff",
-				"markdown",
-				"dockerfile",
-				"mermaid",
-				"xml",
-				"graphql",
-				"protobuf",
-			],
-		});
+		highlighterPromise = createMarkdownHighlighter();
 	}
 	return highlighterPromise;
+}
+
+async function loadShikiLanguages(
+	highlighter: HighlighterCore,
+	languages: Set<SupportedShikiLanguage>,
+) {
+	const pending = [...languages].filter(
+		(lang) => !loadedShikiLanguages.has(lang),
+	);
+	if (pending.length === 0) return;
+
+	const modules = await Promise.all(
+		pending.map(async (lang) => ({
+			lang,
+			registration: (await shikiLanguageLoaders[lang]()).default,
+		})),
+	);
+
+	await highlighter.loadLanguage(
+		...modules.map(({ registration }) => registration),
+	);
+	for (const { lang } of modules) loadedShikiLanguages.add(lang);
 }
 
 /**
@@ -86,21 +186,18 @@ function getHighlighter() {
  */
 async function highlightCodeTokens(tokens: Token[]) {
 	const highlighter = await getHighlighter();
+	await loadShikiLanguages(highlighter, collectCodeTokenLanguages(tokens));
 
 	for (let i = 0; i < tokens.length; i++) {
 		const token = tokens[i];
 		if (token.type === "code" && "lang" in token && token.lang) {
 			const rawLang = token.lang.split(" ")[0]; // handle e.g. "ts {1-3}"
-			const lang = rawLang.toLowerCase();
+			const lang = rawLang ? normalizeShikiLanguage(rawLang) : null;
+			if (!lang) continue;
 
 			try {
-				const supportedLangs = highlighter.getLoadedLanguages();
-				const useLang = supportedLangs.includes(lang as BundledLanguage)
-					? lang
-					: "plaintext";
-
 				const highlighted = highlighter.codeToHtml(token.text, {
-					lang: useLang as BundledLanguage,
+					lang,
 					themes: {
 						light: "github-light",
 						dark: "github-dark",

--- a/apps/web/src/lib/streaming-markdown-controller.ts
+++ b/apps/web/src/lib/streaming-markdown-controller.ts
@@ -1,5 +1,3 @@
-import { renderStreamingMarkdownBlocks } from "$lib/markdown";
-
 type StreamingMarkdownSnapshot = {
 	html: string;
 	source: string;
@@ -164,6 +162,7 @@ export class StreamingMarkdownController {
 		}
 
 		try {
+			const { renderStreamingMarkdownBlocks } = await import("$lib/markdown");
 			const html = await renderStreamingMarkdownBlocks(source);
 			if (
 				this.#disposed ||

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -15,6 +15,9 @@ const config = {
 	},
 	kit: {
 		adapter: adapter(),
+		output: {
+			bundleStrategy: "split",
+		},
 		alias: {
 			// protocol subpaths — must come before bare package alias to avoid prefix matching
 			"@cohub/protocol/core": `${protocolDir}/core/index.ts`,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,9 +4,26 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 
-interface RolldownChecks {
-	eval?: boolean;
-	pluginTimings?: boolean;
+const MIN_CHUNK_SIZE = 32 * 1024;
+
+function getShikiPackageChunkName(id: string) {
+	const normalized = id.replaceAll("\\", "/");
+	const languageMatch = normalized.match(
+		/@shikijs\/langs\/dist\/([^/?]+)\.mjs/,
+	);
+	if (languageMatch?.[1]) return `shiki-lang-${languageMatch[1]}`;
+
+	const themeMatch = normalized.match(/@shikijs\/themes\/dist\/([^/?]+)\.mjs/);
+	if (themeMatch?.[1]) return `shiki-theme-${themeMatch[1]}`;
+
+	return null;
+}
+
+function manualChunkName(id: string) {
+	const normalized = id.replaceAll("\\", "/");
+	const shikiChunkName = getShikiPackageChunkName(normalized);
+	if (shikiChunkName) return shikiChunkName;
+	return undefined;
 }
 
 const protocolDir = fileURLToPath(
@@ -103,11 +120,12 @@ export default defineConfig({
 	},
 	build: {
 		chunkSizeWarningLimit: 1200,
-		rolldownOptions: {
-			checks: {
-				eval: false,
-				pluginTimings: false,
-			} satisfies RolldownChecks,
+		rollupOptions: {
+			output: {
+				experimentalMinChunkSize: MIN_CHUNK_SIZE,
+				manualChunks: manualChunkName,
+				onlyExplicitManualChunks: true,
+			},
 		},
 	},
 	plugins: [
@@ -139,8 +157,27 @@ export default defineConfig({
 				],
 			},
 			workbox: {
-				globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
+				globPatterns: [
+					"**/*.{css,html,ico,png,svg,woff2}",
+					"_app/immutable/entry/*.js",
+					"_app/immutable/nodes/*.js",
+					"_app/version.json",
+				],
 				navigateFallback: undefined,
+				runtimeCaching: [
+					{
+						urlPattern: ({ url }) =>
+							url.pathname.startsWith("/_app/immutable/"),
+						handler: "CacheFirst",
+						options: {
+							cacheName: "immutable-assets",
+							expiration: {
+								maxEntries: 240,
+								maxAgeSeconds: 60 * 60 * 24 * 30,
+							},
+						},
+					},
+				],
 			},
 		}),
 	],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,12 @@ importers:
       '@neta-art/cohub':
         specifier: workspace:*
         version: link:../../packages/sdk
+      '@shikijs/langs':
+        specifier: ^4.2.0
+        version: 4.2.0
+      '@shikijs/themes':
+        specifier: ^4.2.0
+        version: 4.2.0
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2
@@ -423,19 +429,19 @@ importers:
         version: 2.4.16
       '@sveltejs/adapter-cloudflare':
         specifier: 7.2.8
-        version: 7.2.8(@sveltejs/kit@2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.55.10)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(wrangler@4.95.0(@cloudflare/workers-types@4.20260529.1))
+        version: 7.2.8(@sveltejs/kit@2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.10)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.55.10)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(wrangler@4.95.0(@cloudflare/workers-types@4.20260529.1))
       '@sveltejs/kit':
         specifier: ^2.61.1
-        version: 2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.55.10)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.10)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.55.10)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^7.1.2
-        version: 7.1.2(svelte@5.55.10)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+        specifier: ^6.2.4
+        version: 6.2.4(svelte@5.55.10)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.3.0)
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.3.0(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       '@types/node':
         specifier: 25.9.1
         version: 25.9.1
@@ -458,11 +464,11 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: ^8.0.14
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
+        specifier: ^7.3.3
+        version: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
       vite-plugin-pwa:
         specifier: ^1.3.0
-        version: 1.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
+        version: 1.3.0(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
       wrangler:
         specifier: 4.95.0
         version: 4.95.0(@cloudflare/workers-types@4.20260529.1)
@@ -2811,9 +2817,6 @@ packages:
     resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
 
-  '@oxc-project/types@0.132.0':
-    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
-
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
@@ -2865,34 +2868,16 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@rolldown/binding-android-arm64@1.0.2':
-    resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.2':
-    resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rolldown/binding-darwin-arm64@1.0.3':
     resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.0.2':
-    resolution: {integrity: sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.3':
@@ -2901,36 +2886,17 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.2':
-    resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
   '@rolldown/binding-freebsd-x64@1.0.3':
     resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
-    resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
     resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.2':
-    resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
@@ -2939,13 +2905,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.2':
-    resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2953,24 +2912,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
-    resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-s390x-gnu@1.0.2':
-    resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -2981,26 +2926,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.2':
-    resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  '@rolldown/binding-linux-x64-musl@1.0.2':
-    resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
@@ -3009,44 +2940,21 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.2':
-    resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.2':
-    resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
   '@rolldown/binding-wasm32-wasi@1.0.3':
     resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.2':
-    resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
     resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [win32]
-
-  '@rolldown/binding-win32-x64-msvc@1.0.2':
-    resolution: {integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [win32]
 
   '@rolldown/binding-win32-x64-msvc@1.0.3':
@@ -3277,6 +3185,10 @@ packages:
     resolution: {integrity: sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==}
     engines: {node: '>=20'}
 
+  '@shikijs/langs@4.2.0':
+    resolution: {integrity: sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==}
+    engines: {node: '>=20'}
+
   '@shikijs/primitive@4.1.0':
     resolution: {integrity: sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==}
     engines: {node: '>=20'}
@@ -3285,8 +3197,16 @@ packages:
     resolution: {integrity: sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==}
     engines: {node: '>=20'}
 
+  '@shikijs/themes@4.2.0':
+    resolution: {integrity: sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==}
+    engines: {node: '>=20'}
+
   '@shikijs/types@4.1.0':
     resolution: {integrity: sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.2.0':
+    resolution: {integrity: sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==}
     engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
@@ -3373,12 +3293,20 @@ packages:
       typescript:
         optional: true
 
-  '@sveltejs/vite-plugin-svelte@7.1.2':
-    resolution: {integrity: sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==}
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2':
+    resolution: {integrity: sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==}
     engines: {node: ^20.19 || ^22.12 || >=24}
     peerDependencies:
-      svelte: ^5.46.4
-      vite: ^8.0.0-beta.7 || ^8.0.0
+      '@sveltejs/vite-plugin-svelte': ^6.0.0-next.0
+      svelte: ^5.0.0
+      vite: ^6.3.0 || ^7.0.0
+
+  '@sveltejs/vite-plugin-svelte@6.2.4':
+    resolution: {integrity: sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==}
+    engines: {node: ^20.19 || ^22.12 || >=24}
+    peerDependencies:
+      svelte: ^5.0.0
+      vite: ^6.3.0 || ^7.0.0
 
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
@@ -3481,6 +3409,7 @@ packages:
 
   '@talesofai-billing/cli@1.5.0':
     resolution: {integrity: sha512-CQ7mpso92vIk6neuBpm2drkMcWCOuxClPjmpn9EvqZPxtfppEFVTOYJ3a+ptPrlt7sAe77uz37wixG1HmGkuVw==, tarball: https://git.talesofai.com/api/packages/talesofai/npm/%40talesofai-billing%2Fcli/-/1.5.0/cli-1.5.0.tgz}
+    engines: {node: '>=20'}
     hasBin: true
 
   '@talesofai-billing/sdk@1.5.0':
@@ -5424,11 +5353,6 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.2:
-    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5980,16 +5904,15 @@ packages:
       '@vite-pwa/assets-generator':
         optional: true
 
-  vite@8.0.14:
-    resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.18
-      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
+      lightningcss: ^1.21.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -6000,13 +5923,11 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-      '@vitejs/devtools':
-        optional: true
-      esbuild:
-        optional: true
       jiti:
         optional: true
       less:
+        optional: true
+      lightningcss:
         optional: true
       sass:
         optional: true
@@ -8511,8 +8432,6 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.41.1': {}
 
-  '@oxc-project/types@0.132.0': {}
-
   '@oxc-project/types@0.133.0': {}
 
   '@pixi/colord@2.9.6': {}
@@ -8557,83 +8476,40 @@ snapshots:
     dependencies:
       quansync: 1.0.0
 
-  '@rolldown/binding-android-arm64@1.0.2':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.0.3':
-    optional: true
-
-  '@rolldown/binding-darwin-arm64@1.0.2':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.2':
-    optional: true
-
   '@rolldown/binding-darwin-x64@1.0.3':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@1.0.2':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
-    optional: true
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.2':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.2':
-    optional: true
-
   '@rolldown/binding-linux-arm64-musl@1.0.3':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.2':
-    optional: true
-
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.2':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.2':
-    optional: true
-
   '@rolldown/binding-linux-x64-musl@1.0.3':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.2':
-    optional: true
-
   '@rolldown/binding-openharmony-arm64@1.0.3':
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.2':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.3':
@@ -8643,13 +8519,7 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.2':
-    optional: true
-
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.2':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.3':
@@ -8809,6 +8679,10 @@ snapshots:
     dependencies:
       '@shikijs/types': 4.1.0
 
+  '@shikijs/langs@4.2.0':
+    dependencies:
+      '@shikijs/types': 4.2.0
+
   '@shikijs/primitive@4.1.0':
     dependencies:
       '@shikijs/types': 4.1.0
@@ -8819,7 +8693,16 @@ snapshots:
     dependencies:
       '@shikijs/types': 4.1.0
 
+  '@shikijs/themes@4.2.0':
+    dependencies:
+      '@shikijs/types': 4.2.0
+
   '@shikijs/types@4.1.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@4.2.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -8892,18 +8775,18 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-cloudflare@7.2.8(@sveltejs/kit@2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.55.10)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(wrangler@4.95.0(@cloudflare/workers-types@4.20260529.1))':
+  '@sveltejs/adapter-cloudflare@7.2.8(@sveltejs/kit@2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.10)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.55.10)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(wrangler@4.95.0(@cloudflare/workers-types@4.20260529.1))':
     dependencies:
       '@cloudflare/workers-types': 4.20260529.1
-      '@sveltejs/kit': 2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.55.10)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@sveltejs/kit': 2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.10)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.55.10)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       worktop: 0.8.0-next.18
       wrangler: 4.95.0(@cloudflare/workers-types@4.20260529.1)
 
-  '@sveltejs/kit@2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.55.10)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))':
+  '@sveltejs/kit@2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.10)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.55.10)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.55.10)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.10)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -8915,19 +8798,27 @@ snapshots:
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
       svelte: 5.55.10
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       typescript: 6.0.3
 
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.10)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.55.10)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.10)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+      obug: 2.1.1
+      svelte: 5.55.10
+      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
+
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.10)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.10)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.55.10)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.55.10
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@tailwindcss/node@4.3.0':
     dependencies:
@@ -8995,12 +8886,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.0(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@talesofai-billing/cli@1.5.0':
     dependencies:
@@ -10949,27 +10840,6 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.0.2:
-    dependencies:
-      '@oxc-project/types': 0.132.0
-      '@rolldown/pluginutils': 1.0.1
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.2
-      '@rolldown/binding-darwin-arm64': 1.0.2
-      '@rolldown/binding-darwin-x64': 1.0.2
-      '@rolldown/binding-freebsd-x64': 1.0.2
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.2
-      '@rolldown/binding-linux-arm64-gnu': 1.0.2
-      '@rolldown/binding-linux-arm64-musl': 1.0.2
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.2
-      '@rolldown/binding-linux-s390x-gnu': 1.0.2
-      '@rolldown/binding-linux-x64-gnu': 1.0.2
-      '@rolldown/binding-linux-x64-musl': 1.0.2
-      '@rolldown/binding-openharmony-arm64': 1.0.2
-      '@rolldown/binding-wasm32-wasi': 1.0.2
-      '@rolldown/binding-win32-arm64-msvc': 1.0.2
-      '@rolldown/binding-win32-x64-msvc': 1.0.2
-
   rolldown@1.0.3:
     dependencies:
       '@oxc-project/types': 0.133.0
@@ -11648,36 +11518,37 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-pwa@1.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
+  vite-plugin-pwa@1.3.0(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.16
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
       workbox-build: 7.4.1
       workbox-window: 7.4.1
     transitivePeerDependencies:
       - supports-color
 
-  vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0):
+  vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
-      lightningcss: 1.32.0
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.15
-      rolldown: 1.0.2
+      rollup: 4.60.4
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.9.1
-      esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.7.0
+      lightningcss: 1.32.0
       terser: 5.48.0
       tsx: 4.22.3
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
 
   w3c-keyname@2.2.8: {}
 


### PR DESCRIPTION
- lazy-load markdown rendering and workspace-heavy panels
- load Shiki via core with per-language/theme dynamic chunks
- add Rollup min chunk size tuning for Vite 7
- lazy-load CodeMirror language packages
- narrow PWA precache to avoid caching all immutable chunks