### PR TITLE
fix(web): hydrate sidebar spaces from cache on mount

### DIFF
--- a/apps/web/src/lib/components/Sidebar.svelte
+++ b/apps/web/src/lib/components/Sidebar.svelte
@@ -174,7 +174,11 @@ const CHECKPOINT_PAGE_SIZE = 20;
 const TASK_PAGE_SIZE = 10;
 
 let showUserMenu = $state(false);
-let spaces = $state<SpaceRecord[]>([]);
+// Hydrate synchronously from the local cache so a freshly mounted sidebar
+// (e.g. the mobile drawer, which unmounts on close) can resolve the current
+// space on first paint instead of flashing the empty "Select a space" state
+// while loadSpaces() awaits auth + IndexedDB + network.
+let spaces = $state<SpaceRecord[]>(getCachedSpaceList() ?? []);
 let sessions = $state<SessionRecord[]>([]);
 type SessionForkSidebarRecord = Partial<SessionForkRecord> & {
 	childSessionId: string;


### PR DESCRIPTION
The mobile drawer unmounts its Sidebar shortly after closing, so each reopen mounts a fresh Sidebar with an empty spaces array. loadSpaces() only fills it after awaiting auth + IndexedDB + network, leaving a window where currentSpaceId is known but currentSpace is null — collapsing the sidebar to the empty 'Select a space' state after switching spaces.

Initialize spaces synchronously from the local space-list cache so the current space resolves on first paint, matching the cache-first, no-jump loading strategy.