### PR TITLE
feat(sandbox): CI cross-platform binary build + CLI managed download

### DIFF
--- a/.github/workflows/sandbox-binaries-build.yml
+++ b/.github/workflows/sandbox-binaries-build.yml
@@ -1,0 +1,176 @@
+name: Sandbox Binaries Build and Release
+
+# Builds standalone `cohub-sandboxd` binaries for common platforms. These are the
+# same binary as the containerized sandbox, run with `--local` to expose a user's
+# machine as a space sandbox via the gateway relay. On version tags the archives
+# are attached to a GitHub Release; on other runs they are uploaded as artifacts.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+    paths:
+      - 'apps/sandbox/**'
+      - '.github/workflows/sandbox-binaries-build.yml'
+  pull_request:
+    paths:
+      - 'apps/sandbox/**'
+      - '.github/workflows/sandbox-binaries-build.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  BINARY_NAME: cohub-sandboxd
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: apps/sandbox/go.sum
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            VERSION="${{ github.ref_name }}"
+          else
+            VERSION="dev-$(git rev-parse --short HEAD)"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build
+        working-directory: apps/sandbox
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: '0'
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          OUT_DIR="dist/${BINARY_NAME}_${GOOS}_${GOARCH}"
+          mkdir -p "$OUT_DIR"
+          go build -trimpath \
+            -ldflags "-s -w -X main.buildVersion=${VERSION}" \
+            -o "${OUT_DIR}/${BINARY_NAME}" .
+          "${OUT_DIR}/${BINARY_NAME}" --version || true
+
+      - name: Package
+        working-directory: apps/sandbox
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          BASE="${BINARY_NAME}_${VERSION}_${GOOS}_${GOARCH}"
+          cd dist
+          tar -czf "${BASE}.tar.gz" -C "${BINARY_NAME}_${GOOS}_${GOARCH}" "${BINARY_NAME}"
+          sha256sum "${BASE}.tar.gz" > "${BASE}.tar.gz.sha256"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BINARY_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: |
+            apps/sandbox/dist/*.tar.gz
+            apps/sandbox/dist/*.sha256
+          if-no-files-found: error
+          retention-days: 14
+
+  release:
+    needs: build
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Collect release assets
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.sha256' \) -exec cp {} release/ \;
+          # Aggregate a single checksums file for convenience.
+          ( cd release && cat *.sha256 | sort > SHA256SUMS.txt )
+          ls -la release
+
+      - name: Publish to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release/*.tar.gz
+            release/SHA256SUMS.txt
+          fail_on_unmatched_files: true
+
+  publish-cdn:
+    needs: build
+    # The repo is private, so GitHub Release assets are not publicly
+    # downloadable. The CLI fetches the runner from the public CDN, so mirror
+    # the archives to the cohub-public OSS bucket under sandboxd/<version>/.
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    env:
+      OSS_BUCKET: cohub-public
+      OSS_ENDPOINT: https://oss-us-west-1.aliyuncs.com
+      OSS_REGION: us-west-1
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Resolve version
+        id: version
+        run: echo "version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+
+      - name: Collect archives
+        run: |
+          set -euo pipefail
+          mkdir -p upload
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.sha256' \) -exec cp {} upload/ \;
+          ls -la upload
+
+      - name: Upload to public CDN (OSS, S3-compatible)
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.PUBLIC_ASSET_OSS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.PUBLIC_ASSET_OSS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.OSS_REGION }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+            echo "Missing PUBLIC_ASSET_OSS_ACCESS_KEY_ID / PUBLIC_ASSET_OSS_SECRET_ACCESS_KEY secrets"
+            exit 1
+          fi
+          # Immutable, versioned objects — safe to cache forever.
+          aws s3 cp upload "s3://${OSS_BUCKET}/sandboxd/${VERSION}/" \
+            --endpoint-url "${OSS_ENDPOINT}" \
+            --recursive \
+            --cache-control "public, max-age=31536000, immutable"
+          echo "Published sandboxd ${VERSION} to https://public.cohub.run/sandboxd/${VERSION}/"
+

--- a/apps/sandbox/main.go
+++ b/apps/sandbox/main.go
@@ -95,6 +95,11 @@ func toProtocolPortChanges(changes []portwatch.Change) []protocol.PortChange {
 	return out
 }
 
+// buildVersion is stamped at build time via -ldflags "-X main.buildVersion=...".
+// For the containerized sandbox the IMAGE_VERSION env var takes precedence; for
+// standalone local binaries this ldflags value is the source of truth.
+var buildVersion = "dev"
+
 func main() {
 	showVersion := flag.Bool("version", false, "print sandbox version and exit")
 	localMode := flag.Bool("local", false, "run in local dial-out mode (connect to the gateway relay)")
@@ -105,7 +110,7 @@ func main() {
 	if *showVersion {
 		version := os.Getenv("IMAGE_VERSION")
 		if version == "" {
-			version = "unknown"
+			version = buildVersion
 		}
 		fmt.Println(version)
 		return

--- a/docs/agent-sandbox-runtime.md
+++ b/docs/agent-sandbox-runtime.md
@@ -34,6 +34,25 @@
 - `space_sandboxes.provider = "local"` 时，controller 短路 provision / idle-destroy / recover
 - CLI：`cohub sandbox up <dir>` 建/绑 space、拉起 runner、输出 web 链接
 
+### 二进制分发
+
+`cohub-sandboxd` 与云端 sandbox 是同一份代码，仅以 `--local` 拨出运行。CI（`.github/workflows/sandbox-binaries-build.yml`）在打 `v*` tag 时交叉编译常见平台：
+
+- `linux/amd64`、`linux/arm64`、`darwin/amd64`、`darwin/arm64`
+- 每平台产出 `cohub-sandboxd_<version>_<os>_<arch>.tar.gz` + `.sha256`，附带聚合 `SHA256SUMS.txt`
+- 版本经 `-ldflags -X main.buildVersion=<tag>` 注入；容器内仍以 `IMAGE_VERSION` 环境变量优先
+- Windows 暂不支持（进程组管理依赖 Unix syscall，待后续补平台适配）
+- 产物同时：附加到 GitHub Release（私有 repo，仅内部可下）、上传公共 CDN `https://public.cohub.run/sandboxd/<version>/`（CLI 下载源）
+
+### 托管下载（CLI）
+
+CLI 首次 `cohub sandbox up` 时按当前 `os/arch` 从公共 CDN 拉取对应单个平台二进制，校验 `.sha256` 后缓存到 `~/.cache/cohub/sandboxd/<version>/`，后续命中缓存：
+
+- 版本由 CLI 内 `SANDBOXD_VERSION` 常量锁定（独立于 CLI 包版本；协议版本 `"1"` 保证向后兼容），随 runner 演进手动 bump
+- `COHUB_SANDBOXD_BIN` 覆盖二进制路径（本地 `go build` / 离线 / 自建）
+- `COHUB_SANDBOXD_CDN_BASE_URL` 覆盖下载源（staging / 自托管）
+- 并发 `up` 用 mkdir 原子锁避免重复下载；checksum 不匹配直接拒绝
+
 ## 当前 transport 模式
 
 当前系统只保留一种模式：

--- a/packages/cli/src/commands/sandbox.ts
+++ b/packages/cli/src/commands/sandbox.ts
@@ -6,8 +6,9 @@ import { resolveCohubEnvironment, resolveWebsocketUrl } from "@neta-art/cohub";
 import type { Command } from "commander";
 import { requireAccessToken } from "../auth.js";
 import { createClient } from "../client.js";
-import { error, json as outJson, jsonRequested, ok } from "../output.js";
+import { error, json as outJson, jsonRequested, ok, spinner } from "../output.js";
 import { resolveSpace } from "../space.js";
+import { ensureSandboxdBinary, SandboxdDownloadError } from "./sandboxd-binary.js";
 
 type UpOptions = {
   space?: string;
@@ -23,24 +24,6 @@ const resolveRelayUrl = (): string => {
   if (explicit) return explicit;
   const wsUrl = resolveWebsocketUrl({ url: process.env.COHUB_WS_URL });
   return wsUrl.replace(/\/ws$/, "/sandbox/relay");
-};
-
-// Resolve the sandboxd binary path. For MVP the binary is provided via
-// COHUB_SANDBOXD_BIN (built locally with `go build`); the managed release
-// download lands in a follow-up once goreleaser publishing is wired up.
-const resolveSandboxdBinary = async (): Promise<string> => {
-  const override = process.env.COHUB_SANDBOXD_BIN?.trim();
-  if (override) {
-    const info = await stat(override).catch(() => null);
-    if (!info?.isFile()) {
-      return error("sandboxd binary not found", `COHUB_SANDBOXD_BIN=${override} is not a file`);
-    }
-    return override;
-  }
-  return error(
-    "sandboxd binary not available",
-    "Set COHUB_SANDBOXD_BIN to a locally built sandboxd binary (cd apps/sandbox && go build -o cohub-sandboxd .). Managed downloads arrive in a later release.",
-  );
 };
 
 const confirm = async (question: string): Promise<boolean> => {
@@ -90,7 +73,28 @@ export function registerSandbox(program: Command): void {
         return error("Invalid directory", `${rootDir} is not a directory`);
       }
 
-      const binary = await resolveSandboxdBinary();
+      // A single spinner: first status starts it, later statuses only update the
+      // label (calling start twice would leak the previous interval).
+      const spin = spinner();
+      let spinnerStarted = false;
+      let binary: string;
+      try {
+        binary = await ensureSandboxdBinary({
+          onStatus: (msg) => {
+            if (spinnerStarted) {
+              spin.update(msg);
+            } else {
+              spin.start(msg);
+              spinnerStarted = true;
+            }
+          },
+        });
+        if (spinnerStarted) spin.stop("");
+      } catch (err) {
+        if (spinnerStarted) spin.stop("");
+        if (err instanceof SandboxdDownloadError) return error("Sandbox runtime unavailable", err.message);
+        throw err;
+      }
       const relayUrl = resolveRelayUrl();
       const token = await requireAccessToken();
       const client = createClient();

--- a/packages/cli/src/commands/sandboxd-binary.ts
+++ b/packages/cli/src/commands/sandboxd-binary.ts
@@ -1,0 +1,249 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createReadStream, createWriteStream } from "node:fs";
+import { chmod, copyFile, mkdir, mkdtemp, rename, rm, stat } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
+
+// The sandboxd binary version is pinned independently of the CLI package: it
+// only needs to change when apps/sandbox changes, and the agent-sandbox wire
+// protocol ("1") guarantees backward compatibility.
+//
+// IMPORTANT: this must point at a tag whose CDN artifacts have already been
+// published by .github/workflows/sandbox-binaries-build.yml. Only bump it AFTER
+// that tag's publish-cdn job has succeeded, otherwise `sandbox up` 404s on the
+// default download.
+export const SANDBOXD_VERSION = "v1.80.2";
+
+const BINARY_NAME = "cohub-sandboxd";
+
+// Public CDN prefix hosting the release archives (the repo is private, so the
+// GitHub Release assets are not publicly downloadable). Overridable for staging
+// or self-hosting.
+const cdnBaseUrl = (): string =>
+  (process.env.COHUB_SANDBOXD_CDN_BASE_URL?.trim() || "https://public.cohub.run/sandboxd").replace(/\/+$/, "");
+
+const DOWNLOAD_TIMEOUT_MS = 120_000;
+const LOCK_STALE_MS = 5 * 60 * 1000;
+
+// Map Node's platform/arch to the Go GOOS/GOARCH used in release asset names.
+const GOOS_BY_PLATFORM: Record<string, string> = { darwin: "darwin", linux: "linux" };
+const GOARCH_BY_ARCH: Record<string, string> = { x64: "amd64", arm64: "arm64" };
+
+export class SandboxdDownloadError extends Error {
+  override name = "SandboxdDownloadError";
+}
+
+type Target = { goos: string; goarch: string };
+
+const resolveTarget = (): Target => {
+  const goos = GOOS_BY_PLATFORM[process.platform];
+  const goarch = GOARCH_BY_ARCH[process.arch];
+  if (!goos || !goarch) {
+    throw new SandboxdDownloadError(
+      `Unsupported platform ${process.platform}/${process.arch}. Set COHUB_SANDBOXD_BIN to a locally built binary.`,
+    );
+  }
+  return { goos, goarch };
+};
+
+const cacheDir = (version: string): string => join(homedir(), ".cache", "cohub", "sandboxd", version);
+const cachedBinaryPath = (version: string): string => join(cacheDir(version), BINARY_NAME);
+const archiveName = (version: string, target: Target): string =>
+  `${BINARY_NAME}_${version}_${target.goos}_${target.goarch}.tar.gz`;
+
+const isExecutableFile = async (path: string): Promise<boolean> => {
+  const info = await stat(path).catch(() => null);
+  return Boolean(info?.isFile());
+};
+
+const sha256File = async (path: string): Promise<string> => {
+  const hash = createHash("sha256");
+  await pipeline(createReadStream(path), hash);
+  return hash.digest("hex");
+};
+
+// Run `fn` under a single AbortController whose timeout spans the entire body
+// read (not just the response headers), and normalize any network / timeout
+// failure into a user-readable SandboxdDownloadError.
+const withTimeout = async <T>(what: string, fn: (signal: AbortSignal) => Promise<T>): Promise<T> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
+  try {
+    return await fn(controller.signal);
+  } catch (err) {
+    if (err instanceof SandboxdDownloadError) throw err;
+    if (controller.signal.aborted) {
+      throw new SandboxdDownloadError(`${what} timed out after ${DOWNLOAD_TIMEOUT_MS / 1000}s`);
+    }
+    throw new SandboxdDownloadError(`${what} failed: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+// Download a URL straight to disk. The timeout covers the full stream, so a
+// stalled body can never hang indefinitely.
+const downloadToFile = (url: string, accept: string, destPath: string): Promise<void> =>
+  withTimeout(`Download of ${url}`, async (signal) => {
+    const response = await fetch(url, { signal, headers: { accept } });
+    if (!response.ok) throw new SandboxdDownloadError(`Download failed (${response.status}) for ${url}`);
+    if (!response.body) throw new SandboxdDownloadError(`Empty response body for ${url}`);
+    // Cast: Node's web-stream typings diverge from the DOM lib bundled by tsc.
+    await pipeline(Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]), createWriteStream(destPath));
+  });
+
+// Fetch a small text resource (the checksum manifest) under the same timeout.
+const fetchText = (url: string, accept: string): Promise<string> =>
+  withTimeout(`Download of ${url}`, async (signal) => {
+    const response = await fetch(url, { signal, headers: { accept } });
+    if (!response.ok) throw new SandboxdDownloadError(`Download failed (${response.status}) for ${url}`);
+    return (await response.text()).trim();
+  });
+
+// List the entries of a `.tar.gz` without extracting, so we can reject archives
+// that contain anything other than the expected single binary (path traversal,
+// symlinks, extra entries) before touching the filesystem.
+const listTarGz = (archivePath: string): Promise<string[]> =>
+  new Promise((res, rej) => {
+    const child = spawn("tar", ["-tzf", archivePath], { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", rej);
+    child.on("close", (code) =>
+      code === 0
+        ? res(stdout.split("\n").map((line) => line.trim()).filter(Boolean))
+        : rej(new SandboxdDownloadError(`tar listing failed: ${stderr.trim() || `exit ${code}`}`)),
+    );
+  });
+
+// Extract a single-file `.tar.gz` using the system tar (universally present on
+// macOS and Linux), keeping the CLI free of native archive dependencies.
+const extractTarGz = (archivePath: string, cwd: string): Promise<void> =>
+  new Promise((res, rej) => {
+    const child = spawn("tar", ["-xzf", archivePath, "-C", cwd], { stdio: ["ignore", "ignore", "pipe"] });
+    let stderr = "";
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", rej);
+    child.on("close", (code) =>
+      code === 0 ? res() : rej(new SandboxdDownloadError(`tar extraction failed: ${stderr.trim() || `exit ${code}`}`)),
+    );
+  });
+
+// Cross-process lock via atomic mkdir, mirroring the CLI self-update lock so two
+// concurrent `sandbox up` invocations don't download the same archive twice.
+const withLock = async <T>(version: string, fn: () => Promise<T>): Promise<T> => {
+  const lockPath = join(cacheDir(version), ".download.lock");
+  await mkdir(dirname(lockPath), { recursive: true });
+  for (let attempt = 0; attempt < 600; attempt += 1) {
+    try {
+      await mkdir(lockPath);
+      try {
+        return await fn();
+      } finally {
+        await rm(lockPath, { recursive: true, force: true });
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      const info = await stat(lockPath).catch(() => null);
+      if (info && Date.now() - info.mtimeMs > LOCK_STALE_MS) {
+        await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+        continue;
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+  throw new SandboxdDownloadError("Timed out waiting for the sandboxd download lock");
+};
+
+const downloadAndVerify = async (version: string, target: Target): Promise<string> => {
+  const name = archiveName(version, target);
+  const archiveUrl = `${cdnBaseUrl()}/${version}/${name}`;
+  const checksumUrl = `${archiveUrl}.sha256`;
+
+  const tempDir = await mkdtemp(join(tmpdir(), "cohub-sandboxd-"));
+  try {
+    const archivePath = join(tempDir, name);
+
+    // Fetch archive to disk (timeout covers the full body stream).
+    await downloadToFile(archiveUrl, "application/gzip", archivePath);
+
+    // Fetch and verify checksum. The .sha256 file is `<hash>  <filename>`.
+    const checksumText = await fetchText(checksumUrl, "text/plain");
+    const expected = checksumText.split(/\s+/)[0]?.toLowerCase();
+    if (!expected || !/^[0-9a-f]{64}$/.test(expected)) {
+      throw new SandboxdDownloadError(`Invalid checksum manifest for ${name}`);
+    }
+    const actual = (await sha256File(archivePath)).toLowerCase();
+    if (actual !== expected) {
+      throw new SandboxdDownloadError(`Checksum mismatch for ${name} (expected ${expected}, got ${actual})`);
+    }
+
+    // Verify the archive contains exactly the expected binary before extracting,
+    // guarding against path traversal / unexpected entries from a tampered CDN.
+    const entries = await listTarGz(archivePath);
+    if (entries.length !== 1 || entries[0] !== BINARY_NAME) {
+      throw new SandboxdDownloadError(`Unexpected archive contents for ${name}: ${entries.join(", ") || "(empty)"}`);
+    }
+
+    // Extract the single binary from the archive.
+    await extractTarGz(archivePath, tempDir);
+    const extractedBinary = join(tempDir, BINARY_NAME);
+    if (!(await isExecutableFile(extractedBinary))) {
+      throw new SandboxdDownloadError(`Archive ${name} did not contain ${BINARY_NAME}`);
+    }
+
+    // Atomically move into the version cache (fall back to copy across devices).
+    const dest = cachedBinaryPath(version);
+    await mkdir(dirname(dest), { recursive: true });
+    await rename(extractedBinary, dest).catch(async (err) => {
+      if ((err as NodeJS.ErrnoException).code !== "EXDEV") throw err;
+      await copyFile(extractedBinary, dest);
+    });
+    await chmod(dest, 0o755);
+    return dest;
+  } finally {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+};
+
+export type EnsureSandboxdOptions = {
+  version?: string;
+  onStatus?: (message: string) => void;
+};
+
+// Resolve a runnable sandboxd binary path, downloading (once, cached) if needed.
+// COHUB_SANDBOXD_BIN always takes precedence for local development and offline use.
+export const ensureSandboxdBinary = async (options: EnsureSandboxdOptions = {}): Promise<string> => {
+  const override = process.env.COHUB_SANDBOXD_BIN?.trim();
+  if (override) {
+    if (!(await isExecutableFile(override))) {
+      throw new SandboxdDownloadError(`COHUB_SANDBOXD_BIN=${override} is not a file`);
+    }
+    return override;
+  }
+
+  const version = options.version?.trim() || SANDBOXD_VERSION;
+  const cached = cachedBinaryPath(version);
+  if (await isExecutableFile(cached)) return cached;
+
+  const target = resolveTarget();
+  return withLock(version, async () => {
+    // Re-check inside the lock: another process may have finished downloading.
+    if (await isExecutableFile(cached)) return cached;
+    options.onStatus?.(`Downloading sandbox runtime ${version} (${target.goos}/${target.goarch})`);
+    const path = await downloadAndVerify(version, target);
+    options.onStatus?.("Sandbox runtime ready");
+    return path;
+  });
+};


### PR DESCRIPTION
Build standalone cohub-sandboxd binaries for local dial-out mode and let the CLI fetch them on demand.

CI (.github/workflows/sandbox-binaries-build.yml):
- Cross-compile linux/darwin x amd64/arm64 on v* tags; version stamped via -ldflags -X main.buildVersion
- Publish archives + .sha256 to GitHub Release (internal mirror) and mirror to the public CDN (OSS cohub-public/sandboxd/<version>/) which is the CLI's download source since the repo is private
- Least-privilege: default contents:read, only the release job gets write

CLI (packages/cli/src/commands/sandboxd-binary.ts):
- Lazy per-platform download on first 'sandbox up', cached under ~/.cache/cohub/sandboxd/<version>/ with sha256 verification
- Version pinned via SANDBOXD_VERSION constant (decoupled from CLI version; wire protocol '1' guarantees compatibility)
- Single AbortController spans the full body read; all fetch failures are normalized to SandboxdDownloadError so callers surface friendly errors
- tar -tzf allowlist check (exactly one cohub-sandboxd entry) before extract, guarding against path traversal from a tampered archive
- mkdir atomic lock prevents concurrent duplicate downloads
- COHUB_SANDBOXD_BIN / COHUB_SANDBOXD_CDN_BASE_URL escape hatches

sandbox: --version falls back to ldflags buildVersion when IMAGE_VERSION is unset