### PR TITLE
fix(sandbox): map virtual /workspace to fenced root in local sandbox

### DIFF
--- a/apps/sandbox/rpc/helpers.go
+++ b/apps/sandbox/rpc/helpers.go
@@ -94,6 +94,27 @@ type resolvedSandboxPath struct {
 	path string
 }
 
+const virtualWorkspaceRoot = "/workspace"
+
+func mapVirtualWorkspacePath(cfg env.Config, cleaned string) string {
+	if !cfg.Fence {
+		return cleaned
+	}
+	workspaceRoot := filepath.Clean(cfg.WorkspaceDir)
+	virtualRoot := filepath.Clean(virtualWorkspaceRoot)
+	if workspaceRoot == virtualRoot {
+		return cleaned
+	}
+	if cleaned == virtualRoot {
+		return workspaceRoot
+	}
+	if strings.HasPrefix(cleaned, virtualRoot+string(filepath.Separator)) {
+		relativePath := strings.TrimPrefix(cleaned, virtualRoot+string(filepath.Separator))
+		return filepath.Join(workspaceRoot, relativePath)
+	}
+	return cleaned
+}
+
 func resolveSandboxPath(cfg env.Config, rawPath string, cwd string) (resolvedSandboxPath, error) {
 	base := strings.TrimSpace(cwd)
 	if base == "" {
@@ -111,6 +132,7 @@ func resolveSandboxPath(cfg env.Config, rawPath string, cwd string) (resolvedSan
 	} else {
 		cleaned = filepath.Clean(filepath.Join(base, candidate))
 	}
+	cleaned = mapVirtualWorkspacePath(cfg, cleaned)
 
 	if cfg.Fence {
 		if err := ensureWithinRoot(cfg.WorkspaceDir, cleaned); err != nil {

--- a/apps/sandbox/rpc/helpers_fence_test.go
+++ b/apps/sandbox/rpc/helpers_fence_test.go
@@ -51,6 +51,43 @@ func TestResolveSandboxPathFence(t *testing.T) {
 	}
 }
 
+func TestResolveSandboxPathVirtualWorkspaceAlias(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("evalsymlinks root: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	cfg := env.Config{WorkspaceDir: root, Fence: true}
+	tests := []struct {
+		name string
+		raw  string
+		cwd  string
+		want string
+	}{
+		{name: "virtual root", raw: ".", cwd: "/workspace", want: root},
+		{name: "virtual child", raw: "/workspace/sub", cwd: root, want: filepath.Join(root, "sub")},
+		{name: "relative from virtual cwd", raw: "sub", cwd: "/workspace", want: filepath.Join(root, "sub")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveSandboxPath(cfg, tt.raw, tt.cwd)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.path != tt.want {
+				t.Fatalf("path mismatch: got %q want %q", got.path, tt.want)
+			}
+		})
+	}
+
+	if _, err := resolveSandboxPath(cfg, "/workspace/../outside", root); err == nil {
+		t.Fatalf("expected cleaned virtual escape to be denied")
+	}
+}
+
 func TestResolveSandboxPathSymlinkEscape(t *testing.T) {
 	root, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {


### PR DESCRIPTION
Local (fenced) sandboxes run against the user's real host directory, but the agent always addresses tools with the virtual /workspace path. The fence check rejected those absolute paths as escaping the root, so fs/process RPCs failed with ACCESS_DENIED (path escapes sandbox root).

Map /workspace and /workspace/* back to the configured WorkspaceDir before the fence check when fencing is enabled and the root differs from /workspace. Cloud (unfenced) sandboxes are unaffected, and traversal escapes are still rejected.

Add coverage for virtual-root, virtual-child, virtual-cwd relative paths, and a cleaned virtual escape.