### PR TITLE
Unify billing gate 402 responses across the stack

### DIFF
--- a/.changeset/unify-billing-402.md
+++ b/.changeset/unify-billing-402.md
@@ -1,0 +1,6 @@
+---
+"@neta-art/cohub": minor
+"@neta-art/cohub-cli": patch
+---
+
+Unify billing gate responses. Every billing-gated 402 (negative balance limit and plan entitlement) now returns a flat `{ code, message, billing: { conversion, status?, netUsd?, hardNegativeLimitUsd? } }` body, and soft debt warnings ride the same `billing` payload on success responses. The SDK adds `BILLING_ACCESS_BLOCKED_ERROR_CODE`, `isBillingAccessBlockedError`, `isBillingAccessBlockedCode`, `extractBillingPayload`, and a `BillingResponsePayload` type so clients extract the conversion intent with one call. Websocket `session.request.error` events now carry the same `billing` payload. The CLI surfaces the conversion title/message on 402.

--- a/apps/api/src/lib/billing-blocked.ts
+++ b/apps/api/src/lib/billing-blocked.ts
@@ -1,0 +1,7 @@
+import type { Context } from "hono";
+import { serializeBillingBlocked, type BillingAccessBlockedError } from "@cohub/billing";
+
+/** Standard 402 response for a blocked usage gate (negative balance limit). */
+export function billingBlockedResponse(c: Context, error: BillingAccessBlockedError) {
+  return c.json(serializeBillingBlocked(error), 402);
+}

--- a/apps/api/src/routes/generations.route.ts
+++ b/apps/api/src/routes/generations.route.ts
@@ -1,8 +1,9 @@
-import { BillingAccessBlockedError, billingOperations, createBillingUsageGate } from "@cohub/billing";
+import { BillingAccessBlockedError, billingOperations, createBillingUsageGate, serializeBillingWarning } from "@cohub/billing";
 import { Hono, type Context } from "hono";
 import { createGenerationClient, GenerationValidationError } from "@neta-art/generation";
 import { GENERATION_TASK_TYPE, type CreateGenerationTaskResponse } from "@cohub/protocol/generation";
 import { useAuth, authzDenied } from "../lib/middleware.js";
+import { billingBlockedResponse } from "../lib/billing-blocked.js";
 import { hasPermission } from "../permissions.js";
 import { loadGenerationDeclaration } from "../generations/declarations.js";
 import { createGenerationTaskRequestSchema } from "../generations/schema.js";
@@ -25,7 +26,7 @@ const billingUsageGate = createBillingUsageGate({
 type ErrorStatus = 400 | 401 | 402 | 403 | 404 | 409 | 413 | 422 | 500 | 502 | 503;
 
 function generationError(c: Context, status: ErrorStatus, code: string, message: string, details?: unknown) {
-  return c.json({ error: { code, message, ...(details === undefined ? {} : { details }) } }, status);
+  return c.json({ code, message, ...(details === undefined ? {} : { details }) }, status);
 }
 
 function zodDetails(error: { issues: Array<{ path: PropertyKey[]; message: string }> }) {
@@ -33,17 +34,6 @@ function zodDetails(error: { issues: Array<{ path: PropertyKey[]; message: strin
     path: issue.path.map(String).join("."),
     message: issue.message,
   }));
-}
-
-function generationBillingBlocked(c: Context, error: BillingAccessBlockedError) {
-  return generationError(c, 402, error.code, error.message, {
-    decision: {
-      status: error.decision.status,
-      netUsd: error.decision.netUsd,
-      hardNegativeLimitUsd: error.decision.hardNegativeLimitUsd,
-    },
-    conversion: error.decision.conversion,
-  });
 }
 
 router.post("/", async (c) => {
@@ -110,7 +100,7 @@ router.post("/", async (c) => {
     turnId,
   });
   if (billingDecision.status === "blocked") {
-    return generationBillingBlocked(c, new BillingAccessBlockedError(billingDecision));
+    return billingBlockedResponse(c, new BillingAccessBlockedError(billingDecision));
   }
 
   let taskRunId: string;
@@ -146,8 +136,8 @@ router.post("/", async (c) => {
     taskRunId,
     taskType: GENERATION_TASK_TYPE,
     status: "pending",
-    billing: billingDecision.status === "allowed_with_debt" ? billingDecision : null,
-  } satisfies CreateGenerationTaskResponse & { billing?: typeof billingDecision | null }, 202);
+    billing: serializeBillingWarning(billingDecision),
+  } satisfies CreateGenerationTaskResponse, 202);
 });
 
 export default router;

--- a/apps/api/src/routes/internal/spaces.route.ts
+++ b/apps/api/src/routes/internal/spaces.route.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "@cohub/infra/logging";
 import { Hono } from "hono";
+import { BillingAccessBlockedError, serializeBillingBlocked } from "@cohub/billing";
 import { attachSandboxPublicEndpoints } from "../../sandbox-public-network.js";
 import type {
   PersistMessageInput,
@@ -453,6 +454,7 @@ router.post("/:spaceId/sessions/:sessionId/prompt", async (c) => {
     return c.json({ ok: true, ...result });
   } catch (error) {
     if (error instanceof SandboxNotReadyError) return c.json({ message: "sandbox is not ready" }, 503);
+    if (error instanceof BillingAccessBlockedError) return c.json(serializeBillingBlocked(error), 402);
     throw error as Error;
   }
 });

--- a/apps/api/src/routes/spaces/spaces.route.ts
+++ b/apps/api/src/routes/spaces/spaces.route.ts
@@ -62,6 +62,7 @@ import { prepareSpaceModInserts, spaceModErrorResponse, type CreateSpaceModInput
 import { parseChannelConfigPatch, mergeChannelConfig, validateChannelModelConfig } from "../../lib/channel-model-config.js";
 import { redisCommandClient } from "../../redis.js";
 import { featureGateResponse } from "../../lib/feature-gate.js";
+import { billingBlockedResponse } from "../../lib/billing-blocked.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -487,23 +488,6 @@ const hasExplicitTimezone = (value: string) => /(?:Z|[+-]\d{2}:\d{2})$/i.test(va
 function validatePromptContentBlocks(content: unknown): content is ContentBlock[] {
   if (!Array.isArray(content) || content.length === 0) return false;
   return content.every((block) => block && typeof block === "object" && !Array.isArray(block) && typeof (block as { type?: unknown }).type === "string");
-}
-
-function billingBlockedResponse(error: BillingAccessBlockedError) {
-  return {
-    error: {
-      code: error.code,
-      message: error.message,
-      details: {
-        decision: {
-          status: error.decision.status,
-          netUsd: error.decision.netUsd,
-          hardNegativeLimitUsd: error.decision.hardNegativeLimitUsd,
-        },
-        conversion: error.decision.conversion,
-      },
-    },
-  };
 }
 
 function promptInputError(error: unknown): string | null {
@@ -1896,7 +1880,7 @@ router.post("/:id/prompt", async (c) => {
       if (!response) return c.json({ message: "turn not found" }, 500);
       return c.json(response);
     } catch (error) {
-      if (error instanceof BillingAccessBlockedError) return c.json(billingBlockedResponse(error), 402);
+      if (error instanceof BillingAccessBlockedError) return billingBlockedResponse(c, error);
       if (error instanceof SandboxNotReadyError) return c.json({ message: "sandbox is not ready" }, 503);
       const inputError = promptInputError(error);
       if (inputError) return c.json({ message: inputError }, 400);

--- a/apps/api/src/session-turn-response.ts
+++ b/apps/api/src/session-turn-response.ts
@@ -1,4 +1,5 @@
 import type { SessionRecord } from "@cohub/protocol/model";
+import type { BillingResponsePayload } from "@cohub/billing";
 import { getSessionTurnById, hydrateTurnAuthorProfiles } from "./session-turns.js";
 
 type SessionRow = Omit<SessionRecord, "meta" | "lastMessageAt" | "createdAt" | "updatedAt"> & {
@@ -29,11 +30,17 @@ function toSessionRecord(session: SessionRow): SessionRecord {
   };
 }
 
-function extractBillingWarning(meta: unknown) {
+function extractBillingWarning(meta: unknown): BillingResponsePayload | null {
   const record = normalizeRecord(meta);
   const billing = normalizeRecord(record?.billing);
   if (billing?.status !== "allowed_with_debt") return null;
-  return billing;
+  if (!normalizeRecord(billing.conversion)) return null;
+  return {
+    status: "allowed_with_debt",
+    netUsd: typeof billing.netUsd === "number" ? billing.netUsd : 0,
+    hardNegativeLimitUsd: typeof billing.hardNegativeLimitUsd === "number" ? billing.hardNegativeLimitUsd : 0,
+    conversion: billing.conversion as BillingResponsePayload["conversion"],
+  };
 }
 
 export async function buildSessionTurnResponse(session: SessionRow, turnId: string) {

--- a/apps/gateway/src/api-client.ts
+++ b/apps/gateway/src/api-client.ts
@@ -3,6 +3,7 @@ import { AuthorizationError, verifyUserAccessToken } from "@cohub/identity";
 import { buildTraceHeaders, getTraceResponseHeaders, type TraceIdentifiers } from "@cohub/infra/tracing";
 import type { ContentBlock } from "@cohub/protocol/core";
 import type { RealtimeRoom } from "@cohub/protocol/realtime";
+import type { BillingPayload } from "@cohub/protocol";
 import type { GatewayAuthUser } from "./config.js";
 import { gatewayConfig } from "./config.js";
 
@@ -196,6 +197,27 @@ export const submitCanvasTransaction = async (input: {
   return { document: { version: data.document.version }, nodes: data.nodes };
 };
 
+/** Carries a standard billing error body from the internal prompt API. */
+export class InternalPromptError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly billing: BillingPayload | null,
+  ) {
+    super(message);
+    this.name = "InternalPromptError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isBillingErrorBody(value: unknown): value is { code: string; message?: string; billing: BillingPayload } {
+  if (!isRecord(value)) return false;
+  return typeof value.code === "string" && isRecord(value.billing);
+}
+
 export const submitInternalSessionPrompt = async (input: {
   spaceId: string;
   sessionId: string;
@@ -229,8 +251,12 @@ export const submitInternalSessionPrompt = async (input: {
   });
 
   if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    throw new Error(`Internal prompt submit failed ${response.status}: ${text}`);
+    const body = await parseJson<unknown>(response);
+    if (isBillingErrorBody(body)) {
+      throw new InternalPromptError(body.message ?? "prompt blocked", body.code, body.billing);
+    }
+    const message = isRecord(body) && typeof body.message === "string" ? body.message : null;
+    throw new Error(message ?? `Internal prompt submit failed ${response.status}`);
   }
   const data = await parseJson<{ ok?: boolean; turnId?: string; userMessageId?: string }>(response);
   if (!data?.ok || !data.turnId || !data.userMessageId) {

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -31,7 +31,7 @@ import {
   wsClientEventSchema,
 } from "@cohub/protocol/realtime";
 import { getOrCreateRequestId } from "@cohub/infra/tracing";
-import { authenticateRealtimeToken, authorizeRealtimeRooms, notifySpacePresenceUpdated, requestGatewayChannelReconcile, submitCanvasTransaction, submitInternalSessionPrompt, type RealtimeAuthResult } from "./api-client.js";
+import { authenticateRealtimeToken, authorizeRealtimeRooms, notifySpacePresenceUpdated, requestGatewayChannelReconcile, submitCanvasTransaction, submitInternalSessionPrompt, InternalPromptError, type RealtimeAuthResult } from "./api-client.js";
 import { listenOutboundCommands, initOutboundConsumerGroup } from "./bus.js";
 import { summarizeRedisUrl } from "./logging.js";
 import { gatewayConfig } from "./config.js";
@@ -972,6 +972,7 @@ async function main() {
           } catch (error) {
             if (error instanceof WsClientInputError) throw error;
             const payload = message.payload ?? {};
+            const isBillingError = error instanceof InternalPromptError;
             sendWsEnvelope(socket, buildRealtimeEnvelope({
               domain: "session",
               type: "session.request.error",
@@ -979,9 +980,10 @@ async function main() {
               spaceId: typeof payload.spaceId === "string" ? payload.spaceId : null,
               sessionId: typeof payload.sessionId === "string" ? payload.sessionId : null,
               payload: {
-                code: "SUBMIT_FAILED",
+                code: isBillingError ? error.code : "SUBMIT_FAILED",
                 message: error instanceof Error ? error.message : String(error),
                 clientMessageId: typeof payload.clientMessageId === "string" ? payload.clientMessageId : null,
+                billing: isBillingError ? error.billing : null,
               },
             }));
           }

--- a/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
+++ b/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
@@ -12,6 +12,7 @@ import type {
 import type { ChannelEnvelope } from "@cohub/protocol/realtime";
 import type { CanvasSemanticOp } from "@neta-art/cohub";
 import {
+	extractBillingPayload,
 	HttpError,
 	type Permission,
 	type SessionRecord,
@@ -3271,24 +3272,17 @@ async function handleWsEvent(payload: ChannelEnvelope) {
 				code?: string;
 				message?: string;
 				clientMessageId?: string | null;
+				billing?: { conversion?: unknown } | null;
 			};
 			const message = requestError.message?.trim() || "Message request failed";
 			const code =
 				typeof requestError.code === "string" ? requestError.code : null;
-			if (isBillingAccessBlockedCode(code)) {
-				billingConversion.openFromIntent({
-					level: "hard",
-					reason: "negative_balance_limit_exceeded",
-					audience: "unknown",
-					preferredOfferKind: "mixed",
-					title: "Add credits to continue",
-					message: "Add credits or choose a plan to resume AI requests.",
-					primaryAction: {
-						label: "Add credits now",
-						action: "open_billing_conversion",
-					},
-					source: "session_request_error",
-				});
+			const conversion =
+				extractBillingPayload(requestError)?.conversion ?? null;
+			if (conversion) {
+				billingConversion.openFromIntent(conversion);
+			} else if (isBillingAccessBlockedCode(code)) {
+				billingConversion.openFallbackHard();
 			}
 			failGeneration(targetSessionId, message, { errorCode: code });
 			if (isActiveSession) setComposerError(message, code);

--- a/apps/web/src/lib/stores/billing-conversion.svelte.ts
+++ b/apps/web/src/lib/stores/billing-conversion.svelte.ts
@@ -1,8 +1,13 @@
 import type {
-	BillingAccessWarning,
 	BillingConversionIntent,
+	BillingResponsePayload,
 } from "@neta-art/cohub";
-import { HttpError } from "@neta-art/cohub";
+import {
+	BILLING_ACCESS_BLOCKED_ERROR_CODE,
+	extractBillingPayload,
+	HttpError,
+	isBillingAccessBlockedCode,
+} from "@neta-art/cohub";
 
 type BillingConversionLevel = "soft" | "hard";
 
@@ -10,52 +15,22 @@ type BillingConversionState = {
 	open: boolean;
 	level: BillingConversionLevel | null;
 	intent: BillingConversionIntent | null;
-	warning: BillingAccessWarning | null;
+	warning: BillingResponsePayload | null;
 	dismissedSoftAt: number | null;
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return !!value && typeof value === "object" && !Array.isArray(value);
-}
-
-function isBillingConversionIntent(
-	value: unknown,
-): value is BillingConversionIntent {
-	return (
-		isRecord(value) &&
-		(value.level === "soft" || value.level === "hard") &&
-		typeof value.title === "string" &&
-		typeof value.message === "string" &&
-		isRecord(value.primaryAction) &&
-		value.primaryAction.action === "open_billing_conversion"
-	);
-}
-
 function extractIntentFromBody(body: unknown): BillingConversionIntent | null {
-	if (!isRecord(body)) return null;
-	const directBilling = isRecord(body.billing) ? body.billing : null;
-	if (isBillingConversionIntent(directBilling?.conversion)) {
-		return directBilling.conversion;
-	}
-	const error = isRecord(body.error) ? body.error : null;
-	const details = isRecord(error?.details) ? error.details : null;
-	if (isBillingConversionIntent(details?.conversion)) return details.conversion;
-	return null;
+	return extractBillingPayload(body)?.conversion ?? null;
 }
 
-function extractWarningFromBody(body: unknown): BillingAccessWarning | null {
-	if (!isRecord(body)) return null;
-	const billing = isRecord(body.billing) ? body.billing : null;
-	if (billing?.status !== "allowed_with_debt") return null;
-	if (!isBillingConversionIntent(billing.conversion)) return null;
-	return billing as BillingAccessWarning;
+function extractWarningFromBody(body: unknown): BillingResponsePayload | null {
+	const billing = extractBillingPayload(body);
+	return billing?.status === "allowed_with_debt" ? billing : null;
 }
 
-export const BILLING_ACCESS_BLOCKED_CODE = "billing_credit_limit_exceeded";
+export const BILLING_ACCESS_BLOCKED_CODE = BILLING_ACCESS_BLOCKED_ERROR_CODE;
 
-export function isBillingAccessBlockedCode(value: string | null | undefined) {
-	return value === BILLING_ACCESS_BLOCKED_CODE;
-}
+export { isBillingAccessBlockedCode };
 
 function defaultHardIntent(): BillingConversionIntent {
 	return {
@@ -115,7 +90,7 @@ class BillingConversionStore {
 		this.state.open = true;
 	}
 
-	showSoft(warning: BillingAccessWarning) {
+	showSoft(warning: BillingResponsePayload) {
 		this.state.warning = warning;
 		this.state.intent = warning.conversion;
 		this.state.level = "soft";

--- a/apps/worker/src/tasks/registry.ts
+++ b/apps/worker/src/tasks/registry.ts
@@ -1,4 +1,4 @@
-import { BillingAccessBlockedError } from "@cohub/billing";
+import { serializeBillingBlocked, isBillingAccessBlockedError } from "@cohub/billing";
 import type { Job } from "bullmq";
 import { recordJobFailure } from "@cohub/infra/bullmq";
 import type { TaskPayload } from "@cohub/protocol/task";
@@ -31,21 +31,8 @@ const registry = new Map<string, TaskHandler>();
  *   - On failure: update to failed (then rethrow for BullMQ retry)
  */
 function billingFailureResult(error: unknown) {
-  if (!(error instanceof BillingAccessBlockedError)) return null;
-  return {
-    error: {
-      code: error.code,
-      message: error.message,
-      details: {
-        decision: {
-          status: error.decision.status,
-          netUsd: error.decision.netUsd,
-          hardNegativeLimitUsd: error.decision.hardNegativeLimitUsd,
-        },
-        conversion: error.decision.conversion,
-      },
-    },
-  };
+  if (!isBillingAccessBlockedError(error)) return null;
+  return { error: serializeBillingBlocked(error) };
 }
 
 export const markTaskRunFailed = async (job: Job, error: unknown) => {

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -72,6 +72,8 @@ export type {
   BillingPreferredOfferKind,
 } from "./conversion.js";
 export { BillingAccessBlockedError, isBillingAccessBlockedError } from "./errors.js";
+export { serializeBillingBlocked, serializeBillingWarning } from "./response.js";
+export type { BillingErrorBody, BillingResponsePayload } from "./response.js";
 export { createBillingUsageGate } from "./usage-gate.js";
 export type {
   BillingAccessDecision,

--- a/packages/billing/src/response.ts
+++ b/packages/billing/src/response.ts
@@ -1,0 +1,54 @@
+import type { BillingConversionIntent } from "./conversion.js";
+import type { BillingAccessBlockedError } from "./errors.js";
+import type { BillingAccessDecision } from "./usage-gate.js";
+
+/**
+ * Standard billing payload attached under the `billing` key of any response
+ * that involves a billing gate. Present on 402 error bodies (blocked / not
+ * entitled) and on success bodies carrying a soft debt warning. `conversion`
+ * always drives the shared upgrade UI; balance fields appear only for
+ * balance-based gates.
+ */
+export type BillingResponsePayload = {
+  conversion: BillingConversionIntent;
+  status?: "blocked" | "allowed_with_debt";
+  netUsd?: number;
+  hardNegativeLimitUsd?: number;
+};
+
+/** Standard shape of a billing-gated error body (`code` + `message` + `billing`). */
+export type BillingErrorBody = {
+  code: string;
+  message: string;
+  billing: BillingResponsePayload;
+};
+
+/** Serializes a blocked usage-gate error into the standard 402 body. */
+export function serializeBillingBlocked(error: BillingAccessBlockedError): BillingErrorBody {
+  return {
+    code: error.code,
+    message: error.message,
+    billing: {
+      status: error.decision.status,
+      netUsd: error.decision.netUsd,
+      hardNegativeLimitUsd: error.decision.hardNegativeLimitUsd,
+      conversion: error.decision.conversion,
+    },
+  };
+}
+
+/**
+ * Serializes a soft debt warning into the standard `billing` payload for
+ * success responses. Returns `null` for any non-warning decision.
+ */
+export function serializeBillingWarning(
+  decision: BillingAccessDecision | null | undefined,
+): BillingResponsePayload | null {
+  if (decision?.status !== "allowed_with_debt") return null;
+  return {
+    status: decision.status,
+    netUsd: decision.netUsd,
+    hardNegativeLimitUsd: decision.hardNegativeLimitUsd,
+    conversion: decision.conversion,
+  };
+}

--- a/packages/billing/tests/response.test.ts
+++ b/packages/billing/tests/response.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { serializeBillingBlocked, serializeBillingWarning } from "../src/response.js";
+import { BillingAccessBlockedError } from "../src/errors.js";
+import type { BillingAccessDecision } from "../src/usage-gate.js";
+import { createBillingConversionIntent } from "../src/conversion.js";
+
+const conversion = createBillingConversionIntent({
+	level: "hard",
+	reason: "negative_balance_limit_exceeded",
+	source: "session_prompt",
+});
+
+test("serializeBillingBlocked produces the standard 402 body", () => {
+	const decision = {
+		status: "blocked",
+		code: "billing_credit_limit_exceeded",
+		balanceState: "negative",
+		netUsd: -5,
+		hardNegativeLimitUsd: -1,
+		conversion,
+	} satisfies Extract<BillingAccessDecision, { status: "blocked" }>;
+	const body = serializeBillingBlocked(new BillingAccessBlockedError(decision));
+	assert.equal(body.code, "billing_credit_limit_exceeded");
+	assert.equal(body.billing.status, "blocked");
+	assert.equal(body.billing.netUsd, -5);
+	assert.equal(body.billing.hardNegativeLimitUsd, -1);
+	assert.equal(body.billing.conversion, conversion);
+});
+
+test("serializeBillingWarning returns payload only for soft debt", () => {
+	const warning = {
+		status: "allowed_with_debt",
+		balanceState: "negative",
+		netUsd: -0.5,
+		hardNegativeLimitUsd: -1,
+		conversion,
+	} satisfies Extract<BillingAccessDecision, { status: "allowed_with_debt" }>;
+	const payload = serializeBillingWarning(warning);
+	assert.ok(payload);
+	assert.equal(payload.status, "allowed_with_debt");
+	assert.equal(payload.conversion, conversion);
+
+	assert.equal(serializeBillingWarning({ status: "allowed", balanceState: "zero", netUsd: 0 }), null);
+	assert.equal(serializeBillingWarning(null), null);
+});

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,4 +1,5 @@
 import process from "node:process";
+import { extractBillingPayload } from "@neta-art/cohub";
 
 // -- Table rendering ---------------------------------------------------------
 
@@ -67,9 +68,8 @@ export function error(msg: string, detail?: string): never {
 
 function errorMessageFromBody(body: unknown): string | null {
   if (!body || typeof body !== "object") return null;
-  const errorBody = body as { message?: unknown; error?: { message?: unknown } };
+  const errorBody = body as { message?: unknown };
   if (typeof errorBody.message === "string" && errorBody.message.trim()) return errorBody.message;
-  if (typeof errorBody.error?.message === "string" && errorBody.error.message.trim()) return errorBody.error.message;
   return null;
 }
 
@@ -79,10 +79,9 @@ function debugErrorMetaFromBody(body: unknown): string[] {
     code?: unknown;
     requestId?: unknown;
     traceId?: unknown;
-    error?: { code?: unknown };
   };
   const items: string[] = [];
-  const code = typeof errorBody.code === "string" ? errorBody.code : typeof errorBody.error?.code === "string" ? errorBody.error.code : null;
+  const code = typeof errorBody.code === "string" ? errorBody.code : null;
   if (code) items.push(code);
   if (typeof errorBody.requestId === "string") items.push(`requestId: ${errorBody.requestId}`);
   if (typeof errorBody.traceId === "string") items.push(`traceId: ${errorBody.traceId}`);
@@ -119,6 +118,21 @@ export function handleHttp(e: unknown): never {
 
   const status = (e as { status?: number }).status;
   const body = (e as { body?: unknown }).body;
+
+  if (status === 402) {
+    const conversion = extractBillingPayload(body)?.conversion as
+      | { title?: string; message?: string }
+      | undefined;
+    if (conversion) {
+      return error(
+        conversion.title || "Upgrade required",
+        [conversion.message, "Manage billing at your Cohub account settings."]
+          .filter(Boolean)
+          .join(" · "),
+      );
+    }
+  }
+
   const presentation = errorPresentationFromHttpError(e);
   const message = presentation?.message ?? errorMessageFromBody(body) ?? (e instanceof Error ? e.message : String(e));
   const fetchDetail = fetchFailureDetail(e);

--- a/packages/protocol/src/billing.ts
+++ b/packages/protocol/src/billing.ts
@@ -1,0 +1,16 @@
+/**
+ * Standard billing payload attached under the `billing` key of any response
+ * or realtime event that involves a billing gate. Present on 402 error bodies
+ * (blocked / not entitled), on success responses carrying a soft debt warning,
+ * and on realtime error events. `conversion` always drives the shared upgrade
+ * UI; balance fields appear only for balance-based gates.
+ *
+ * `conversion` is intentionally `unknown` here to keep the protocol layer free
+ * of a billing dependency — clients validate it against `BillingConversionIntent`.
+ */
+export type BillingPayload = {
+  conversion: unknown;
+  status?: "blocked" | "allowed_with_debt";
+  netUsd?: number;
+  hardNegativeLimitUsd?: number;
+};

--- a/packages/protocol/src/generation/index.ts
+++ b/packages/protocol/src/generation/index.ts
@@ -1,4 +1,5 @@
 import type { GenerationContentBlock, GenerationModelDeclaration } from "@neta-art/generation";
+import type { BillingPayload } from "../billing.js";
 export * from "./policy.js";
 
 export type {
@@ -27,6 +28,7 @@ export type CreateGenerationTaskResponse = {
   taskRunId: string;
   taskType: typeof GENERATION_TASK_TYPE;
   status: "pending";
+  billing?: BillingPayload | null;
 };
 
 export type GenerationTaskData = {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./attachments.js";
+export * from "./billing.js";
 export * from "./core/content.js";
 export * from "./core/usage.js";
 export * from "./model/session.js";

--- a/packages/protocol/src/realtime/types.ts
+++ b/packages/protocol/src/realtime/types.ts
@@ -1,4 +1,5 @@
 import type { ContentBlock } from "../core/content.js";
+import type { BillingPayload } from "../billing.js";
 import type { MessageRecord, SessionRecord, SessionTurnRecord } from "../model/session.js";
 import type { SessionTurnSummary } from "../model/turn.js";
 import type { TaskRunStatus } from "../task/index.js";
@@ -200,7 +201,7 @@ export type SessionRequestErrorEvent = {
   requestId?: string | null;
   spaceId?: string | null;
   sessionId?: string | null;
-  payload: { code?: string; message: string; clientMessageId?: string | null };
+  payload: { code?: string; message: string; clientMessageId?: string | null; billing?: BillingPayload | null };
 };
 
 export type RealtimePatchOperation =

--- a/packages/sdk/src/http-error.ts
+++ b/packages/sdk/src/http-error.ts
@@ -1,7 +1,11 @@
 import { HttpError } from "./transport.js";
+import type { BillingResponsePayload } from "./types.js";
 
 /** Shared HTTP error code for every plan entitlement gate (402). */
 export const FEATURE_NOT_ENTITLED_ERROR_CODE = "feature_not_entitled" as const;
+
+/** Shared HTTP error code for a blocked usage gate (negative balance limit, 402). */
+export const BILLING_ACCESS_BLOCKED_ERROR_CODE = "billing_credit_limit_exceeded" as const;
 
 export function isHttpErrorCode(error: unknown, code: string): error is HttpError & { code: string } {
   return error instanceof HttpError && error.code === code;
@@ -9,4 +13,41 @@ export function isHttpErrorCode(error: unknown, code: string): error is HttpErro
 
 export function isFeatureNotEntitledError(error: unknown): error is HttpError & { code: string } {
   return isHttpErrorCode(error, FEATURE_NOT_ENTITLED_ERROR_CODE);
+}
+
+export function isBillingAccessBlockedError(error: unknown): error is HttpError & { code: string } {
+  return isHttpErrorCode(error, BILLING_ACCESS_BLOCKED_ERROR_CODE);
+}
+
+export function isBillingAccessBlockedCode(code: string | null | undefined): boolean {
+  return code === BILLING_ACCESS_BLOCKED_ERROR_CODE;
+}
+
+type Record_ = Record<string, unknown>;
+const isRecord = (value: unknown): value is Record_ =>
+  !!value && typeof value === "object" && !Array.isArray(value);
+
+function isBillingConversionIntent(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    (value.level === "soft" || value.level === "hard") &&
+    typeof value.title === "string" &&
+    typeof value.message === "string" &&
+    isRecord(value.primaryAction) &&
+    value.primaryAction.action === "open_billing_conversion"
+  );
+}
+
+/**
+ * Extracts the standard `billing` payload from a response body, an
+ * `HttpError`, or a bare billing payload (e.g. a realtime error event's
+ * `billing` field). Returns `null` unless it carries a valid conversion
+ * intent.
+ */
+export function extractBillingPayload(source: unknown): BillingResponsePayload | null {
+  const root = source instanceof HttpError ? source.body : source;
+  if (!isRecord(root)) return null;
+  const billing = isRecord(root.billing) ? root.billing : root;
+  if (!isBillingConversionIntent(billing.conversion)) return null;
+  return billing as unknown as BillingResponsePayload;
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -19,7 +19,15 @@ export {
   createSessionGenerationStreamClient,
   parseAssistantMessageCommit,
 } from "./session-generation-stream.js";
-export { FEATURE_NOT_ENTITLED_ERROR_CODE, isFeatureNotEntitledError, isHttpErrorCode } from "./http-error.js";
+export {
+  BILLING_ACCESS_BLOCKED_ERROR_CODE,
+  FEATURE_NOT_ENTITLED_ERROR_CODE,
+  extractBillingPayload,
+  isBillingAccessBlockedCode,
+  isBillingAccessBlockedError,
+  isFeatureNotEntitledError,
+  isHttpErrorCode,
+} from "./http-error.js";
 export { HttpError } from "./transport.js";
 export {
   GenerationPolicyError,

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -18,9 +18,8 @@ const responseBodyForError = async (response: Response) => {
 const messageFromErrorBody = (body: unknown, fallback: string) => {
   if (typeof body === "string") return body.trim() || fallback;
   if (body && typeof body === "object") {
-    const errorBody = body as { message?: unknown; error?: { message?: unknown } };
+    const errorBody = body as { message?: unknown };
     if (typeof errorBody.message === "string" && errorBody.message.trim()) return errorBody.message;
-    if (typeof errorBody.error?.message === "string" && errorBody.error.message.trim()) return errorBody.error.message;
   }
   return fallback;
 };
@@ -49,9 +48,8 @@ export type CohubClientOptions = {
 
 function errorCodeFromBody(body: unknown): string | null {
   if (!body || typeof body !== "object") return null;
-  const errorBody = body as { code?: unknown; error?: { code?: unknown } };
+  const errorBody = body as { code?: unknown };
   if (typeof errorBody.code === "string" && errorBody.code.trim()) return errorBody.code;
-  if (typeof errorBody.error?.code === "string" && errorBody.error.code.trim()) return errorBody.error.code;
   return null;
 }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -388,12 +388,15 @@ export type BillingConversionIntent = {
   source: string;
 };
 
-export type BillingAccessWarning = {
-  status: "allowed_with_debt";
-  balanceState: "negative";
-  netUsd: number;
-  hardNegativeLimitUsd: number;
+/**
+ * Standard `billing` payload on 402 error bodies and soft-warning success
+ * responses. `conversion` drives the shared upgrade UI.
+ */
+export type BillingResponsePayload = {
   conversion: BillingConversionIntent;
+  status?: "blocked" | "allowed_with_debt";
+  netUsd?: number;
+  hardNegativeLimitUsd?: number;
 };
 
 export type BillingBalanceActivityKind =
@@ -812,7 +815,7 @@ export type SessionTurnWindowResponse = {
 export type SessionTurnResponse = {
   session: SessionRecord;
   turn: SessionTurnRecord;
-  billing?: BillingAccessWarning | null;
+  billing?: BillingResponsePayload | null;
 };
 
 export type SessionTurnSignedUrlsResponse = {

--- a/packages/sdk/src/websocket.ts
+++ b/packages/sdk/src/websocket.ts
@@ -12,6 +12,8 @@ import {
 } from "@cohub/protocol/realtime/types";
 import type { ContentBlock } from "@cohub/protocol/core";
 import type { CohubEnvironment } from "./environment.js";
+import { extractBillingPayload } from "./http-error.js";
+import type { BillingResponsePayload } from "./types.js";
 import { resolveWebsocketUrl } from "./environment.js";
 
 export type WebsocketEventPayload = ChannelEnvelope;
@@ -68,6 +70,7 @@ export type WebsocketClientEvents = {
     sessionId?: string | null;
     spaceId?: string | null;
     clientMessageId?: string | null;
+    billing?: BillingResponsePayload | null;
   };
   subscribed: { rooms: RealtimeRoom[]; requestId?: string | null };
   subscribeError: { rejected: Array<{ room: string; code: string; message: string }>; requestId?: string | null };
@@ -669,6 +672,7 @@ export class WebsocketClient {
           spaceId: envelope.spaceId ?? null,
           clientMessageId:
             typeof payload.clientMessageId === "string" ? payload.clientMessageId : null,
+          billing: extractBillingPayload(payload.billing),
         });
         this.emit("event", envelope);
         return;

--- a/packages/sdk/tests/billing-error.test.ts
+++ b/packages/sdk/tests/billing-error.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+	BILLING_ACCESS_BLOCKED_ERROR_CODE,
+	FEATURE_NOT_ENTITLED_ERROR_CODE,
+	extractBillingPayload,
+	isBillingAccessBlockedCode,
+	isBillingAccessBlockedError,
+	isFeatureNotEntitledError,
+} from "../src/http-error.js";
+import { HttpError } from "../src/transport.js";
+
+const conversion = {
+	level: "hard",
+	reason: "negative_balance_limit_exceeded",
+	audience: "unknown",
+	preferredOfferKind: "mixed",
+	title: "Add credits to continue",
+	message: "Add credits to resume AI requests.",
+	primaryAction: { label: "Add credits", action: "open_billing_conversion" },
+	source: "session_prompt",
+};
+
+test("extractBillingPayload reads standard blocked body", () => {
+	const body = {
+		code: BILLING_ACCESS_BLOCKED_ERROR_CODE,
+		message: "Add credits to continue.",
+		billing: { status: "blocked", netUsd: -3, hardNegativeLimitUsd: -1, conversion },
+	};
+	const payload = extractBillingPayload(body);
+	assert.ok(payload);
+	assert.equal(payload.status, "blocked");
+	assert.equal(payload.conversion.title, "Add credits to continue");
+});
+
+test("extractBillingPayload reads from HttpError", () => {
+	const error = new HttpError("blocked", 402, {
+		code: BILLING_ACCESS_BLOCKED_ERROR_CODE,
+		message: "blocked",
+		billing: { status: "blocked", conversion },
+	});
+	const payload = extractBillingPayload(error);
+	assert.ok(payload);
+	assert.equal(payload.status, "blocked");
+});
+
+test("extractBillingPayload reads a bare billing payload (realtime event)", () => {
+	const payload = extractBillingPayload({ status: "blocked", netUsd: -2, conversion });
+	assert.ok(payload);
+	assert.equal(payload.status, "blocked");
+	assert.equal(payload.conversion.title, "Add credits to continue");
+});
+
+test("extractBillingPayload rejects body without a valid conversion", () => {
+	assert.equal(extractBillingPayload({ billing: { status: "blocked" } }), null);
+	assert.equal(extractBillingPayload({ message: "nope" }), null);
+	assert.equal(extractBillingPayload(null), null);
+});
+
+test("feature gate body extracts its conversion", () => {
+	const body = {
+		code: FEATURE_NOT_ENTITLED_ERROR_CODE,
+		message: "Upgrade required.",
+		billing: { conversion: { ...conversion, reason: "feature_not_entitled" } },
+	};
+	const payload = extractBillingPayload(body);
+	assert.ok(payload);
+	assert.equal(payload.status, undefined);
+	assert.equal(payload.conversion.reason, "feature_not_entitled");
+});
+
+test("error code helpers classify HttpError instances", () => {
+	const blocked = new HttpError("x", 402, { code: BILLING_ACCESS_BLOCKED_ERROR_CODE });
+	const gate = new HttpError("x", 402, { code: FEATURE_NOT_ENTITLED_ERROR_CODE });
+	assert.equal(isBillingAccessBlockedError(blocked), true);
+	assert.equal(isBillingAccessBlockedError(gate), false);
+	assert.equal(isFeatureNotEntitledError(gate), true);
+	assert.equal(isBillingAccessBlockedCode(BILLING_ACCESS_BLOCKED_ERROR_CODE), true);
+	assert.equal(isBillingAccessBlockedCode(null), false);
+});


### PR DESCRIPTION
All billing-gated 402s (negative balance limit and plan entitlement) now return a flat { code, message, billing } body, and soft debt warnings ride the same billing payload on success responses. Adds a shared serializer in @cohub/billing, a protocol-level BillingPayload type, SDK helpers (isBillingAccessBlockedError, extractBillingPayload, etc.), and surfaces the billing payload on websocket session.request.error events. CLI shows the conversion title/message on 402.