### PR TITLE
feat: add Z-Image and Qwen Edit generation configs

### DIFF
--- a/apps/worker/src/generations/openai-image-edits-adapter.ts
+++ b/apps/worker/src/generations/openai-image-edits-adapter.ts
@@ -1,0 +1,79 @@
+import {
+  GenerationProviderError,
+  GenerationValidationError,
+  type GenerationAdapterInput,
+  type GenerationContentBlock,
+} from "@neta-art/generation";
+
+const REQUEST_TIMEOUT_MS = 300_000;
+
+type OpenAiImagesResponse = {
+  data?: Array<{ url?: unknown; b64_json?: unknown; revised_prompt?: unknown }>;
+};
+
+function joinUrl(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+function mergeText(content: GenerationContentBlock[]): string {
+  return content
+    .filter((block): block is Extract<GenerationContentBlock, { type: "text" }> => block.type === "text")
+    .map((block) => block.text.trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
+function firstUrlImage(content: GenerationContentBlock[]): string {
+  const image = content.find(
+    (block): block is Extract<GenerationContentBlock, { type: "image" }> => block.type === "image",
+  );
+  if (!image) throw new GenerationValidationError("Source image is required");
+  if (image.source.type !== "url") throw new GenerationValidationError("This image edit model only supports image URLs");
+  return image.source.url;
+}
+
+export async function openAiImageEditsAdapter(input: GenerationAdapterInput): Promise<GenerationContentBlock[]> {
+  const prompt = mergeText(input.request.content);
+  if (!prompt) throw new GenerationValidationError("Edit instruction is required");
+
+  const body = new FormData();
+  body.set("model", input.declaration.model);
+  body.set("prompt", prompt);
+  body.set("image", firstUrlImage(input.request.content));
+  for (const [key, value] of Object.entries(input.parameters)) {
+    if (value !== undefined && value !== null) body.set(key, String(value));
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await input.context.fetch(joinUrl(input.context.baseUrl, "/v1/images/edits"), {
+      method: "POST",
+      headers: { Authorization: `Bearer ${input.context.apiKey}` },
+      body,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!response.ok) {
+    const bodyText = await response.text().catch(() => response.statusText);
+    throw new GenerationProviderError("Image edit provider request failed", { status: response.status, body: bodyText });
+  }
+
+  const raw = (await response.json()) as OpenAiImagesResponse;
+  const output: GenerationContentBlock[] = [];
+  for (const item of raw.data ?? []) {
+    if (typeof item.url === "string" && item.url) output.push({ type: "image", source: { type: "url", url: item.url } });
+    if (typeof item.b64_json === "string" && item.b64_json) {
+      output.push({ type: "image", source: { type: "base64", mediaType: "image/png", data: item.b64_json } });
+    }
+    if (typeof item.revised_prompt === "string" && item.revised_prompt.trim()) {
+      output.push({ type: "text", text: item.revised_prompt, meta: { role: "revised_prompt" } });
+    }
+  }
+  if (output.length === 0) throw new GenerationProviderError("Image edit returned no output", { details: raw });
+  return output;
+}

--- a/apps/worker/src/tasks/generation-task.ts
+++ b/apps/worker/src/tasks/generation-task.ts
@@ -11,6 +11,7 @@ import { createGenerationDeclarationLoader } from "@cohub/infra/config-runtime/g
 import { GENERATION_TASK_TYPE, type GenerationTaskData, type GenerationTaskResult } from "@cohub/protocol/generation";
 import type { TaskPayload } from "@cohub/protocol/task";
 import { config } from "../config.js";
+import { openAiImageEditsAdapter } from "../generations/openai-image-edits-adapter.js";
 import { redisCommandClient } from "../redis.js";
 import { registerTask } from "./registry.js";
 
@@ -154,6 +155,9 @@ registerTask(GENERATION_TASK_TYPE, async (job: Job, context) => {
       models: [declaration],
       includeBuiltinModels: false,
       apiKey: getNetaRouterApiKey(),
+      adapters: {
+        "openai.imageEdits": openAiImageEditsAdapter,
+      },
     }).generate({
       model: data.model,
       content: data.content,

--- a/docs/examples/generations/qwen-image-edit.yaml
+++ b/docs/examples/generations/qwen-image-edit.yaml
@@ -1,0 +1,44 @@
+schema: neta.generation.model.v1
+model: qwen-image-edit
+title: Qwen Image Edit
+description: Neta Qwen image editing with one source image and an edit instruction.
+adapter:
+  type: openai.imageEdits
+content:
+  input:
+    - type: text
+      required: true
+      min: 1
+      max: 16
+      merge: newline
+      description: Edit instruction.
+    - type: image
+      required: true
+      min: 1
+      max: 1
+      sources:
+        - url
+      description: Source image URL to edit.
+parameters:
+  size:
+    type: string
+    optional: true
+    default: 1024x1024
+    description: Output image size.
+    examples:
+      - 1024x1024
+      - 768x1024
+      - 1024x768
+examples:
+  - title: Edit image
+    request:
+      model: qwen-image-edit
+      content:
+        - type: text
+          text: change the background to a clean white studio backdrop
+        - type: image
+          source:
+            type: url
+            url: https://example.com/input.png
+      parameters:
+        size: 1024x1024

--- a/docs/examples/generations/z-image-turbo.yaml
+++ b/docs/examples/generations/z-image-turbo.yaml
@@ -1,0 +1,34 @@
+schema: neta.generation.model.v1
+model: z-image-turbo
+title: Z-Image Turbo
+description: Fast text-to-image generation through Neta Router. Z-Image Turbo accepts prompt text only; it does not support reference images.
+adapter:
+  type: openai.images
+content:
+  input:
+    - type: text
+      required: true
+      min: 1
+      max: 16
+      merge: newline
+      description: Prompt text.
+parameters:
+  size:
+    type: string
+    optional: true
+    default: 1024*1024
+    enum:
+      - 1024*1024
+      - 1536*1024
+      - 1024*1536
+      - 2048*2048
+    description: Output image size.
+examples:
+  - title: Text to image
+    request:
+      model: z-image-turbo
+      content:
+        - type: text
+          text: a clean product-style image of a small red toy robot standing on a white desk
+      parameters:
+        size: 1024*1024

--- a/docs/generations.md
+++ b/docs/generations.md
@@ -85,6 +85,8 @@ parameters:
 See the full examples:
 
 - [`docs/examples/generations/gpt-image-2.yaml`](./examples/generations/gpt-image-2.yaml)
+- [`docs/examples/generations/z-image-turbo.yaml`](./examples/generations/z-image-turbo.yaml)
+- [`docs/examples/generations/qwen-image-edit.yaml`](./examples/generations/qwen-image-edit.yaml)
 - [`docs/examples/generations/gemini-3.1-flash-image-preview.yaml`](./examples/generations/gemini-3.1-flash-image-preview.yaml)
 - [`docs/examples/generations/seedance-2-0-fast.yaml`](./examples/generations/seedance-2-0-fast.yaml)
 - [`docs/examples/generations/seedance-2-0.yaml`](./examples/generations/seedance-2-0.yaml)
@@ -99,6 +101,15 @@ cohub generate "a cyberpunk cat in neon rain" \
   --model gpt-image-2 \
   --param size=1024x1024 \
   --param quality=high
+
+cohub generate "a clean product-style image of a small red toy robot" \
+  --model z-image-turbo \
+  --param 'size=1024*1024'
+
+cohub generate "change the background to a clean white studio backdrop" \
+  --model qwen-image-edit \
+  --image https://example.com/input.png \
+  --param size=1024x1024
 
 cohub generate "same character, smiling" \
   --model gpt-image-2 \


### PR DESCRIPTION
## Summary
- add Z-Image Turbo generation declaration with text-only input and common size parameter
- add Qwen Image Edit declaration with URL image input and common size parameter
- add a minimal worker adapter for OpenAI-compatible image edits because Qwen Edit uses `/v1/images/edits`, not `/v1/images/generations`

## Validation
- Real Z-Image call succeeded against USA prod New API `/v1/images/generations` with `z-image-turbo`
- Real Qwen Edit call succeeded against USA dev New API `/v1/images/edits` with `qwen-image-edit` and URL image input
- Verified Qwen Edit fails on `/v1/images/generations`, which is why the new `openai.imageEdits` adapter is required

## Notes
- Did not modify New API production configuration
- Qwen Edit is enabled in USA dev; USA prod currently reports no available channel for `qwen-image-edit` in group `default`
