### PR TITLE
feat(web): add desktop task notifications

### DIFF
--- a/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
+++ b/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
@@ -142,6 +142,7 @@ import {
 	parseResourceLabelRealtimePayload,
 	syncResourceLabelsToCache,
 } from "$lib/labels/resource-label-cache-sync";
+import { notifyTaskFinished } from "$lib/notifications/desktop-task-notifications";
 import { extractSpaceMentionsFromText } from "$lib/mentions/space";
 import { sdk } from "$lib/sdk";
 import { mergeSessionRecord } from "$lib/session-record-merge";
@@ -5634,10 +5635,18 @@ function handleTaskRealtimeEvent(payload: ChannelEnvelope) {
 		});
 	}
 	if (payload.type === "task.updated") {
-		if (
-			eventPayload.changed?.includes("status") &&
-			task.status === "completed"
-		) {
+		if (eventPayload.changed?.includes("status")) {
+			if (task.status === "completed" || task.status === "failed") {
+				notifyTaskFinished({
+					...(task as Partial<TaskRunRecord>),
+					id: task.id,
+					type: task.type,
+					userId: task.userId,
+				});
+			}
+			if (task.status === "completed") {
+				void loadSpaceCheckpoints();
+			}
 		}
 	}
 }

--- a/apps/web/src/lib/notifications/desktop-task-notifications.ts
+++ b/apps/web/src/lib/notifications/desktop-task-notifications.ts
@@ -1,0 +1,129 @@
+import type { TaskRunRecord } from "@neta-art/cohub";
+
+const STORAGE_KEY = "cohub:desktop-task-notifications:v1";
+const DEDUPE_LIMIT = 500;
+
+export type DesktopTaskNotificationStatus = "unsupported" | NotificationPermission;
+
+export type DesktopTaskNotificationPreferences = {
+	enabled: boolean;
+	notifyCompleted: boolean;
+	notifyFailed: boolean;
+};
+
+export type DesktopTaskNotificationTask = Partial<TaskRunRecord> & {
+	id: string;
+	type?: string | null;
+	userId?: string | null;
+};
+
+const DEFAULT_PREFERENCES: DesktopTaskNotificationPreferences = {
+	enabled: false,
+	notifyCompleted: true,
+	notifyFailed: true,
+};
+
+const notifiedTaskKeys: string[] = [];
+const notifiedTaskKeySet = new Set<string>();
+
+function isBrowser() {
+	return typeof window !== "undefined";
+}
+
+export function getDesktopTaskNotificationStatus(): DesktopTaskNotificationStatus {
+	if (!isBrowser() || !("Notification" in window)) return "unsupported";
+	return Notification.permission;
+}
+
+function readPreferences(): DesktopTaskNotificationPreferences {
+	if (!isBrowser()) return { ...DEFAULT_PREFERENCES };
+	try {
+		const raw = window.localStorage.getItem(STORAGE_KEY);
+		if (!raw) return { ...DEFAULT_PREFERENCES };
+		const parsed = JSON.parse(raw) as Partial<DesktopTaskNotificationPreferences>;
+		return {
+			enabled: parsed.enabled === true,
+			notifyCompleted: parsed.notifyCompleted !== false,
+			notifyFailed: parsed.notifyFailed !== false,
+		};
+	} catch {
+		return { ...DEFAULT_PREFERENCES };
+	}
+}
+
+function writePreferences(preferences: DesktopTaskNotificationPreferences) {
+	if (!isBrowser()) return;
+	try {
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+	} catch {
+		// localStorage can be unavailable; runtime permission remains authoritative.
+	}
+}
+
+export function getDesktopTaskNotificationPreferences() {
+	return readPreferences();
+}
+
+export function setDesktopTaskNotificationPreferences(
+	patch: Partial<DesktopTaskNotificationPreferences>,
+) {
+	const next = { ...readPreferences(), ...patch };
+	writePreferences(next);
+	return next;
+}
+
+export async function requestDesktopTaskNotificationPermission() {
+	if (getDesktopTaskNotificationStatus() === "unsupported") return "unsupported";
+	const permission = await Notification.requestPermission();
+	setDesktopTaskNotificationPreferences({ enabled: permission === "granted" });
+	return permission;
+}
+
+function remember(key: string) {
+	if (notifiedTaskKeySet.has(key)) return false;
+	notifiedTaskKeySet.add(key);
+	notifiedTaskKeys.push(key);
+	while (notifiedTaskKeys.length > DEDUPE_LIMIT) {
+		const stale = notifiedTaskKeys.shift();
+		if (stale) notifiedTaskKeySet.delete(stale);
+	}
+	return true;
+}
+
+function taskTypeLabel(task: DesktopTaskNotificationTask) {
+	return (task.type ?? task.taskType ?? "task").replaceAll("_", " ");
+}
+
+function notificationBody(task: DesktopTaskNotificationTask) {
+	const type = taskTypeLabel(task);
+	if (task.status === "failed") {
+		const message = task.errorMessage?.trim();
+		return message ? `${type} failed: ${message}` : `${type} failed`;
+	}
+	return `${type} completed`;
+}
+
+export function notifyTaskFinished(task: DesktopTaskNotificationTask) {
+	if (getDesktopTaskNotificationStatus() !== "granted") return false;
+	const preferences = readPreferences();
+	if (!preferences.enabled) return false;
+	if (task.status === "completed" && !preferences.notifyCompleted) return false;
+	if (task.status === "failed" && !preferences.notifyFailed) return false;
+	if (task.status !== "completed" && task.status !== "failed") return false;
+
+	const key = `${task.id}:${task.status}:${task.finishedAt ?? task.updatedAt ?? ""}`;
+	if (!remember(key)) return false;
+
+	const notification = new Notification(
+		task.status === "failed" ? "Cohub task failed" : "Cohub task completed",
+		{
+			body: notificationBody(task),
+			tag: `cohub-task-${task.id}-${task.status}`,
+			requireInteraction: true,
+		},
+	);
+	notification.onclick = () => {
+		window.focus();
+	};
+	return true;
+}

--- a/apps/web/src/routes/settings/appearance/+page.svelte
+++ b/apps/web/src/routes/settings/appearance/+page.svelte
@@ -1,10 +1,25 @@
 <script lang="ts">
-import { Monitor, Moon, Palette, Sun } from "lucide-svelte";
+import { Bell, Monitor, Moon, Palette, Sun } from "lucide-svelte";
+import {
+	getDesktopTaskNotificationPreferences,
+	getDesktopTaskNotificationStatus,
+	requestDesktopTaskNotificationPermission,
+	setDesktopTaskNotificationPreferences,
+	type DesktopTaskNotificationPreferences,
+	type DesktopTaskNotificationStatus,
+} from "$lib/notifications/desktop-task-notifications";
 import { getTheme, setTheme } from "$lib/theme.svelte";
 import { THEME_OPTIONS, type ThemeMode } from "$lib/theme-registry";
 
 // Reactive — reads from $state-backed store, auto-updates on system changes
 const mode = $derived(getTheme());
+let notificationStatus = $state<DesktopTaskNotificationStatus>(
+	getDesktopTaskNotificationStatus(),
+);
+let notificationPreferences = $state<DesktopTaskNotificationPreferences>(
+	getDesktopTaskNotificationPreferences(),
+);
+let notificationActionPending = $state(false);
 
 const themeIcon = {
 	dark: Moon,
@@ -22,6 +37,22 @@ function handleThemeChange(mode: ThemeMode) {
 // separate, even though it resolves to the current OS light/dark preference.
 function isActive(option: ThemeMode): boolean {
 	return mode === option;
+}
+
+function updateNotificationPreferences(
+	patch: Partial<DesktopTaskNotificationPreferences>,
+) {
+	notificationPreferences = setDesktopTaskNotificationPreferences(patch);
+}
+
+async function enableDesktopNotifications() {
+	notificationActionPending = true;
+	try {
+		notificationStatus = await requestDesktopTaskNotificationPermission();
+		notificationPreferences = getDesktopTaskNotificationPreferences();
+	} finally {
+		notificationActionPending = false;
+	}
 }
 </script>
 
@@ -65,6 +96,73 @@ function isActive(option: ThemeMode): boolean {
             </div>
           </button>
         {/each}
+      </div>
+    </section>
+
+    <section class="mt-8 max-w-xl border-t border-border-subtle pt-6">
+      <h2 class="text-[15px] font-semibold text-text-primary tracking-tight">Desktop notifications</h2>
+      <p class="mt-1 text-[13px] text-text-tertiary">
+        Get browser notifications when Cohub tasks finish while this workspace is open.
+      </p>
+
+      <div class="mt-4 rounded-[7px] border border-border-subtle bg-bg-surface p-4">
+        <div class="flex items-start gap-3">
+          <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-[5px] bg-bg-hover-strong">
+            <Bell class="h-4 w-4 text-text-tertiary" />
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="text-[13px] font-medium text-text-primary">Task completion alerts</div>
+            <div class="mt-0.5 text-[11px] text-text-tertiary">
+              macOS controls how long browser notifications stay visible. Set your browser notification style to Alerts for persistent banners.
+            </div>
+            <div class="mt-3 flex flex-wrap items-center gap-2">
+              {#if notificationStatus === "unsupported"}
+                <span class="rounded bg-warning-bg px-2 py-1 text-[11px] text-warning">Not supported in this browser</span>
+              {:else if notificationStatus === "denied"}
+                <span class="rounded bg-error-bg px-2 py-1 text-[11px] text-error-soft">Blocked by browser settings</span>
+              {:else if notificationStatus === "granted"}
+                <label class="inline-flex items-center gap-2 text-[12px] text-text-secondary">
+                  <input
+                    type="checkbox"
+                    checked={notificationPreferences.enabled}
+                    onchange={(event) => updateNotificationPreferences({ enabled: event.currentTarget.checked })}
+                  />
+                  Enabled
+                </label>
+              {:else}
+                <button
+                  type="button"
+                  class="rounded-[5px] bg-brand px-3 py-1.5 text-[12px] font-medium text-brand-contrast-fg transition-colors hover:bg-brand-hover disabled:opacity-50"
+                  disabled={notificationActionPending}
+                  onclick={enableDesktopNotifications}
+                >
+                  {notificationActionPending ? "Requesting..." : "Enable notifications"}
+                </button>
+              {/if}
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-4 grid gap-2 border-t border-border-subtle pt-4 sm:grid-cols-2">
+          <label class="flex items-center gap-2 text-[12px] text-text-secondary">
+            <input
+              type="checkbox"
+              checked={notificationPreferences.notifyCompleted}
+              disabled={notificationStatus !== "granted" || !notificationPreferences.enabled}
+              onchange={(event) => updateNotificationPreferences({ notifyCompleted: event.currentTarget.checked })}
+            />
+            Completed tasks
+          </label>
+          <label class="flex items-center gap-2 text-[12px] text-text-secondary">
+            <input
+              type="checkbox"
+              checked={notificationPreferences.notifyFailed}
+              disabled={notificationStatus !== "granted" || !notificationPreferences.enabled}
+              onchange={(event) => updateNotificationPreferences({ notifyFailed: event.currentTarget.checked })}
+            />
+            Failed tasks
+          </label>
+        </div>
       </div>
     </section>
   </div>


### PR DESCRIPTION
## Summary
- add browser desktop notification preferences under Settings → Appearance
- notify on task completed/failed realtime status updates while the workspace is open
- dedupe task notifications and keep completed/failed notification toggles local

## Testing
- Not run: `pnpm --filter web typecheck` requires workspace dependencies; current sandbox has no node_modules and lacks `GITEA_NPM_TOKEN` for install.

Note: this PR targets the GitHub repository baseline.
