### PR TITLE
fix(api): purge Work assets and CDN on cleanup

### DIFF
--- a/.github/workflows/api-docker-build-push.yml
+++ b/.github/workflows/api-docker-build-push.yml
@@ -142,6 +142,37 @@ jobs:
           mkdir -p ~/.kube
           echo "${{ secrets.KUBECONFIG_DEV }}" | base64 -d > ~/.kube/config
 
+      - name: Wait for compatible system Worker when required
+        run: |
+          BASE_SHA="${{ github.event.before }}"
+          HEAD_SHA="${{ github.sha }}"
+          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            BASE_SHA="HEAD~1"
+          fi
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- \
+            'apps/worker/src/system/jobs/work-publish-asset/**' \
+            'apps/worker/src/system/jobs/work-asset-cleanup/**' \
+            'apps/worker/src/config.ts' \
+            'packages/infra/src/bullmq/index.ts' 2>/dev/null || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No Worker protocol change in this push"
+            exit 0
+          fi
+
+          EXPECTED=${{ env.REGISTRY }}/${{ env.NAMESPACE }}/cohub-worker:${{ env.IMAGE_TAG }}
+          for attempt in $(seq 1 180); do
+            ACTUAL=$(kubectl get deployment/cohub-system-worker-dev -n cohub-dev \
+              -o jsonpath='{.spec.template.spec.containers[?(@.name=="system-worker")].image}')
+            if [ "$ACTUAL" = "$EXPECTED" ]; then
+              kubectl rollout status deployment/cohub-system-worker-dev -n cohub-dev --timeout=300s
+              exit 0
+            fi
+            echo "Waiting for compatible system Worker image: expected=$EXPECTED actual=$ACTUAL"
+            sleep 10
+          done
+          echo "Compatible system Worker did not deploy before API timeout"
+          exit 1
+
       - name: Run migration if needed
         run: |
           BASE_SHA="${{ github.event.before }}"
@@ -232,6 +263,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup kubectl
         uses: azure/setup-kubectl@v3
@@ -242,6 +275,22 @@ jobs:
         run: |
           mkdir -p ~/.kube
           echo "${{ secrets.KUBECONFIG_PROD }}" | base64 -d > ~/.kube/config
+
+      - name: Wait for compatible system Worker
+        run: |
+          EXPECTED=${{ env.REGISTRY }}/${{ env.NAMESPACE }}/cohub-worker:${{ github.ref_name }}
+          for attempt in $(seq 1 180); do
+            ACTUAL=$(kubectl get deployment/cohub-system-worker -n cohub \
+              -o jsonpath='{.spec.template.spec.containers[?(@.name=="system-worker")].image}')
+            if [ "$ACTUAL" = "$EXPECTED" ]; then
+              kubectl rollout status deployment/cohub-system-worker -n cohub --timeout=300s
+              exit 0
+            fi
+            echo "Waiting for compatible system Worker image: expected=$EXPECTED actual=$ACTUAL"
+            sleep 10
+          done
+          echo "Compatible system Worker did not deploy before API timeout"
+          exit 1
 
       - name: Get tag
         id: get-tag

--- a/.github/workflows/worker-docker-build-push.yml
+++ b/.github/workflows/worker-docker-build-push.yml
@@ -10,6 +10,7 @@ on:
       - 'apps/worker/**'
       - 'deploy/worker/**'
       - 'packages/**'
+      - '.github/workflows/worker-docker-build-push.yml'
   workflow_dispatch:
     inputs:
       environment:

--- a/apps/api/drizzle/v2/0043_work_asset_reservations.sql
+++ b/apps/api/drizzle/v2/0043_work_asset_reservations.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "v2"."work_asset_reservations" (
+	"publish_job_id" varchar(160) PRIMARY KEY NOT NULL,
+	"asset_key" text NOT NULL,
+	"space_id" uuid NOT NULL,
+	"slug" varchar(80) NOT NULL,
+	"state" varchar(20) DEFAULT 'pending' NOT NULL,
+	"lease_expires_at" timestamp with time zone NOT NULL,
+	"claimant" varchar(160),
+	"writer_id" varchar(160),
+	"writer_lease_expires_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now(),
+	CONSTRAINT "v2_chk_work_asset_reservations_state" CHECK ("v2"."work_asset_reservations"."state" in ('pending', 'committed', 'abandoned', 'claimed', 'cleaned'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "v2_uq_work_asset_reservations_asset_key" ON "v2"."work_asset_reservations" USING btree ("asset_key");
+--> statement-breakpoint
+CREATE INDEX "v2_idx_work_asset_reservations_state_lease" ON "v2"."work_asset_reservations" USING btree ("state","lease_expires_at");
+--> statement-breakpoint
+CREATE INDEX "v2_idx_work_asset_reservations_writer_lease" ON "v2"."work_asset_reservations" USING btree ("writer_lease_expires_at");

--- a/apps/api/drizzle/v2/meta/0043_snapshot.json
+++ b/apps/api/drizzle/v2/meta/0043_snapshot.json
@@ -1,0 +1,6733 @@
+{
+  "id": "c814f9a4-f2a0-481b-bc99-931852c7a0bf",
+  "prevId": "94d4e163-406b-4531-9535-6b4f05fec8d4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "v2.access_policies": {
+      "name": "access_policies",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_in_user_role": {
+          "name": "signed_in_user_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_user_role": {
+          "name": "anonymous_user_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_access_policies_resource": {
+          "name": "v2_uq_access_policies_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_access_policies_resource": {
+          "name": "v2_idx_access_policies_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.canvas_checkpoint_snapshots": {
+      "name": "canvas_checkpoint_snapshots",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_space_id": {
+          "name": "source_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_file_path": {
+          "name": "source_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_checkpoint_snapshots_path": {
+          "name": "v2_uq_canvas_checkpoint_snapshots_path",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_checkpoint_snapshots_checkpoint_id": {
+          "name": "v2_idx_canvas_checkpoint_snapshots_checkpoint_id",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.canvas_documents": {
+      "name": "canvas_documents",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_canvas_documents_space_id": {
+          "name": "v2_idx_canvas_documents_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_canvas_documents_space_path": {
+          "name": "v2_uq_canvas_documents_space_path",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.canvas_nodes": {
+      "name": "canvas_nodes",
+      "schema": "v2",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 240
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 160
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ref_kind": {
+          "name": "ref_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_path": {
+          "name": "ref_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_url": {
+          "name": "ref_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view": {
+          "name": "view",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "style": {
+          "name": "style",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "animation": {
+          "name": "animation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_nodes_document_node": {
+          "name": "v2_uq_canvas_nodes_document_node",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_nodes_document_id": {
+          "name": "v2_idx_canvas_nodes_document_id",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_nodes_viewport": {
+          "name": "v2_idx_canvas_nodes_viewport",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "x",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "y",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_nodes_ref_path": {
+          "name": "v2_idx_canvas_nodes_ref_path",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.canvas_updates": {
+      "name": "canvas_updates",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "undo_group_id": {
+          "name": "undo_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_updates_document_version": {
+          "name": "v2_uq_canvas_updates_document_version",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_updates_document_id": {
+          "name": "v2_idx_canvas_updates_document_id",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.checkpoints": {
+      "name": "checkpoints",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_checkpoint_id": {
+          "name": "parent_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_checkpoint_id": {
+          "name": "root_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fork_count": {
+          "name": "fork_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "save_version": {
+          "name": "save_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_checkpoints_space_id": {
+          "name": "v2_idx_checkpoints_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_parent_id": {
+          "name": "v2_idx_checkpoints_parent_id",
+          "columns": [
+            {
+              "expression": "parent_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_root_id": {
+          "name": "v2_idx_checkpoints_root_id",
+          "columns": [
+            {
+              "expression": "root_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_description_trgm": {
+          "name": "v2_idx_checkpoints_description_trgm",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_uq_checkpoints_space_commit": {
+          "name": "v2_uq_checkpoints_space_commit",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asia/Shanghai'"
+        },
+        "bull_job_key": {
+          "name": "bull_job_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_cron_jobs_user_uuid": {
+          "name": "v2_idx_cron_jobs_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_space_id": {
+          "name": "v2_idx_cron_jobs_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_enabled": {
+          "name": "v2_idx_cron_jobs_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_created_at": {
+          "name": "v2_idx_cron_jobs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.gateway_logs": {
+      "name": "gateway_logs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_payload": {
+          "name": "normalized_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'success'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_gateway_logs_channel": {
+          "name": "v2_idx_gateway_logs_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_gateway_logs_direction": {
+          "name": "v2_idx_gateway_logs_direction",
+          "columns": [
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_gateway_logs_created": {
+          "name": "v2_idx_gateway_logs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.generation_usage_stats_hourly": {
+      "name": "generation_usage_stats_hourly",
+      "schema": "v2",
+      "columns": {
+        "bucket_start_at": {
+          "name": "bucket_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_generation_usage_stats_hourly_bucket_dims": {
+          "name": "v2_uq_generation_usage_stats_hourly_bucket_dims",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usage_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_user_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_user_bucket",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_space_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_space_bucket",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_session_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_session_bucket",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_usage_type_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_usage_type_bucket",
+          "columns": [
+            {
+              "expression": "usage_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_provider_model_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_provider_model_bucket",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.label_assignments": {
+      "name": "label_assignments",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_ref": {
+          "name": "resource_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_label_assignments_label_resource": {
+          "name": "v2_uq_label_assignments_label_resource",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_label_rank": {
+          "name": "v2_idx_label_assignments_label_rank",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_scope_resource": {
+          "name": "v2_idx_label_assignments_scope_resource",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_scope_label": {
+          "name": "v2_idx_label_assignments_scope_label",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_session_label_resource": {
+          "name": "v2_idx_label_assignments_session_label_resource",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2\".\"label_assignments\".\"resource_type\" = 'session'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_resource_label": {
+          "name": "v2_idx_label_assignments_resource_label",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_resource_ref_trgm": {
+          "name": "v2_idx_label_assignments_resource_ref_trgm",
+          "columns": [
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.labels": {
+      "name": "labels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "system_key": {
+          "name": "system_key",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_labels_scope_rank": {
+          "name": "v2_idx_labels_scope_rank",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_labels_scope_parent": {
+          "name": "v2_idx_labels_scope_parent",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_labels_scope_parent_name": {
+          "name": "v2_uq_labels_scope_parent_name",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"parent_id\"::text, '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_labels_scope_system_key": {
+          "name": "v2_uq_labels_scope_system_key",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_labels_depth": {
+          "name": "v2_chk_labels_depth",
+          "value": "\"v2\".\"labels\".\"depth\" in (0, 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.proposals": {
+      "name": "proposals",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_checkpoint_id": {
+          "name": "source_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_space_id": {
+          "name": "target_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_branch_name": {
+          "name": "source_branch_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch_name": {
+          "name": "target_branch_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_pr_id": {
+          "name": "external_pr_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'open'"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_proposals_target_space_id": {
+          "name": "v2_idx_proposals_target_space_id",
+          "columns": [
+            {
+              "expression": "target_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_proposals_source_checkpoint_id": {
+          "name": "v2_idx_proposals_source_checkpoint_id",
+          "columns": [
+            {
+              "expression": "source_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_proposals_status": {
+          "name": "v2_idx_proposals_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.provider_message_refs": {
+      "name": "provider_message_refs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_session_id": {
+          "name": "space_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_channel_id": {
+          "name": "space_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_message_id": {
+          "name": "session_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_conversation_id": {
+          "name": "external_conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_external_conversation_id": {
+          "name": "parent_external_conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_external_message_id": {
+          "name": "parent_external_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_author_id": {
+          "name": "external_author_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_author_name": {
+          "name": "external_author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_provider_message_refs_provider_conversation": {
+          "name": "v2_idx_provider_message_refs_provider_conversation",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_provider_message_refs_provider_message": {
+          "name": "v2_uq_provider_message_refs_provider_message",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_space_session": {
+          "name": "v2_idx_provider_message_refs_space_session",
+          "columns": [
+            {
+              "expression": "space_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_session_message": {
+          "name": "v2_idx_provider_message_refs_session_message",
+          "columns": [
+            {
+              "expression": "session_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_parent_message": {
+          "name": "v2_idx_provider_message_refs_parent_message",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_space_channel": {
+          "name": "v2_idx_provider_message_refs_space_channel",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.referral_codes": {
+      "name": "referral_codes",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_referral_codes_code": {
+          "name": "v2_uq_referral_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_referral_codes_active_user": {
+          "name": "v2_uq_referral_codes_active_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2\".\"referral_codes\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referral_codes_user": {
+          "name": "v2_idx_referral_codes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.referrals": {
+      "name": "referrals",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referral_code_id": {
+          "name": "referral_code_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_user_id": {
+          "name": "inviter_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_user_id": {
+          "name": "invitee_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "qualified_at": {
+          "name": "qualified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewarded_at": {
+          "name": "rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_rewarded_at": {
+          "name": "inviter_rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitee_rewarded_at": {
+          "name": "invitee_rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_reward_amount_usd": {
+          "name": "inviter_reward_amount_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_reward_amount_usd": {
+          "name": "invitee_reward_amount_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_error": {
+          "name": "reward_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_attempted_at": {
+          "name": "reward_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_lease_token": {
+          "name": "reward_lease_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_lease_expires_at": {
+          "name": "reward_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_referrals_invitee": {
+          "name": "v2_uq_referrals_invitee",
+          "columns": [
+            {
+              "expression": "invitee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_inviter": {
+          "name": "v2_idx_referrals_inviter",
+          "columns": [
+            {
+              "expression": "inviter_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_code": {
+          "name": "v2_idx_referrals_code",
+          "columns": [
+            {
+              "expression": "referral_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_qualified_retry": {
+          "name": "v2_idx_referrals_qualified_retry",
+          "columns": [
+            {
+              "expression": "reward_attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2\".\"referrals\".\"status\" = 'qualified'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.resource_references": {
+      "name": "resource_references",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_turn_id": {
+          "name": "source_turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_resource_references_target": {
+          "name": "v2_idx_resource_references_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_source": {
+          "name": "v2_idx_resource_references_source",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_space_kind": {
+          "name": "v2_idx_resource_references_space_kind",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_session_kind": {
+          "name": "v2_idx_resource_references_session_kind",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_turn": {
+          "name": "v2_idx_resource_references_turn",
+          "columns": [
+            {
+              "expression": "source_turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "v2_uq_resource_references_identity": {
+          "name": "v2_uq_resource_references_identity",
+          "nullsNotDistinct": true,
+          "columns": [
+            "kind",
+            "source_type",
+            "source_id",
+            "source_turn_id",
+            "target_type",
+            "target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_forks": {
+      "name": "session_forks",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_session_id": {
+          "name": "child_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_session_id": {
+          "name": "root_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_source_session_id": {
+          "name": "anchor_source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_turn_id": {
+          "name": "anchor_turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_sequence": {
+          "name": "anchor_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_session_ids": {
+          "name": "ancestor_session_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_path": {
+          "name": "session_path",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_session_forks_child": {
+          "name": "v2_uq_session_forks_child",
+          "columns": [
+            {
+              "expression": "child_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_parent": {
+          "name": "v2_idx_session_forks_parent",
+          "columns": [
+            {
+              "expression": "parent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_root_depth": {
+          "name": "v2_idx_session_forks_root_depth",
+          "columns": [
+            {
+              "expression": "root_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_anchor_turn": {
+          "name": "v2_idx_session_forks_anchor_turn",
+          "columns": [
+            {
+              "expression": "anchor_turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_messages": {
+      "name": "session_messages",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_aggregated_at": {
+          "name": "usage_aggregated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_session_messages_session_id": {
+          "name": "v2_idx_session_messages_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_messages_session_sequence": {
+          "name": "v2_uq_session_messages_session_sequence",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_messages_session_id_idempotency_key": {
+          "name": "v2_uq_session_messages_session_id_idempotency_key",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_turn_segments": {
+      "name": "session_turn_segments",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_sequence": {
+          "name": "from_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_sequence": {
+          "name": "to_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_session_turn_segments_session_ordinal": {
+          "name": "v2_uq_session_turn_segments_session_ordinal",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turn_segments_session": {
+          "name": "v2_idx_session_turn_segments_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turn_segments_source": {
+          "name": "v2_idx_session_turn_segments_source",
+          "columns": [
+            {
+              "expression": "source_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_turns": {
+      "name": "session_turns",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "intent": {
+          "name": "intent",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'steer'"
+        },
+        "user_content": {
+          "name": "user_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_text": {
+          "name": "user_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_content": {
+          "name": "assistant_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_text": {
+          "name": "assistant_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_usage": {
+          "name": "final_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_usage": {
+          "name": "total_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intermediate_index": {
+          "name": "intermediate_index",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intermediate_summary": {
+          "name": "intermediate_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_session_turns_session_id": {
+          "name": "v2_idx_session_turns_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_turns_session_sequence": {
+          "name": "v2_uq_session_turns_session_sequence",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_user_uuid": {
+          "name": "v2_idx_session_turns_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_created_at": {
+          "name": "v2_idx_session_turns_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_user_text_trgm": {
+          "name": "v2_idx_session_turns_user_text_trgm",
+          "columns": [
+            {
+              "expression": "user_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_channels": {
+      "name": "space_channels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_channels_space": {
+          "name": "v2_idx_space_channels_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_channels_channel": {
+          "name": "v2_uq_space_channels_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_commerce_businesses": {
+      "name": "space_commerce_businesses",
+      "schema": "v2",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_business_key": {
+          "name": "billing_business_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_commerce_businesses_business_key": {
+          "name": "v2_uq_space_commerce_businesses_business_key",
+          "columns": [
+            {
+              "expression": "billing_business_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_marks": {
+      "name": "space_marks",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_ref": {
+          "name": "resource_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_marks_resource": {
+          "name": "v2_uq_space_marks_resource",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_marks_space_kind_rank": {
+          "name": "v2_idx_space_marks_space_kind_rank",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_marks_space_resource": {
+          "name": "v2_idx_space_marks_space_resource",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_members": {
+      "name": "space_members",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_members_space_user": {
+          "name": "v2_uq_space_members_space_user",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_space": {
+          "name": "v2_idx_space_members_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_user": {
+          "name": "v2_idx_space_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_user_space": {
+          "name": "v2_idx_space_members_user_space",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_space_role": {
+          "name": "v2_idx_space_members_space_role",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_mods": {
+      "name": "space_mods",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mod_space_id": {
+          "name": "mod_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mount_slug": {
+          "name": "mount_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_mods_space_id": {
+          "name": "v2_idx_space_mods_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_mods_mod_space_id": {
+          "name": "v2_idx_space_mods_mod_space_id",
+          "columns": [
+            {
+              "expression": "mod_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_mods_space_mod": {
+          "name": "v2_uq_space_mods_space_mod",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mod_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_mods_space_mount_slug": {
+          "name": "v2_uq_space_mods_space_mount_slug",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mount_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_sandboxes": {
+      "name": "space_sandboxes",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloud'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "runtime_status": {
+          "name": "runtime_status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "pod_name": {
+          "name": "pod_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_image": {
+          "name": "desired_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_image_version": {
+          "name": "reported_image_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_sandboxes_space_id": {
+          "name": "v2_uq_space_sandboxes_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_status": {
+          "name": "v2_idx_space_sandboxes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_desired_image": {
+          "name": "v2_idx_space_sandboxes_desired_image",
+          "columns": [
+            {
+              "expression": "desired_image",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_reported_image_version": {
+          "name": "v2_idx_space_sandboxes_reported_image_version",
+          "columns": [
+            {
+              "expression": "reported_image_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_last_heartbeat_at": {
+          "name": "v2_idx_space_sandboxes_last_heartbeat_at",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_last_activity_at": {
+          "name": "v2_idx_space_sandboxes_last_activity_at",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_runtime_status": {
+          "name": "v2_idx_space_sandboxes_runtime_status",
+          "columns": [
+            {
+              "expression": "runtime_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_stopped_at": {
+          "name": "v2_idx_space_sandboxes_stopped_at",
+          "columns": [
+            {
+              "expression": "stopped_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_space_sandboxes_provider": {
+          "name": "v2_chk_space_sandboxes_provider",
+          "value": "\"v2\".\"space_sandboxes\".\"provider\" in ('cloud', 'local')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.space_session_bindings": {
+      "name": "space_session_bindings",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_session_id": {
+          "name": "space_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_channel_id": {
+          "name": "space_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_key": {
+          "name": "binding_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_space_session_bindings_space": {
+          "name": "v2_idx_space_session_bindings_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_session": {
+          "name": "v2_idx_space_session_bindings_session",
+          "columns": [
+            {
+              "expression": "space_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_channel": {
+          "name": "v2_idx_space_session_bindings_channel",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_binding_key": {
+          "name": "v2_idx_space_session_bindings_binding_key",
+          "columns": [
+            {
+              "expression": "binding_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_external_chat": {
+          "name": "v2_idx_space_session_bindings_external_chat",
+          "columns": [
+            {
+              "expression": "external_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_session_bindings_channel_binding": {
+          "name": "v2_uq_space_session_bindings_channel_binding",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_sessions": {
+      "name": "space_sessions",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "external_session_id": {
+          "name": "external_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_message_text": {
+          "name": "latest_message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_id": {
+          "name": "last_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_sessions_space_id": {
+          "name": "v2_idx_space_sessions_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_user_uuid": {
+          "name": "v2_idx_space_sessions_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_last_message_id": {
+          "name": "v2_idx_space_sessions_last_message_id",
+          "columns": [
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_last_message_at": {
+          "name": "v2_idx_space_sessions_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_title_trgm": {
+          "name": "v2_idx_space_sessions_title_trgm",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_space_sessions_latest_message_text_trgm": {
+          "name": "v2_idx_space_sessions_latest_message_text_trgm",
+          "columns": [
+            {
+              "expression": "latest_message_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_space_sessions_space_last_message_id": {
+          "name": "v2_idx_space_sessions_space_last_message_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_user_last_message": {
+          "name": "v2_idx_space_sessions_user_last_message",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_participant_user_uuids": {
+          "name": "v2_idx_space_sessions_participant_user_uuids",
+          "columns": [
+            {
+              "expression": "(\"meta\" -> 'participants' -> 'userUuids')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.spaces": {
+      "name": "spaces",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_repo_name": {
+          "name": "storage_repo_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_checkpoint_id": {
+          "name": "base_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_checkpoint_id": {
+          "name": "head_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_spaces_user_uuid": {
+          "name": "v2_idx_spaces_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_base_checkpoint_id": {
+          "name": "v2_idx_spaces_base_checkpoint_id",
+          "columns": [
+            {
+              "expression": "base_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_head_checkpoint_id": {
+          "name": "v2_idx_spaces_head_checkpoint_id",
+          "columns": [
+            {
+              "expression": "head_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_last_activity_at": {
+          "name": "v2_idx_spaces_last_activity_at",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_name_trgm": {
+          "name": "v2_idx_spaces_name_trgm",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_spaces_description_trgm": {
+          "name": "v2_idx_spaces_description_trgm",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_uq_spaces_user_name": {
+          "name": "v2_uq_spaces_user_name",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_spaces_user_slug": {
+          "name": "v2_uq_spaces_user_slug",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2\".\"spaces\".\"slug\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_spaces_storage_repo_name": {
+          "name": "v2_uq_spaces_storage_repo_name",
+          "columns": [
+            {
+              "expression": "storage_repo_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_spaces_slug_format": {
+          "name": "v2_chk_spaces_slug_format",
+          "value": "\"v2\".\"spaces\".\"slug\" is null or (length(\"v2\".\"spaces\".\"slug\") between 1 and 80 and \"v2\".\"spaces\".\"slug\" !~ '[^a-z0-9_-]' and left(\"v2\".\"spaces\".\"slug\", 1) ~ '[a-z0-9]' and right(\"v2\".\"spaces\".\"slug\", 1) ~ '[a-z0-9]')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.task_runs": {
+      "name": "task_runs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_task_runs_job_id": {
+          "name": "v2_uq_task_runs_job_id",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_cron_job_id": {
+          "name": "v2_idx_task_runs_cron_job_id",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_space_id": {
+          "name": "v2_idx_task_runs_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_session_id": {
+          "name": "v2_idx_task_runs_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_turn_id": {
+          "name": "v2_idx_task_runs_turn_id",
+          "columns": [
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_session_turn": {
+          "name": "v2_idx_task_runs_session_turn",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_user_uuid": {
+          "name": "v2_idx_task_runs_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_status": {
+          "name": "v2_idx_task_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_task_type": {
+          "name": "v2_idx_task_runs_task_type",
+          "columns": [
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_space_session_type_status_created": {
+          "name": "v2_idx_task_runs_space_session_type_status_created",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_user_session_type_status_created": {
+          "name": "v2_idx_task_runs_user_session_type_status_created",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_cron_job_status_created": {
+          "name": "v2_idx_task_runs_cron_job_status_created",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_created_at": {
+          "name": "v2_idx_task_runs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_scheduled_at": {
+          "name": "v2_idx_task_runs_scheduled_at",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.token_usage_stats_hourly": {
+      "name": "token_usage_stats_hourly",
+      "schema": "v2",
+      "columns": {
+        "bucket_start_at": {
+          "name": "bucket_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_cache_read": {
+          "name": "cost_cache_read",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_token_usage_stats_hourly_bucket_dims": {
+          "name": "v2_uq_token_usage_stats_hourly_bucket_dims",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_user_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_user_bucket",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_space_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_space_bucket",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_session_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_session_bucket",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_provider_model_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_provider_model_bucket",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_channels": {
+      "name": "user_channels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_user_channels_user_uuid": {
+          "name": "v2_idx_user_channels_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_channels_provider": {
+          "name": "v2_idx_user_channels_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_git_accounts": {
+      "name": "user_git_accounts",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gitea'"
+        },
+        "gitea_user_id": {
+          "name": "gitea_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_username": {
+          "name": "gitea_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_password_encrypted": {
+          "name": "gitea_password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_access_token_encrypted": {
+          "name": "gitea_access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_user_git_accounts_user_provider": {
+          "name": "v2_uq_user_git_accounts_user_provider",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_user_git_accounts_gitea_username": {
+          "name": "v2_uq_user_git_accounts_gitea_username",
+          "columns": [
+            {
+              "expression": "gitea_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_git_accounts_user_uuid": {
+          "name": "v2_idx_user_git_accounts_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_git_accounts_provider": {
+          "name": "v2_idx_user_git_accounts_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_profiles": {
+      "name": "user_profiles",
+      "schema": "v2",
+      "columns": {
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logto_user_id": {
+          "name": "logto_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_user_profiles_logto_user_id": {
+          "name": "v2_uq_user_profiles_logto_user_id",
+          "columns": [
+            {
+              "expression": "logto_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_profiles_updated_at": {
+          "name": "v2_idx_user_profiles_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_user_profiles_username": {
+          "name": "v2_uq_user_profiles_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.work_versions": {
+      "name": "work_versions",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ref": {
+          "name": "target_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_work_versions_work_id": {
+          "name": "v2_idx_work_versions_work_id",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_work_versions_work_version": {
+          "name": "v2_uq_work_versions_work_version",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.work_asset_reservations": {
+      "name": "work_asset_reservations",
+      "schema": "v2",
+      "columns": {
+        "publish_job_id": {
+          "name": "publish_job_id",
+          "type": "varchar(160)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimant": {
+          "name": "claimant",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writer_id": {
+          "name": "writer_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writer_lease_expires_at": {
+          "name": "writer_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_work_asset_reservations_asset_key": {
+          "name": "v2_uq_work_asset_reservations_asset_key",
+          "columns": [
+            {
+              "expression": "asset_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_work_asset_reservations_state_lease": {
+          "name": "v2_idx_work_asset_reservations_state_lease",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_work_asset_reservations_writer_lease": {
+          "name": "v2_idx_work_asset_reservations_writer_lease",
+          "columns": [
+            {
+              "expression": "writer_lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_work_asset_reservations_state": {
+          "name": "v2_chk_work_asset_reservations_state",
+          "value": "\"v2\".\"work_asset_reservations\".\"state\" in ('pending', 'committed', 'abandoned', 'claimed', 'cleaned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.work_viewer_grants": {
+      "name": "work_viewer_grants",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_user_uuid": {
+          "name": "viewer_user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_work_viewer_grants_work_id": {
+          "name": "v2_idx_work_viewer_grants_work_id",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_work_viewer_grants_space_id": {
+          "name": "v2_idx_work_viewer_grants_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_work_viewer_grants_viewer_user_uuid": {
+          "name": "v2_idx_work_viewer_grants_viewer_user_uuid",
+          "columns": [
+            {
+              "expression": "viewer_user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_work_viewer_grants_work_viewer": {
+          "name": "v2_uq_work_viewer_grants_work_viewer",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewer_user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.works": {
+      "name": "works",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ref": {
+          "name": "target_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_scopes": {
+          "name": "work_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_viewer_scopes": {
+          "name": "allowed_viewer_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_works_space_id": {
+          "name": "v2_idx_works_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_user_uuid": {
+          "name": "v2_idx_works_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_status": {
+          "name": "v2_idx_works_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_visibility": {
+          "name": "v2_idx_works_visibility",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_works_space_slug": {
+          "name": "v2_uq_works_space_slug",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_works_status": {
+          "name": "v2_chk_works_status",
+          "value": "\"v2\".\"works\".\"status\" in ('published', 'disabled')"
+        },
+        "v2_chk_works_visibility": {
+          "name": "v2_chk_works_visibility",
+          "value": "\"v2\".\"works\".\"visibility\" in ('public', 'space')"
+        },
+        "v2_chk_works_slug_format": {
+          "name": "v2_chk_works_slug_format",
+          "value": "length(\"v2\".\"works\".\"slug\") between 1 and 80 and \"v2\".\"works\".\"slug\" !~ '[^a-z0-9_-]' and left(\"v2\".\"works\".\"slug\", 1) ~ '[a-z0-9]' and right(\"v2\".\"works\".\"slug\", 1) ~ '[a-z0-9]'"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "v2": "v2"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/v2/meta/_journal.json
+++ b/apps/api/drizzle/v2/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1783833799122,
       "tag": "0042_glorious_sunspot",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1783932000000,
+      "tag": "0043_work_asset_reservations",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -39,6 +39,8 @@ export type AppConfig = {
   publicAssetOssSecretAccessKey?: string;
   publicAssetCdnBaseUrl?: string;
   workAssetCdnBaseUrl?: string;
+  workAssetCdnCloudflareZoneId?: string;
+  workAssetCdnCloudflareApiToken?: string;
   checkpointAssetOssEndpoint?: string;
   checkpointAssetOssPublicEndpoint?: string;
   checkpointAssetOssRegion: string;
@@ -158,6 +160,8 @@ export const config: AppConfig = {
   publicAssetOssSecretAccessKey: process.env.PUBLIC_ASSET_OSS_SECRET_ACCESS_KEY,
   publicAssetCdnBaseUrl: process.env.PUBLIC_ASSET_CDN_BASE_URL?.replace(/\/+$/, ""),
   workAssetCdnBaseUrl: process.env.WORK_ASSET_CDN_BASE_URL?.replace(/\/+$/, ""),
+  workAssetCdnCloudflareZoneId: process.env.WORK_ASSET_CDN_CLOUDFLARE_ZONE_ID,
+  workAssetCdnCloudflareApiToken: process.env.WORK_ASSET_CDN_CLOUDFLARE_API_TOKEN,
   checkpointAssetOssEndpoint: process.env.CHECKPOINT_ASSET_OSS_ENDPOINT ?? process.env.TURN_OBJECT_S3_ENDPOINT ?? "https://oss-us-west-1-internal.aliyuncs.com",
   checkpointAssetOssPublicEndpoint: process.env.CHECKPOINT_ASSET_OSS_PUBLIC_ENDPOINT ?? process.env.TURN_OBJECT_S3_PUBLIC_ENDPOINT,
   checkpointAssetOssRegion: process.env.CHECKPOINT_ASSET_OSS_REGION ?? process.env.TURN_OBJECT_S3_REGION ?? "us-west-1",

--- a/apps/api/src/routes/internal/index.ts
+++ b/apps/api/src/routes/internal/index.ts
@@ -3,6 +3,7 @@ import internalGatewayRouter from "./gateway.route.js";
 import internalCanvasRouter from "./canvas.route.js";
 import internalSpaceEventsRouter from "./space-events.route.js";
 import internalSpacesRouter from "./spaces.route.js";
+import internalWorksRouter from "./works.route.js";
 
 const router = new Hono();
 
@@ -10,5 +11,6 @@ router.route("/gateway", internalGatewayRouter);
 router.route("/space-events", internalSpaceEventsRouter);
 router.route("/spaces", internalSpacesRouter);
 router.route("/canvas", internalCanvasRouter);
+router.route("/works", internalWorksRouter);
 
 export default router;

--- a/apps/api/src/routes/internal/works.route.ts
+++ b/apps/api/src/routes/internal/works.route.ts
@@ -1,0 +1,240 @@
+import { Hono } from "hono";
+import { and, eq, inArray } from "drizzle-orm";
+import { works, workAssetReservations, workVersions } from "@cohub/db";
+import { createLogger } from "@cohub/infra/logging";
+import { config } from "../../config.js";
+import { db } from "../../db/index.js";
+import { ensureInternalRequest } from "../../lib/middleware.js";
+import { deleteWorkAssetsByObjectKeys } from "../../work-asset-storage.js";
+import {
+  getWorkAssetReservationCleanupDecision,
+  hasActiveWorkAssetWriterLease,
+  shouldDeferWorkAssetCleanupForReferences,
+} from "../../work-asset-reservation-state.js";
+import { WorkAssetCleanupError, collectWorkAssetKeys, excludeReferencedWorkAssetKeys } from "../work-delete.js";
+
+const logger = createLogger({ serviceName: "cohub-api" });
+const router = new Hono();
+const WRITER_LEASE_MS = 2 * 60_000;
+
+router.post("/writer-lease/:action", async (c) => {
+  const forbidden = ensureInternalRequest(c);
+  if (forbidden) return forbidden;
+  const action = c.req.param("action");
+  if (!new Set(["acquire", "heartbeat", "release"]).has(action)) {
+    return c.json({ ok: false, message: "writer lease action not found" }, 404);
+  }
+  const body = await c.req.json().catch(() => null) as {
+    publishJobId?: unknown;
+    writerId?: unknown;
+  } | null;
+  if (
+    typeof body?.publishJobId !== "string" ||
+    !body.publishJobId ||
+    typeof body.writerId !== "string" ||
+    !body.writerId
+  ) {
+    return c.json({ ok: false, message: "invalid work asset writer lease" }, 400);
+  }
+
+  if (action === "acquire") {
+    const result = await db.transaction(async (tx) => {
+      const [reservation] = await tx
+        .select()
+        .from(workAssetReservations)
+        .where(eq(workAssetReservations.publishJobId, body.publishJobId as string))
+        .limit(1)
+        .for("update");
+      if (!reservation) return "missing" as const;
+      if (reservation.state !== "pending") return "closed" as const;
+      if (
+        reservation.writerId !== null &&
+        reservation.writerId !== body.writerId &&
+        hasActiveWorkAssetWriterLease(reservation.writerLeaseExpiresAt, Date.now())
+      ) {
+        return "busy" as const;
+      }
+      await tx
+        .update(workAssetReservations)
+        .set({
+          writerId: body.writerId as string,
+          writerLeaseExpiresAt: new Date(Date.now() + WRITER_LEASE_MS),
+          updatedAt: new Date(),
+        })
+        .where(eq(workAssetReservations.publishJobId, reservation.publishJobId));
+      return "acquired" as const;
+    });
+    if (result !== "acquired") {
+      return c.json({ ok: false, message: `writer lease ${result}` }, result === "missing" ? 404 : 409);
+    }
+    return c.json({ ok: true, leaseMs: WRITER_LEASE_MS });
+  }
+
+  const writerConditions = [
+    eq(workAssetReservations.publishJobId, body.publishJobId),
+    eq(workAssetReservations.writerId, body.writerId),
+  ];
+  if (action === "heartbeat") {
+    writerConditions.push(inArray(workAssetReservations.state, ["pending", "abandoned"]));
+  }
+  const [reservation] = await db
+    .update(workAssetReservations)
+    .set({
+      writerId: action === "release" ? null : body.writerId,
+      writerLeaseExpiresAt: action === "release" ? null : new Date(Date.now() + WRITER_LEASE_MS),
+      updatedAt: new Date(),
+    })
+    .where(and(...writerConditions))
+    .returning({ publishJobId: workAssetReservations.publishJobId });
+  if (!reservation) return c.json({ ok: false, message: "writer lease lost" }, 409);
+  return c.json({ ok: true, leaseMs: action === "release" ? 0 : WRITER_LEASE_MS });
+});
+
+router.post("/cleanup-assets", async (c) => {
+  const forbidden = ensureInternalRequest(c);
+  if (forbidden) return forbidden;
+
+  const body = await c.req.json().catch(() => null) as {
+    assetKeys?: unknown;
+    scope?: { env?: unknown; spaceId?: unknown; slug?: unknown };
+    reason?: unknown;
+    publishJobId?: unknown;
+    deferWhileReferenced?: unknown;
+    claimant?: unknown;
+  } | null;
+  if (
+    !Array.isArray(body?.assetKeys) ||
+    body.assetKeys.length === 0 ||
+    body.assetKeys.some((assetKey) => typeof assetKey !== "string") ||
+    body.scope?.env !== config.env ||
+    typeof body.scope?.spaceId !== "string" ||
+    typeof body.scope.slug !== "string" ||
+    typeof body.reason !== "string" ||
+    !body.reason.trim() ||
+    (body.deferWhileReferenced !== undefined && typeof body.deferWhileReferenced !== "boolean") ||
+    (body.publishJobId !== undefined && (
+      typeof body.publishJobId !== "string" ||
+      !body.publishJobId ||
+      typeof body.claimant !== "string" ||
+      !body.claimant
+    ))
+  ) {
+    return c.json({ ok: false, message: "invalid work asset cleanup job" }, 400);
+  }
+
+  try {
+    const assetKeys = collectWorkAssetKeys(body.assetKeys as string[], {
+      env: config.env,
+      spaceId: body.scope.spaceId,
+      slug: body.scope.slug,
+    });
+    const reservationResult = typeof body.publishJobId === "string"
+      ? await db.transaction(async (tx) => {
+        const [reservation] = await tx
+          .select()
+          .from(workAssetReservations)
+          .where(eq(workAssetReservations.publishJobId, body.publishJobId as string))
+          .limit(1)
+          .for("update");
+        if (!reservation) return { action: "retry" as const, reason: "reservation_missing" };
+        if (
+          assetKeys.length !== 1 ||
+          reservation.assetKey !== assetKeys[0] ||
+          reservation.spaceId !== body.scope.spaceId ||
+          reservation.slug !== body.scope.slug
+        ) {
+          throw new WorkAssetCleanupError([
+            { assetKey: assetKeys[0] ?? "", message: "work asset reservation does not match cleanup scope" },
+          ]);
+        }
+        if (hasActiveWorkAssetWriterLease(reservation.writerLeaseExpiresAt, Date.now())) {
+          return { action: "retry" as const, reason: "writer_lease_active" };
+        }
+        const decision = getWorkAssetReservationCleanupDecision(
+          reservation.state,
+          reservation.leaseExpiresAt.getTime(),
+          Date.now(),
+        );
+        if (decision === "skip") return { action: "skip" as const };
+        if (decision === "retry") return { action: "retry" as const, reason: "reservation_pending" };
+        await tx
+          .update(workAssetReservations)
+          .set({
+            state: "claimed",
+            claimant: body.claimant as string,
+            writerId: null,
+            writerLeaseExpiresAt: null,
+            updatedAt: new Date(),
+          })
+          .where(eq(workAssetReservations.publishJobId, reservation.publishJobId));
+        return { action: "delete" as const, publishJobId: reservation.publishJobId };
+      })
+      : { action: "delete" as const, publishJobId: null };
+
+    if (reservationResult.action === "retry") {
+      return c.json({ ok: false, message: reservationResult.reason, code: "work_asset_cleanup_deferred" }, 409);
+    }
+    if (reservationResult.action === "skip") {
+      return c.json({ ok: true, deleted: 0, skippedReferenced: assetKeys.length });
+    }
+
+    const versionReferences = await db
+      .select({ assetKey: workVersions.assetKey })
+      .from(workVersions)
+      .where(inArray(workVersions.assetKey, assetKeys));
+    const workReferences = await db
+      .select({ assetKey: works.assetKey })
+      .from(works)
+      .where(inArray(works.assetKey, assetKeys));
+    const unreferencedAssetKeys = excludeReferencedWorkAssetKeys(
+      assetKeys,
+      [...versionReferences, ...workReferences].map((reference) => reference.assetKey),
+    );
+    if (shouldDeferWorkAssetCleanupForReferences(
+      body.deferWhileReferenced === true,
+      assetKeys.length,
+      unreferencedAssetKeys.length,
+    )) {
+      return c.json({
+        ok: false,
+        message: "work asset cleanup is waiting for database references to detach",
+        code: "work_asset_cleanup_deferred",
+      }, 409);
+    }
+    if (unreferencedAssetKeys.length === 0) {
+      if (reservationResult.publishJobId) {
+        await db
+          .update(workAssetReservations)
+          .set({ state: "committed", updatedAt: new Date() })
+          .where(eq(workAssetReservations.publishJobId, reservationResult.publishJobId));
+      }
+      return c.json({ ok: true, deleted: 0, skippedReferenced: assetKeys.length });
+    }
+
+    const deleted = await deleteWorkAssetsByObjectKeys(unreferencedAssetKeys);
+    if (reservationResult.publishJobId) {
+      await db
+        .update(workAssetReservations)
+        .set({ state: "cleaned", updatedAt: new Date() })
+        .where(eq(workAssetReservations.publishJobId, reservationResult.publishJobId));
+    }
+    return c.json({
+      ok: true,
+      deleted: deleted.deleted,
+      skippedReferenced: assetKeys.length - unreferencedAssetKeys.length,
+    });
+  } catch (error) {
+    if (error instanceof WorkAssetCleanupError) {
+      return c.json({ ok: false, message: error.message, code: "work_asset_cleanup_invalid" }, 400);
+    }
+    logger.error("[works] durable asset cleanup failed", {
+      spaceId: body.scope.spaceId,
+      slug: body.scope.slug,
+      reason: body.reason,
+      error,
+    });
+    return c.json({ ok: false, message: "work asset cleanup failed" }, 502);
+  }
+});
+
+export default router;

--- a/apps/api/src/routes/work-delete.test.ts
+++ b/apps/api/src/routes/work-delete.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+
+const {
+  WorkAssetCleanupError,
+  collectHistoricalWorkAssetKeys,
+  deleteWorkAssetKeys,
+  detachWorkWithAssetCleanupScheduled,
+  excludeReferencedWorkAssetKeys,
+} = await import("./work-delete.js");
+
+const scope = {
+  env: "prod" as const,
+  spaceId: "4eb3029c-5113-4de0-9fef-cc42c25431c5",
+  slug: "ip-planning-control-room",
+};
+const v1 = `w/${scope.spaceId}/${scope.slug}/d404f9484ccc/index.html`;
+const v2 = `w/${scope.spaceId}/${scope.slug}/2786435fdeac/index.html`;
+const v3 = `w/${scope.spaceId}/${scope.slug}/025ecf828f70/index.html`;
+
+assert.deepEqual(
+  collectHistoricalWorkAssetKeys(
+    [
+      { id: "version-1", assetKey: v1 },
+      { id: "version-2", assetKey: v2 },
+      { id: "version-3", assetKey: v3 },
+    ],
+    "version-3",
+    scope,
+  ),
+  { assetKeys: [v1, v2], versionIds: ["version-1", "version-2"] },
+);
+
+const calls: string[] = [];
+const cleaned = await deleteWorkAssetKeys(
+  [v1, null, v2, v1, undefined],
+  scope,
+  async (assetKeys: string[]) => {
+    calls.push(...assetKeys);
+    return { deleted: 5 };
+  },
+);
+
+assert.deepEqual(calls, [v1, v2]);
+assert.deepEqual(cleaned, { assetKeys: 2, objects: 5 });
+
+const attempted: string[] = [];
+await assert.rejects(
+  deleteWorkAssetKeys(
+    [v1, v2, v3],
+    scope,
+    async (assetKeys: string[]) => {
+      attempted.push(...assetKeys);
+      throw new Error("storage unavailable");
+    },
+  ),
+  (error: unknown) => {
+    assert.ok(error instanceof WorkAssetCleanupError);
+    assert.deepEqual(
+      error.failures.map((failure: { assetKey: string; message: string }) => failure.assetKey),
+      [v1, v2, v3],
+    );
+    return true;
+  },
+);
+assert.deepEqual(attempted, [v1, v2, v3]);
+
+assert.deepEqual(await deleteWorkAssetKeys([null, undefined], scope, async () => ({ deleted: 1 })), {
+  assetKeys: 0,
+  objects: 0,
+});
+
+let invalidKeyDeleterCalled = false;
+await assert.rejects(
+  deleteWorkAssetKeys(
+    ["w/index.html", `w/another-space/work/0123456789ab/index.html`, `w/${scope.spaceId}/another-work/0123456789ab/index.html`],
+    scope,
+    async () => {
+      invalidKeyDeleterCalled = true;
+      return { deleted: 1 };
+    },
+  ),
+  (error: unknown) => error instanceof WorkAssetCleanupError && error.failures.length === 3,
+);
+assert.equal(invalidKeyDeleterCalled, false);
+
+await assert.rejects(
+  deleteWorkAssetKeys([v1], scope, async () => ({ deleted: -1 })),
+  (error: unknown) =>
+    error instanceof WorkAssetCleanupError && error.failures[0]?.message === "invalid deleted object count",
+);
+
+const deleteOrder: string[] = [];
+assert.deepEqual(
+  await detachWorkWithAssetCleanupScheduled({
+    assetKeys: [v1],
+    scope,
+    scheduleCleanup: async () => {
+      deleteOrder.push("schedule");
+    },
+    deleteRecords: async () => {
+      deleteOrder.push("records");
+    },
+  }),
+  { assetKeys: [v1] },
+);
+assert.deepEqual(deleteOrder, ["schedule", "records"]);
+
+let recordsDeleted = false;
+await assert.rejects(
+  detachWorkWithAssetCleanupScheduled({
+    assetKeys: [v1],
+    scope,
+    scheduleCleanup: async () => {
+      throw new Error("cleanup queue unavailable");
+    },
+    deleteRecords: async () => {
+      recordsDeleted = true;
+    },
+  }),
+  /cleanup queue unavailable/,
+);
+assert.equal(recordsDeleted, false);
+
+assert.deepEqual(excludeReferencedWorkAssetKeys([v1, v2, v3], [v2, v2, null]), [v1, v3]);
+
+console.log("api work delete asset cleanup checks passed");

--- a/apps/api/src/routes/work-delete.ts
+++ b/apps/api/src/routes/work-delete.ts
@@ -1,0 +1,117 @@
+export type WorkAssetCleanupFailure = {
+  assetKey: string;
+  message: string;
+};
+
+export class WorkAssetCleanupError extends Error {
+  constructor(public readonly failures: WorkAssetCleanupFailure[]) {
+    super(`failed to delete ${failures.length} work asset prefix${failures.length === 1 ? "" : "es"}`);
+    this.name = "WorkAssetCleanupError";
+  }
+}
+
+type DeleteWorkAssets = (assetKeys: string[]) => Promise<{ deleted: number }>;
+
+export type WorkAssetKeyScope = {
+  env: "dev" | "prod";
+  spaceId: string;
+  slug: string;
+};
+
+const WORK_SLUG_RE = /^[a-z0-9](?:[a-z0-9_-]{0,78}[a-z0-9])?$/;
+const VERSION_SEGMENT_RE = /^[a-f0-9]{12}$/;
+
+const isWorkAssetKeyInScope = (assetKey: string, scope: WorkAssetKeyScope) => {
+  if (!assetKey || assetKey.trim() !== assetKey || assetKey.startsWith("/")) return false;
+  const segments = assetKey.split("/");
+  const offset = scope.env === "prod" ? 0 : 1;
+  if (segments.length !== offset + 5) return false;
+  if (scope.env !== "prod" && segments[0] !== scope.env) return false;
+  return (
+    segments[offset] === "w" &&
+    segments[offset + 1] === scope.spaceId &&
+    segments[offset + 2] === scope.slug &&
+    WORK_SLUG_RE.test(scope.slug) &&
+    VERSION_SEGMENT_RE.test(segments[offset + 3] ?? "") &&
+    segments[offset + 4] === "index.html"
+  );
+};
+
+export function collectWorkAssetKeys(
+  assetKeys: Array<string | null | undefined>,
+  scope: WorkAssetKeyScope,
+) {
+  const failures: WorkAssetCleanupFailure[] = [];
+  const uniqueAssetKeys: string[] = [];
+  const seenAssetKeys = new Set<string>();
+
+  for (const assetKey of assetKeys) {
+    if (assetKey === null || assetKey === undefined) continue;
+    if (!isWorkAssetKeyInScope(assetKey, scope)) {
+      failures.push({ assetKey, message: "work asset key is outside the work space scope" });
+      continue;
+    }
+    if (seenAssetKeys.has(assetKey)) continue;
+    seenAssetKeys.add(assetKey);
+    uniqueAssetKeys.push(assetKey);
+  }
+
+  if (failures.length > 0) throw new WorkAssetCleanupError(failures);
+  return uniqueAssetKeys;
+}
+
+export function collectHistoricalWorkAssetKeys(
+  versions: Array<{ id: string; assetKey: string | null }>,
+  currentVersionId: string | null,
+  scope: WorkAssetKeyScope,
+) {
+  const historicalVersions = versions.filter(
+    (version) => version.id !== currentVersionId && version.assetKey !== null,
+  );
+  return {
+    assetKeys: collectWorkAssetKeys(
+      historicalVersions.map((version) => version.assetKey),
+      scope,
+    ),
+    versionIds: historicalVersions.map((version) => version.id),
+  };
+}
+
+export function excludeReferencedWorkAssetKeys(
+  assetKeys: string[],
+  referencedAssetKeys: Array<string | null>,
+) {
+  const referenced = new Set(referencedAssetKeys.filter((assetKey): assetKey is string => assetKey !== null));
+  return assetKeys.filter((assetKey) => !referenced.has(assetKey));
+}
+
+export async function deleteWorkAssetKeys(
+  assetKeys: Array<string | null | undefined>,
+  scope: WorkAssetKeyScope,
+  deleteWorkAssets: DeleteWorkAssets,
+) {
+  const uniqueAssetKeys = collectWorkAssetKeys(assetKeys, scope);
+  if (uniqueAssetKeys.length === 0) return { assetKeys: 0, objects: 0 };
+  try {
+    const result = await deleteWorkAssets(uniqueAssetKeys);
+    if (!Number.isSafeInteger(result.deleted) || result.deleted < 0) {
+      throw new Error("invalid deleted object count");
+    }
+    return { assetKeys: uniqueAssetKeys.length, objects: result.deleted };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new WorkAssetCleanupError(uniqueAssetKeys.map((assetKey) => ({ assetKey, message })));
+  }
+}
+
+export async function detachWorkWithAssetCleanupScheduled(input: {
+  assetKeys: Array<string | null | undefined>;
+  scope: WorkAssetKeyScope;
+  scheduleCleanup: (assetKeys: string[]) => Promise<void>;
+  deleteRecords: () => Promise<void>;
+}) {
+  const assetKeys = collectWorkAssetKeys(input.assetKeys, input.scope);
+  if (assetKeys.length > 0) await input.scheduleCleanup(assetKeys);
+  await input.deleteRecords();
+  return { assetKeys };
+}

--- a/apps/api/src/routes/works.route.ts
+++ b/apps/api/src/routes/works.route.ts
@@ -1,7 +1,7 @@
 import { Hono, type Context } from "hono";
-import { and, desc, eq, ne, sql } from "drizzle-orm";
-import { spaces, works, workVersions, workViewerGrants, userProfiles } from "@cohub/db";
-import { createWorkAssetPublicUrl, deleteWorkAssetsByObjectKey, isConfiguredWorkAssetPublicUrl } from "../work-asset-storage.js";
+import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
+import { spaces, works, workAssetReservations, workVersions, workViewerGrants, userProfiles } from "@cohub/db";
+import { createWorkAssetPublicUrl, deleteWorkAssetsByObjectKeys, isConfiguredWorkAssetPublicUrl } from "../work-asset-storage.js";
 import { publishWorkAssetInWorker, type WorkPublishAssetJobResult } from "../work-publish-asset-queue.js";
 import type { Permission } from "@cohub/core/permissions";
 import { db } from "../db/index.js";
@@ -12,8 +12,26 @@ import { getSandboxPublicEndpoints } from "../sandbox-public-network.js";
 import { SANDBOX_PUBLIC_PORTS } from "@cohub/protocol/ports";
 import { createLogger } from "@cohub/infra/logging";
 import { billingOperations, COHUB_BILLING_FEATURES } from "@cohub/billing";
+import { config } from "../config.js";
+import { enqueueWorkAssetCleanup } from "../work-asset-cleanup-queue.js";
+import { markWorkAssetReservationCleaned, startWorkAssetReservation } from "../work-asset-reservation.js";
+import { hasSameWorkPublishTarget } from "../work-publish-target.js";
+import { getWorkUpdateVersionState } from "../work-update-state.js";
+import {
+  createWorkAssetCleanupScope,
+  createWorkAssetObjectKey,
+  createWorkAssetPublishJobId,
+  selectWorkAssetCleanupKey,
+} from "../work-asset-publish-cleanup.js";
 import { featureGateResponse } from "../lib/feature-gate.js";
 import { createWorkPublicUrl } from "../lib/work-public-url.js";
+import {
+  WorkAssetCleanupError,
+  collectHistoricalWorkAssetKeys,
+  collectWorkAssetKeys,
+  deleteWorkAssetKeys,
+  detachWorkWithAssetCleanupScheduled,
+} from "./work-delete.js";
 
 const logger = createLogger({ serviceName: "cohub-api" });
 const router = new Hono();
@@ -32,6 +50,7 @@ const ALLOWED_VIEWER_SCOPES = new Set<Permission>([
   "user.session.list",
   "user.usage.read",
 ]);
+const WORK_ASSET_CLEANUP_WATCHDOG_DELAY_MS = 5 * 60_000;
 
 
 const normalizeScopes = (value: unknown, allowed: Set<Permission>): Permission[] => {
@@ -179,12 +198,51 @@ class WorkAssetPublishError extends Error {
   }
 }
 
-async function writeWorkAsset(input: { spaceId: string; slug: string; targetType: string; targetRef: string; status: string }) {
-  const { spaceId, slug, targetType, targetRef, status } = input;
+async function writeWorkAsset(input: {
+  spaceId: string;
+  slug: string;
+  assetKey: string | null;
+  publishJobId: string | null;
+  targetType: string;
+  targetRef: string;
+  status: string;
+}) {
+  const { spaceId, slug, assetKey, publishJobId, targetType, targetRef, status } = input;
   if (status !== "published" || (targetType !== "file" && targetType !== "directory")) return null;
-  const result = await publishWorkAssetInWorker({ spaceId, slug, targetType, targetRef });
+  if (!assetKey) throw new Error("published work asset key was not reserved");
+  if (!publishJobId) throw new Error("published work asset job id was not reserved");
+  const result = await publishWorkAssetInWorker(
+    { spaceId, slug, assetKey, targetType, targetRef },
+    { jobId: publishJobId },
+  );
   if (!result.ok) throw new WorkAssetPublishError(result);
+  if (result.assetKey !== assetKey) {
+    throw new WorkAssetPublishError({
+      ok: false,
+      status: 502,
+      message: "work asset worker returned an unexpected key",
+      code: "work_asset_key_mismatch",
+      cleanupAssetKey: result.assetKey,
+    });
+  }
   return result.assetKey;
+}
+
+async function scheduleWorkAssetCleanupWatchdog(input: {
+  assetKey: string;
+  scope: ReturnType<typeof createWorkAssetCleanupScope>;
+  publishJobId: string;
+  reason: string;
+}) {
+  return enqueueWorkAssetCleanup(
+    {
+      assetKeys: [input.assetKey],
+      scope: input.scope,
+      publishJobId: input.publishJobId,
+      reason: input.reason,
+    },
+    { delayMs: WORK_ASSET_CLEANUP_WATCHDOG_DELAY_MS },
+  );
 }
 
 function workAssetErrorResponse(c: Context, error: unknown, context: { spaceId: string; targetType: string; targetRef: string }) {
@@ -195,12 +253,64 @@ function workAssetErrorResponse(c: Context, error: unknown, context: { spaceId: 
   return c.json({ message: "work asset storage failed" }, 502);
 }
 
-async function cleanupWorkAssets(assetKey: string | null | undefined, context: { workId: string; spaceId: string; reason: string }) {
+async function cleanupWorkAssets(
+  assetKey: string | null | undefined,
+  context: {
+    workId: string;
+    spaceId: string;
+    slug: string;
+    reason: string;
+    publishJobId?: string;
+    deferUntilPublishTerminal?: boolean;
+  },
+) {
   if (!assetKey) return;
+  if (context.deferUntilPublishTerminal) {
+    const retryJob = await enqueueWorkAssetCleanup({
+      assetKeys: [assetKey],
+      scope: { env: config.env, spaceId: context.spaceId, slug: context.slug },
+      publishJobId: context.publishJobId,
+      reason: context.reason,
+    });
+    logger.error("[works] work asset cleanup deferred until publish job is terminal", {
+      ...context,
+      assetKey,
+      retryJobId: retryJob.id,
+    });
+    return;
+  }
   try {
-    await deleteWorkAssetsByObjectKey(assetKey);
+    await deleteWorkAssetKeys(
+      [assetKey],
+      { env: config.env, spaceId: context.spaceId, slug: context.slug },
+      deleteWorkAssetsByObjectKeys,
+    );
+    if (context.publishJobId) await markWorkAssetReservationCleaned(context.publishJobId);
   } catch (error) {
-    logger.warn("[works] failed to delete stale work asset", { ...context, assetKey, error });
+    let retryJob;
+    try {
+      retryJob = await enqueueWorkAssetCleanup({
+        assetKeys: [assetKey],
+        scope: { env: config.env, spaceId: context.spaceId, slug: context.slug },
+        publishJobId: context.publishJobId,
+        reason: context.reason,
+      });
+    } catch (queueError) {
+      logger.error("[works] failed to schedule durable work asset cleanup", {
+        ...context,
+        assetKey,
+        cleanupError: error,
+        queueError,
+      });
+      throw new AggregateError([error, queueError], "work asset cleanup and retry scheduling failed");
+    }
+    logger.error("[works] failed to delete stale work asset; durable retry scheduled", {
+      ...context,
+      assetKey,
+      retryJobId: retryJob.id,
+      error,
+    });
+    throw error;
   }
 }
 
@@ -369,15 +479,66 @@ router.post("/", async (c) => {
   const [existingWork] = await db.select().from(works).where(and(eq(works.spaceId, spaceId), eq(works.slug, slug))).limit(1);
   if (existingWork) return c.json({ message: "slug already exists" }, 409);
 
-  let assetKey: string | null = null;
+  let assetKey = status === "published" && (targetType === "file" || targetType === "directory")
+    ? createWorkAssetObjectKey(config.env, { spaceId, slug })
+    : null;
+  let publishJobId: string | null = null;
+  let reservation: Awaited<ReturnType<typeof startWorkAssetReservation>> | null = null;
+  let uploadMayHaveStarted = false;
+  let uploadJobTerminal = false;
+  if (assetKey) {
+    publishJobId = createWorkAssetPublishJobId(assetKey);
+    try {
+      reservation = await startWorkAssetReservation({ publishJobId, assetKey, spaceId, slug });
+      await scheduleWorkAssetCleanupWatchdog({
+        assetKey,
+        scope: createWorkAssetCleanupScope(config.env, { spaceId, slug }),
+        publishJobId,
+        reason: "create_upload_watchdog",
+      });
+      uploadMayHaveStarted = true;
+    } catch (error) {
+      if (reservation) await reservation.abandon();
+      logger.error("[works] failed to schedule work creation upload watchdog", { spaceId, slug, error });
+      return c.json({ message: "work asset cleanup queue unavailable" }, 502);
+    }
+  }
   try {
-    assetKey = await writeWorkAsset({ spaceId, slug, targetType, targetRef, status });
+    assetKey = await writeWorkAsset({ spaceId, slug, assetKey, publishJobId, targetType, targetRef, status });
+    uploadJobTerminal = true;
   } catch (error) {
+    const publishJobIsTerminal = uploadJobTerminal || error instanceof WorkAssetPublishError;
+    const cleanupAssetKey = selectWorkAssetCleanupKey(
+      uploadMayHaveStarted ? assetKey : null,
+      error instanceof WorkAssetPublishError ? error.result : null,
+    );
+    if (cleanupAssetKey) {
+      try {
+        if (reservation) await reservation.abandon();
+        await cleanupWorkAssets(cleanupAssetKey, {
+          workId: "new",
+          spaceId,
+          slug,
+          publishJobId: publishJobId ?? undefined,
+          deferUntilPublishTerminal: !publishJobIsTerminal,
+          reason: "create_upload_failed",
+        });
+      } catch (cleanupError) {
+        logger.error("[works] failed to clean up unsuccessful work creation upload", {
+          spaceId,
+          slug,
+          cleanupError,
+        });
+        return c.json({ message: "work asset cleanup failed", code: "work_asset_cleanup_failed" }, 502);
+      }
+    }
     return workAssetErrorResponse(c, error, { spaceId, targetType, targetRef });
   }
 
+  let work: typeof works.$inferSelect | null = null;
   try {
-    const work = await db.transaction(async (tx) => {
+    if (reservation) await reservation.assertHealthy();
+    work = await db.transaction(async (tx) => {
       const [createdWork] = await tx.insert(works).values({
         spaceId,
         userUuid: user.uuid,
@@ -405,20 +566,46 @@ router.post("/", async (c) => {
       }).returning();
       if (!version) throw new Error("failed to create work version");
       const [updatedWork] = await tx.update(works).set({ currentVersionId: version.id }).where(eq(works.id, createdWork.id)).returning();
+      if (publishJobId) {
+        const [committedReservation] = await tx
+          .update(workAssetReservations)
+          .set({ state: "committed", updatedAt: new Date() })
+          .where(and(
+            eq(workAssetReservations.publishJobId, publishJobId),
+            eq(workAssetReservations.state, "pending"),
+          ))
+          .returning({ publishJobId: workAssetReservations.publishJobId });
+        if (!committedReservation) throw new Error("failed to commit work asset reservation");
+      }
       return updatedWork ?? createdWork;
     }).catch((error: unknown) => {
       if (isWorkSlugConflict(error)) return null;
       throw error;
     });
-    if (!work) {
-      await cleanupWorkAssets(assetKey, { workId: "new", spaceId, reason: "create_slug_conflict" });
-      return c.json({ message: "slug already exists" }, 409);
-    }
-    return c.json({ work: serializeWork(work) }, 201);
   } catch (error) {
-    await cleanupWorkAssets(assetKey, { workId: "new", spaceId, reason: "create_failed" });
+    if (reservation) await reservation.abandon();
+    await cleanupWorkAssets(assetKey, {
+      workId: "new",
+      spaceId,
+      slug,
+      publishJobId: publishJobId ?? undefined,
+      reason: "create_failed",
+    });
     throw error;
   }
+  if (!work) {
+    if (reservation) await reservation.abandon();
+    await cleanupWorkAssets(assetKey, {
+      workId: "new",
+      spaceId,
+      slug,
+      publishJobId: publishJobId ?? undefined,
+      reason: "create_slug_conflict",
+    });
+    return c.json({ message: "slug already exists" }, 409);
+  }
+  if (reservation) await reservation.stop();
+  return c.json({ work: serializeWork(work) }, 201);
 });
 
 async function updateWork(
@@ -454,38 +641,67 @@ async function updateWork(
   if (nextStatus === "published" && current.status !== "published") {
     return c.json({ message: "publish a version to publish this work" }, 409);
   }
-  const nextVisibility = typeof body?.visibility === "string" ? body.visibility : (current.visibility ?? "public");
   const identityError = await ensureWorkPublicIdentity(c, current.spaceId);
   if (identityError) return identityError;
   const nextMeta = "meta" in (body ?? {}) ? getWorkMeta(body?.meta) : getWorkMeta(current.meta);
   const presentationError = await ensureWorkPresentationAllowed(c, { userId: actorUserId, meta: nextMeta });
   if (presentationError) return presentationError;
 
-  const assetKey = nextStatus === "published" ? current.assetKey : null;
-
   const now = new Date();
   const work = await db.transaction(async (tx) => {
+    const [lockedWork] = await tx
+      .select()
+      .from(works)
+      .where(eq(works.id, current.id))
+      .limit(1)
+      .for("update");
+    if (!lockedWork) return null;
+
+    const lockedNextSlug = typeof body?.slug === "string" ? body.slug.trim().toLowerCase() : lockedWork.slug;
+    if (!SLUG_RE.test(lockedNextSlug)) {
+      return c.json({ message: "slug must use lowercase letters, numbers, hyphens, or underscores" }, 400);
+    }
+    const lockedNextTargetType = typeof body?.targetType === "string" ? body.targetType : lockedWork.targetType;
+    let lockedNextTargetRef = typeof body?.targetRef === "string" ? body.targetRef.trim() : lockedWork.targetRef;
+    if (!TARGET_TYPES.has(lockedNextTargetType) || !lockedNextTargetRef) {
+      return c.json({ message: "target is invalid" }, 400);
+    }
+    if (lockedNextTargetType === "file" && !/\.html?$/i.test(lockedNextTargetRef)) {
+      return c.json({ message: "only HTML files can be published as work" }, 400);
+    }
+    if (lockedNextTargetType === "port") {
+      const portRef = normalizePortRef(lockedNextTargetRef);
+      if (!portRef) return c.json({ message: "port is invalid" }, 400);
+      lockedNextTargetRef = portRef;
+    }
+    const lockedNextStatus = typeof body?.status === "string" ? body.status : lockedWork.status;
+    if (lockedNextStatus === "published" && lockedWork.status !== "published") {
+      return c.json({ message: "publish a version to publish this work" }, 409);
+    }
+    const lockedNextVisibility = typeof body?.visibility === "string"
+      ? body.visibility
+      : (lockedWork.visibility ?? "public");
+    const versionState = getWorkUpdateVersionState(lockedWork, lockedNextStatus, now);
+
     const [updatedWork] = await tx.update(works).set({
-      slug: nextSlug,
-      status: nextStatus,
-      visibility: nextVisibility,
-      targetType: nextTargetType,
-      targetRef: nextTargetRef,
-      assetKey,
-      currentVersionId: current.currentVersionId,
-      latestVersion: current.latestVersion,
-      publishedAt: nextStatus === "published" ? (current.publishedAt ?? now) : null,
-      workScopes: "workScopes" in (body ?? {}) ? normalizeScopes(body?.workScopes, ALLOWED_WORK_SCOPES) : current.workScopes,
-      allowedViewerScopes: "allowedViewerScopes" in (body ?? {}) ? normalizeScopes(body?.allowedViewerScopes, ALLOWED_VIEWER_SCOPES) : current.allowedViewerScopes,
-      meta: nextMeta,
+      slug: lockedNextSlug,
+      status: lockedNextStatus,
+      visibility: lockedNextVisibility,
+      targetType: lockedNextTargetType,
+      targetRef: lockedNextTargetRef,
+      ...versionState,
+      workScopes: "workScopes" in (body ?? {}) ? normalizeScopes(body?.workScopes, ALLOWED_WORK_SCOPES) : lockedWork.workScopes,
+      allowedViewerScopes: "allowedViewerScopes" in (body ?? {}) ? normalizeScopes(body?.allowedViewerScopes, ALLOWED_VIEWER_SCOPES) : lockedWork.allowedViewerScopes,
+      meta: "meta" in (body ?? {}) ? nextMeta : lockedWork.meta,
       updatedAt: now,
-    }).where(eq(works.id, current.id)).returning();
+    }).where(eq(works.id, lockedWork.id)).returning();
     return updatedWork ?? null;
   }).catch((error: unknown) => {
     if (isWorkSlugConflict(error)) return null;
     throw error;
   });
-  if (!work) return c.json({ message: "slug already exists" }, 409);
+  if (work instanceof Response) return work;
+  if (!work) return c.json({ message: "work not found" }, 404);
   return c.json({ work: serializeWork(work) });
 }
 
@@ -493,31 +709,87 @@ async function publishWorkVersion(c: Context, current: typeof works.$inferSelect
   const identityError = await ensureWorkPublicIdentity(c, current.spaceId);
   if (identityError) return identityError;
   let assetKey: string | null = null;
+  let publishJobId: string | null = null;
+  let reservation: Awaited<ReturnType<typeof startWorkAssetReservation>> | null = null;
+  let cleanupScope = createWorkAssetCleanupScope(config.env, current);
+  let publishTarget = {
+    spaceId: current.spaceId,
+    slug: current.slug,
+    targetType: current.targetType,
+    targetRef: current.targetRef,
+  };
+  let uploadMayHaveStarted = false;
+  let uploadJobTerminal = false;
   try {
+    const preparedWork = await db.transaction(async (tx) => {
+      const [lockedWork] = await tx
+        .select()
+        .from(works)
+        .where(eq(works.id, current.id))
+        .limit(1)
+        .for("update");
+      if (!lockedWork) return null;
+      return lockedWork;
+    });
+    if (!preparedWork) return c.json({ message: "work not found" }, 404);
+
+    publishTarget = {
+      spaceId: preparedWork.spaceId,
+      slug: preparedWork.slug,
+      targetType: preparedWork.targetType,
+      targetRef: preparedWork.targetRef,
+    };
+    cleanupScope = createWorkAssetCleanupScope(config.env, preparedWork);
+    assetKey = preparedWork.targetType === "file" || preparedWork.targetType === "directory"
+      ? createWorkAssetObjectKey(config.env, preparedWork)
+      : null;
+    if (assetKey) {
+      publishJobId = createWorkAssetPublishJobId(assetKey);
+      reservation = await startWorkAssetReservation({
+        publishJobId,
+        assetKey,
+        spaceId: cleanupScope.spaceId,
+        slug: cleanupScope.slug,
+      });
+      await scheduleWorkAssetCleanupWatchdog({
+        assetKey,
+        scope: cleanupScope,
+        publishJobId,
+        reason: "publish_upload_watchdog",
+      });
+      uploadMayHaveStarted = true;
+    }
     assetKey = await writeWorkAsset({
-      spaceId: current.spaceId,
-      slug: current.slug,
-      targetType: current.targetType,
-      targetRef: current.targetRef,
+      ...publishTarget,
+      assetKey,
+      publishJobId,
       status: "published",
     });
-  } catch (error) {
-    return workAssetErrorResponse(c, error, { spaceId: current.spaceId, targetType: current.targetType, targetRef: current.targetRef });
-  }
+    uploadJobTerminal = true;
+    if (reservation) await reservation.assertHealthy();
 
-  try {
     const result = await db.transaction(async (tx) => {
+      const [lockedWork] = await tx
+        .select()
+        .from(works)
+        .where(eq(works.id, current.id))
+        .limit(1)
+        .for("update");
+      if (!lockedWork) throw new Error("work was deleted while its asset was publishing");
+      if (!hasSameWorkPublishTarget(publishTarget, lockedWork)) {
+        throw new Error("work target changed while its asset was publishing");
+      }
       const now = new Date();
       const [versionedWork] = await tx.update(works).set({
         latestVersion: sql`${works.latestVersion} + 1`,
         updatedAt: now,
-      }).where(eq(works.id, current.id)).returning({ latestVersion: works.latestVersion });
+      }).where(eq(works.id, lockedWork.id)).returning({ latestVersion: works.latestVersion });
       if (!versionedWork) throw new Error("failed to reserve work version");
       const [version] = await tx.insert(workVersions).values({
-        workId: current.id,
+        workId: lockedWork.id,
         version: versionedWork.latestVersion,
-        targetType: current.targetType,
-        targetRef: current.targetRef,
+        targetType: lockedWork.targetType,
+        targetRef: lockedWork.targetRef,
         assetKey,
         createdAt: now,
       }).returning();
@@ -527,18 +799,77 @@ async function publishWorkVersion(c: Context, current: typeof works.$inferSelect
         assetKey,
         currentVersionId: version.id,
         latestVersion: versionedWork.latestVersion,
-        publishedAt: current.publishedAt ?? now,
+        publishedAt: lockedWork.publishedAt ?? now,
         updatedAt: now,
-      }).where(eq(works.id, current.id)).returning();
+      }).where(eq(works.id, lockedWork.id)).returning();
       if (!work) throw new Error("failed to publish work version");
+      if (publishJobId) {
+        const [committedReservation] = await tx
+          .update(workAssetReservations)
+          .set({ state: "committed", updatedAt: new Date() })
+          .where(and(
+            eq(workAssetReservations.publishJobId, publishJobId),
+            eq(workAssetReservations.state, "pending"),
+          ))
+          .returning({ publishJobId: workAssetReservations.publishJobId });
+        if (!committedReservation) throw new Error("failed to commit work asset reservation");
+      }
       return { work, version };
     });
+    if (reservation) await reservation.stop();
     return c.json({ work: serializeWork(result.work), version: serializeWorkVersion(result.version) });
   } catch (error) {
-    try {
-      await cleanupWorkAssets(assetKey, { workId: current.id, spaceId: current.spaceId, reason: "publish_failed" });
-    } catch (cleanupError) {
-      logger.warn("[works] failed to run publish cleanup", { workId: current.id, spaceId: current.spaceId, cleanupError });
+    if (reservation) {
+      try {
+        await reservation.abandon();
+      } catch (reservationError) {
+        logger.error("[works] failed to abandon work version asset reservation", {
+          workId: current.id,
+          spaceId: cleanupScope.spaceId,
+          slug: cleanupScope.slug,
+          publishJobId,
+          error: reservationError,
+        });
+        return c.json({ message: "work asset cleanup failed", code: "work_asset_cleanup_failed" }, 502);
+      }
+    }
+    if (assetKey && !uploadMayHaveStarted) {
+      logger.error("[works] failed to schedule work publish upload watchdog", {
+        workId: current.id,
+        spaceId: cleanupScope.spaceId,
+        slug: cleanupScope.slug,
+        error,
+      });
+      return c.json({ message: "work asset cleanup queue unavailable" }, 502);
+    }
+    const publishJobIsTerminal = uploadJobTerminal || error instanceof WorkAssetPublishError;
+    const cleanupAssetKey = selectWorkAssetCleanupKey(
+      uploadMayHaveStarted ? assetKey : null,
+      error instanceof WorkAssetPublishError ? error.result : null,
+    );
+    if (cleanupAssetKey) {
+      try {
+        await cleanupWorkAssets(cleanupAssetKey, {
+          workId: current.id,
+          spaceId: cleanupScope.spaceId,
+          slug: cleanupScope.slug,
+          publishJobId: publishJobId ?? undefined,
+          deferUntilPublishTerminal: !publishJobIsTerminal,
+          reason: "publish_failed",
+        });
+      } catch (cleanupError) {
+        if (cleanupError instanceof WorkAssetCleanupError) {
+          return c.json({ message: "work asset cleanup failed", code: "work_asset_cleanup_failed" }, 502);
+        }
+        throw cleanupError;
+      }
+    }
+    if (error instanceof WorkAssetPublishError) {
+      return workAssetErrorResponse(c, error, {
+        spaceId: cleanupScope.spaceId,
+        targetType: publishTarget.targetType,
+        targetRef: publishTarget.targetRef,
+      });
     }
     throw error;
   }
@@ -580,6 +911,88 @@ router.post("/:id/versions", async (c) => {
   return publishWorkVersion(c, work);
 });
 
+router.post("/:id/purge-historical-assets", async (c) => {
+  const user = useAuth(c);
+  if (user instanceof Response) return user;
+  const id = c.req.param("id");
+  if (!requireValidId(id)) return c.json({ message: "work not found" }, 404);
+  const current = await getWorkById(id);
+  if (!current) return c.json({ message: "work not found" }, 404);
+  if (!(await hasPermission(user, "space.edit", { spaceId: current.spaceId }))) return authzDenied(c);
+
+  try {
+    const result = await db.transaction(async (tx) => {
+      const [lockedWork] = await tx
+        .select()
+        .from(works)
+        .where(eq(works.id, current.id))
+        .limit(1)
+        .for("update");
+      if (!lockedWork) return null;
+
+      const versions = await tx
+        .select({ id: workVersions.id, assetKey: workVersions.assetKey })
+        .from(workVersions)
+        .where(eq(workVersions.workId, lockedWork.id));
+      const scope = { env: config.env, spaceId: lockedWork.spaceId, slug: lockedWork.slug };
+      const historical = collectHistoricalWorkAssetKeys(versions, lockedWork.currentVersionId, scope);
+      if (historical.assetKeys.length > 0) {
+        const [versionConflict] = await tx
+          .select({ assetKey: workVersions.assetKey })
+          .from(workVersions)
+          .where(and(ne(workVersions.workId, lockedWork.id), inArray(workVersions.assetKey, historical.assetKeys)))
+          .limit(1);
+        const [workConflict] = await tx
+          .select({ assetKey: works.assetKey })
+          .from(works)
+          .where(and(ne(works.id, lockedWork.id), inArray(works.assetKey, historical.assetKeys)))
+          .limit(1);
+        const conflictingAssetKey = versionConflict?.assetKey ?? workConflict?.assetKey;
+        if (conflictingAssetKey) {
+          throw new WorkAssetCleanupError([
+            { assetKey: conflictingAssetKey, message: "work asset key is referenced by another work" },
+          ]);
+        }
+      }
+
+      if (historical.assetKeys.length > 0) {
+        await enqueueWorkAssetCleanup({
+          assetKeys: historical.assetKeys,
+          scope,
+          reason: "purge_historical_assets",
+          deferWhileReferenced: true,
+        });
+      }
+      if (historical.versionIds.length > 0) {
+        await tx
+          .update(workVersions)
+          .set({ assetKey: null })
+          .where(inArray(workVersions.id, historical.versionIds));
+      }
+      return { assetKeys: historical.assetKeys, scope, purgedVersions: historical.versionIds.length };
+    });
+    if (!result) return c.json({ message: "work not found" }, 404);
+    const cleanup = await deleteWorkAssetKeys(
+      result.assetKeys,
+      result.scope,
+      deleteWorkAssetsByObjectKeys,
+    );
+    return c.json({
+      ok: true,
+      purgedVersions: result.purgedVersions,
+      deletedAssets: cleanup.objects,
+    });
+  } catch (error) {
+    if (!(error instanceof WorkAssetCleanupError)) throw error;
+    logger.error("[works] failed to purge historical work assets", {
+      workId: current.id,
+      spaceId: current.spaceId,
+      failures: error.failures,
+    });
+    return c.json({ message: "work asset cleanup failed", code: "work_asset_cleanup_failed" }, 502);
+  }
+});
+
 router.delete("/:id", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
@@ -588,12 +1001,74 @@ router.delete("/:id", async (c) => {
   const work = await getWorkById(id);
   if (!work) return c.json({ message: "work not found" }, 404);
   if (!(await hasPermission(user, "space.edit", { spaceId: work.spaceId }))) return authzDenied(c);
-  await db.transaction(async (tx) => {
-    await tx.delete(workViewerGrants).where(eq(workViewerGrants.workId, work.id));
-    await tx.delete(workVersions).where(eq(workVersions.workId, work.id));
-    await tx.delete(works).where(eq(works.id, work.id));
-  });
-  return c.json({ ok: true });
+  try {
+    const result = await db.transaction(async (tx) => {
+      const [lockedWork] = await tx
+        .select()
+        .from(works)
+        .where(eq(works.id, work.id))
+        .limit(1)
+        .for("update");
+      if (!lockedWork) return null;
+
+      const versions = await tx
+        .select({ assetKey: workVersions.assetKey })
+        .from(workVersions)
+        .where(eq(workVersions.workId, lockedWork.id));
+      const scope = { env: config.env, spaceId: lockedWork.spaceId, slug: lockedWork.slug };
+      const assetKeys = collectWorkAssetKeys(
+        [lockedWork.assetKey, ...versions.map((version) => version.assetKey)],
+        scope,
+      );
+      if (assetKeys.length > 0) {
+        const [versionConflict] = await tx
+          .select({ assetKey: workVersions.assetKey })
+          .from(workVersions)
+          .where(and(ne(workVersions.workId, lockedWork.id), inArray(workVersions.assetKey, assetKeys)))
+          .limit(1);
+        const [workConflict] = await tx
+          .select({ assetKey: works.assetKey })
+          .from(works)
+          .where(and(ne(works.id, lockedWork.id), inArray(works.assetKey, assetKeys)))
+          .limit(1);
+        const conflictingAssetKey = versionConflict?.assetKey ?? workConflict?.assetKey;
+        if (conflictingAssetKey) {
+          throw new WorkAssetCleanupError([
+            { assetKey: conflictingAssetKey, message: "work asset key is referenced by another work" },
+          ]);
+        }
+      }
+      const detached = await detachWorkWithAssetCleanupScheduled({
+        assetKeys,
+        scope,
+        scheduleCleanup: async (cleanupAssetKeys) => {
+          await enqueueWorkAssetCleanup({
+            assetKeys: cleanupAssetKeys,
+            scope,
+            reason: "delete_work",
+            deferWhileReferenced: true,
+          });
+        },
+        deleteRecords: async () => {
+          await tx.delete(workViewerGrants).where(eq(workViewerGrants.workId, lockedWork.id));
+          await tx.delete(workVersions).where(eq(workVersions.workId, lockedWork.id));
+          await tx.delete(works).where(eq(works.id, lockedWork.id));
+        },
+      });
+      return { ...detached, scope };
+    });
+    if (!result) return c.json({ message: "work not found" }, 404);
+    await deleteWorkAssetKeys(result.assetKeys, result.scope, deleteWorkAssetsByObjectKeys);
+    return c.json({ ok: true });
+  } catch (error) {
+    if (!(error instanceof WorkAssetCleanupError)) throw error;
+    logger.error("[works] failed to delete work assets", {
+      workId: work.id,
+      spaceId: work.spaceId,
+      failures: error.failures,
+    });
+    return c.json({ message: "work asset cleanup failed", code: "work_asset_cleanup_failed" }, 502);
+  }
 });
 
 router.post("/:id/session", async (c) => {

--- a/apps/api/src/work-asset-cleanup-job.test.ts
+++ b/apps/api/src/work-asset-cleanup-job.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+
+const { createWorkAssetCleanupJobId } = await import("./work-asset-cleanup-job.js");
+
+const assetKeys = ["w/space/work/0123456789ab/index.html"];
+const first = createWorkAssetCleanupJobId(assetKeys, "11111111-1111-4111-8111-111111111111");
+const second = createWorkAssetCleanupJobId(assetKeys, "22222222-2222-4222-8222-222222222222");
+
+assert.notEqual(first, second);
+assert.match(first, /^work-asset-cleanup-[a-f0-9]{24}-11111111-1111-4111-8111-111111111111$/);
+assert.notEqual(createWorkAssetCleanupJobId(assetKeys), createWorkAssetCleanupJobId(assetKeys));
+
+console.log("api work asset cleanup job identity checks passed");

--- a/apps/api/src/work-asset-cleanup-job.ts
+++ b/apps/api/src/work-asset-cleanup-job.ts
@@ -1,0 +1,6 @@
+import { createHash, randomUUID } from "node:crypto";
+
+export function createWorkAssetCleanupJobId(assetKeys: string[], nonce = randomUUID()) {
+  const digest = createHash("sha256").update(assetKeys.slice().sort().join("\n")).digest("hex").slice(0, 24);
+  return `work-asset-cleanup-${digest}-${nonce}`;
+}

--- a/apps/api/src/work-asset-cleanup-queue.ts
+++ b/apps/api/src/work-asset-cleanup-queue.ts
@@ -1,0 +1,45 @@
+import { COHUB_SYSTEM_QUEUE, createBullmqQueue } from "@cohub/infra/bullmq";
+import { getCurrentRequestId } from "@cohub/infra/tracing";
+import { injectTrace } from "@cohub/infra/tracing/propagator";
+import { config } from "./config.js";
+import type { WorkAssetKeyScope } from "./routes/work-delete.js";
+import { createWorkAssetCleanupJobId } from "./work-asset-cleanup-job.js";
+
+export const WORK_ASSET_CLEANUP_JOB = "work.cleanup_asset";
+
+export type WorkAssetCleanupJobData = {
+  assetKeys: string[];
+  scope: WorkAssetKeyScope;
+  reason: string;
+  publishJobId?: string;
+  deferWhileReferenced?: boolean;
+  requestId?: string | null;
+  trace?: Record<string, unknown>;
+};
+
+const queue = createBullmqQueue<WorkAssetCleanupJobData>(COHUB_SYSTEM_QUEUE, {
+  redisUrl: config.bullmqRedisUrl,
+  telemetryServiceName: "cohub-api-work-asset-cleanup",
+});
+
+export async function enqueueWorkAssetCleanup(
+  input: Omit<WorkAssetCleanupJobData, "requestId" | "trace">,
+  options?: { delayMs?: number },
+) {
+  return queue.add(
+    WORK_ASSET_CLEANUP_JOB,
+    {
+      ...input,
+      requestId: getCurrentRequestId() ?? null,
+      trace: injectTrace(),
+    },
+    {
+      jobId: createWorkAssetCleanupJobId(input.assetKeys),
+      attempts: 12,
+      backoff: { type: "exponential", delay: 30_000 },
+      ...(options?.delayMs !== undefined ? { delay: options.delayMs } : {}),
+      removeOnComplete: { age: 7 * 24 * 3600, count: 1_000 },
+      removeOnFail: { age: 30 * 24 * 3600, count: 10_000 },
+    },
+  );
+}

--- a/apps/api/src/work-asset-delete.test.ts
+++ b/apps/api/src/work-asset-delete.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+
+const { assertDeleteObjectsSucceeded, createCloudflareWorkAssetPrefix, purgeCloudflareWorkAssetPrefixes } = await import(
+  "./work-asset-delete.js"
+);
+
+assert.equal(
+  createCloudflareWorkAssetPrefix(
+    "https://works.cohub.run",
+    "w/4eb3029c-5113-4de0-9fef-cc42c25431c5/ip-planning-control-room/d404f9484ccc/index.html",
+  ),
+  "works.cohub.run/w/4eb3029c-5113-4de0-9fef-cc42c25431c5/ip-planning-control-room/d404f9484ccc",
+);
+
+assert.equal(assertDeleteObjectsSucceeded(["one", "two"], { Errors: [] }), 2);
+assert.throws(
+  () =>
+    assertDeleteObjectsSucceeded(["one", "two"], {
+      Errors: [{ Key: "two", Code: "AccessDenied", Message: "denied" }],
+    }),
+  /failed to delete 1 work asset object/,
+);
+
+let purgeRequest: { url: string; init: RequestInit } | null = null;
+await purgeCloudflareWorkAssetPrefixes({
+  zoneId: "zone-id",
+  apiToken: "api-token",
+  prefixes: [
+    "works.cohub.run/w/space/work/hash-1",
+    "works.cohub.run/w/space/work/hash-2",
+    "works.cohub.run/w/space/work/hash-3",
+    "works.cohub.run/w/space/work/hash-4",
+    "works.cohub.run/w/space/work/hash-5",
+    "works.cohub.run/w/space/work/hash-6",
+  ],
+  fetchImpl: async (url: string, init: RequestInit) => {
+    purgeRequest = { url, init };
+    return new Response(JSON.stringify({ success: true, errors: [] }), { status: 200 });
+  },
+});
+assert.equal(purgeRequest?.url, "https://api.cloudflare.com/client/v4/zones/zone-id/purge_cache");
+assert.equal((purgeRequest?.init.headers as Record<string, string>).Authorization, "Bearer api-token");
+assert.deepEqual(JSON.parse(String(purgeRequest?.init.body)), {
+  prefixes: [
+    "works.cohub.run/w/space/work/hash-1",
+    "works.cohub.run/w/space/work/hash-2",
+    "works.cohub.run/w/space/work/hash-3",
+    "works.cohub.run/w/space/work/hash-4",
+    "works.cohub.run/w/space/work/hash-5",
+    "works.cohub.run/w/space/work/hash-6",
+  ],
+});
+
+await assert.rejects(
+  purgeCloudflareWorkAssetPrefixes({
+    zoneId: "zone-id",
+    apiToken: "api-token",
+    prefixes: ["works.cohub.run/w/space/work/hash"],
+    fetchImpl: async () =>
+      new Response(JSON.stringify({ success: false, errors: [{ code: 1000, message: "purge failed" }] }), {
+        status: 400,
+      }),
+  }),
+  /Cloudflare rejected work asset cache purge/,
+);
+
+let largePurgeBody: unknown;
+await purgeCloudflareWorkAssetPrefixes({
+  zoneId: "zone-id",
+  apiToken: "api-token",
+  prefixes: Array.from({ length: 31 }, (_, index) => `works.cohub.run/w/space/work/hash-${index}`),
+  fetchImpl: async (_url: string, init: RequestInit) => {
+    largePurgeBody = JSON.parse(String(init.body));
+    return new Response(JSON.stringify({ success: true, errors: [] }), { status: 200 });
+  },
+});
+assert.deepEqual(largePurgeBody, { hosts: ["works.cohub.run"] });
+
+console.log("api work asset delete checks passed");

--- a/apps/api/src/work-asset-delete.ts
+++ b/apps/api/src/work-asset-delete.ts
@@ -1,0 +1,76 @@
+type DeleteObjectsResult = {
+  Errors?: Array<{ Key?: string; Code?: string; Message?: string }>;
+};
+
+type FetchLike = (url: string, init: RequestInit) => Promise<Response>;
+
+export const workAssetPrefixFromObjectKey = (objectKey: string) => {
+  const normalized = objectKey.replace(/^\/+/, "");
+  const slash = normalized.lastIndexOf("/");
+  if (slash <= 0) throw new Error("invalid work asset object key");
+  return normalized.slice(0, slash + 1);
+};
+
+export function assertDeleteObjectsSucceeded(objectKeys: string[], result: DeleteObjectsResult) {
+  const errors = result.Errors ?? [];
+  if (errors.length > 0) {
+    const failedKeys = errors.map((error) => error.Key).filter((key): key is string => Boolean(key));
+    throw new Error(
+      `failed to delete ${errors.length} work asset object${errors.length === 1 ? "" : "s"}` +
+        (failedKeys.length > 0 ? `: ${failedKeys.join(", ")}` : ""),
+    );
+  }
+  return objectKeys.length;
+}
+
+export function createCloudflareWorkAssetPrefix(cdnBaseUrl: string, objectKey: string) {
+  const baseUrl = new URL(cdnBaseUrl);
+  if (baseUrl.protocol !== "https:" || baseUrl.username || baseUrl.password || baseUrl.search || baseUrl.hash) {
+    throw new Error("invalid work asset CDN base URL");
+  }
+  const assetPrefix = workAssetPrefixFromObjectKey(objectKey).replace(/\/$/, "");
+  const basePath = baseUrl.pathname.replace(/^\/+|\/+$/g, "");
+  return [baseUrl.host, basePath, assetPrefix].filter(Boolean).join("/");
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === "object" && !Array.isArray(value));
+
+export async function purgeCloudflareWorkAssetPrefixes(input: {
+  zoneId: string;
+  apiToken: string;
+  prefixes: string[];
+  fetchImpl?: FetchLike;
+}) {
+  if (!input.zoneId || !input.apiToken || input.prefixes.length === 0) {
+    throw new Error("work asset CDN purge is not configured");
+  }
+  const prefixes = Array.from(new Set(input.prefixes));
+  const hosts = Array.from(new Set(prefixes.map((prefix) => prefix.split("/")[0]).filter(Boolean)));
+  if (hosts.length !== 1 || prefixes.some((prefix) => !prefix.startsWith(`${hosts[0]}/`))) {
+    throw new Error("work asset CDN prefixes must share one host");
+  }
+  const purgeBody = prefixes.length <= 30 ? { prefixes } : { hosts };
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const response = await fetchImpl(
+    `https://api.cloudflare.com/client/v4/zones/${encodeURIComponent(input.zoneId)}/purge_cache`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${input.apiToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(purgeBody),
+    },
+  );
+  const body: unknown = await response.json();
+  if (
+    !response.ok ||
+    !isRecord(body) ||
+    body.success !== true ||
+    !Array.isArray(body.errors) ||
+    body.errors.length > 0
+  ) {
+    throw new Error(`Cloudflare rejected work asset cache purge with status ${response.status}`);
+  }
+}

--- a/apps/api/src/work-asset-publish-cleanup.test.ts
+++ b/apps/api/src/work-asset-publish-cleanup.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+
+const {
+  createWorkAssetCleanupScope,
+  createWorkAssetObjectKey,
+  createWorkAssetPublishJobId,
+  selectWorkAssetCleanupKey,
+} = await import("./work-asset-publish-cleanup.js");
+
+const current = {
+  spaceId: "space-id",
+  slug: "old-slug",
+};
+const locked = {
+  spaceId: "space-id",
+  slug: "renamed-slug",
+};
+
+assert.deepEqual(createWorkAssetCleanupScope("prod", locked), {
+  env: "prod",
+  spaceId: "space-id",
+  slug: "renamed-slug",
+});
+assert.notDeepEqual(createWorkAssetCleanupScope("prod", locked), createWorkAssetCleanupScope("prod", current));
+assert.equal(
+  createWorkAssetObjectKey("prod", locked, "0123456789ab"),
+  "w/space-id/renamed-slug/0123456789ab/index.html",
+);
+assert.equal(
+  createWorkAssetObjectKey("dev", locked, "0123456789ab"),
+  "dev/w/space-id/renamed-slug/0123456789ab/index.html",
+);
+assert.match(
+  createWorkAssetPublishJobId(
+    "w/space-id/renamed-slug/0123456789ab/index.html",
+    "11111111-1111-4111-8111-111111111111",
+  ),
+  /^work-publish-asset-[a-f0-9]{24}-11111111-1111-4111-8111-111111111111$/,
+);
+assert.notEqual(
+  createWorkAssetPublishJobId("w/space-id/renamed-slug/0123456789ab/index.html"),
+  createWorkAssetPublishJobId("w/space-id/renamed-slug/0123456789ab/index.html"),
+);
+assert.equal(
+  selectWorkAssetCleanupKey(null, {
+    ok: false,
+    status: 502,
+    message: "work asset storage failed",
+    cleanupAssetKey: "w/space-id/renamed-slug/0123456789ab/index.html",
+  }),
+  "w/space-id/renamed-slug/0123456789ab/index.html",
+);
+assert.equal(
+  selectWorkAssetCleanupKey("w/space-id/renamed-slug/0123456789ab/index.html", {
+    ok: false,
+    status: 502,
+    message: "worker returned an unexpected key",
+    cleanupAssetKey: "w/space-id/renamed-slug/fedcba987654/index.html",
+  }),
+  "w/space-id/renamed-slug/fedcba987654/index.html",
+);
+
+console.log("api work asset publish cleanup scope checks passed");

--- a/apps/api/src/work-asset-publish-cleanup.ts
+++ b/apps/api/src/work-asset-publish-cleanup.ts
@@ -1,0 +1,34 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { WorkPublishAssetJobResult } from "./work-publish-asset-queue.js";
+import type { WorkAssetKeyScope } from "./routes/work-delete.js";
+
+const VERSION_SEGMENT_RE = /^[a-f0-9]{12}$/;
+
+export function createWorkAssetCleanupScope(
+  env: WorkAssetKeyScope["env"],
+  work: { spaceId: string; slug: string },
+): WorkAssetKeyScope {
+  return { env, spaceId: work.spaceId, slug: work.slug };
+}
+
+export function createWorkAssetObjectKey(
+  env: WorkAssetKeyScope["env"],
+  work: { spaceId: string; slug: string },
+  versionSegment = randomUUID().replaceAll("-", "").slice(0, 12),
+) {
+  if (!VERSION_SEGMENT_RE.test(versionSegment)) throw new Error("invalid work asset version segment");
+  const envPrefix = env === "prod" ? "" : `${env}/`;
+  return `${envPrefix}w/${work.spaceId}/${work.slug}/${versionSegment}/index.html`;
+}
+
+export function createWorkAssetPublishJobId(assetKey: string, nonce = randomUUID()) {
+  const digest = createHash("sha256").update(assetKey).digest("hex").slice(0, 24);
+  return `work-publish-asset-${digest}-${nonce}`;
+}
+
+export function selectWorkAssetCleanupKey(
+  assetKey: string | null,
+  failure: Extract<WorkPublishAssetJobResult, { ok: false }> | null,
+) {
+  return failure?.cleanupAssetKey ?? assetKey ?? null;
+}

--- a/apps/api/src/work-asset-reservation-state.test.ts
+++ b/apps/api/src/work-asset-reservation-state.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+
+const {
+  getWorkAssetReservationCleanupDecision,
+  hasActiveWorkAssetWriterLease,
+  shouldDeferWorkAssetCleanupForReferences,
+} = await import(
+  "./work-asset-reservation-state.js"
+);
+
+const now = Date.parse("2026-07-13T10:00:00Z");
+assert.equal(getWorkAssetReservationCleanupDecision("committed", now - 1, now), "skip");
+assert.equal(getWorkAssetReservationCleanupDecision("cleaned", now - 1, now), "skip");
+assert.equal(getWorkAssetReservationCleanupDecision("pending", now + 1, now), "retry");
+assert.equal(getWorkAssetReservationCleanupDecision("pending", now, now), "claim");
+assert.equal(getWorkAssetReservationCleanupDecision("abandoned", now + 1, now), "claim");
+assert.equal(getWorkAssetReservationCleanupDecision("claimed", now + 1, now), "claim");
+assert.throws(() => getWorkAssetReservationCleanupDecision("broken", now, now));
+assert.equal(hasActiveWorkAssetWriterLease(new Date(now + 1), now), true);
+assert.equal(hasActiveWorkAssetWriterLease(new Date(now), now), false);
+assert.equal(hasActiveWorkAssetWriterLease(null, now), false);
+assert.equal(shouldDeferWorkAssetCleanupForReferences(true, 2, 1), true);
+assert.equal(shouldDeferWorkAssetCleanupForReferences(true, 2, 2), false);
+assert.equal(shouldDeferWorkAssetCleanupForReferences(false, 2, 1), false);
+
+console.log("api work asset reservation state checks passed");

--- a/apps/api/src/work-asset-reservation-state.ts
+++ b/apps/api/src/work-asset-reservation-state.ts
@@ -1,0 +1,22 @@
+export function getWorkAssetReservationCleanupDecision(
+  state: string,
+  leaseExpiresAt: number,
+  now: number,
+) {
+  if (state === "committed" || state === "cleaned") return "skip" as const;
+  if (state === "pending") return leaseExpiresAt > now ? "retry" as const : "claim" as const;
+  if (state === "abandoned" || state === "claimed") return "claim" as const;
+  throw new Error(`invalid work asset reservation state: ${state}`);
+}
+
+export function hasActiveWorkAssetWriterLease(writerLeaseExpiresAt: Date | null, now: number) {
+  return writerLeaseExpiresAt !== null && writerLeaseExpiresAt.getTime() > now;
+}
+
+export function shouldDeferWorkAssetCleanupForReferences(
+  deferWhileReferenced: boolean,
+  requestedAssetCount: number,
+  unreferencedAssetCount: number,
+) {
+  return deferWhileReferenced && unreferencedAssetCount !== requestedAssetCount;
+}

--- a/apps/api/src/work-asset-reservation.ts
+++ b/apps/api/src/work-asset-reservation.ts
@@ -1,0 +1,90 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { workAssetReservations } from "@cohub/db";
+import { db } from "./db/index.js";
+
+const RESERVATION_LEASE_MS = 2 * 60_000;
+const RESERVATION_HEARTBEAT_MS = 30_000;
+
+export async function startWorkAssetReservation(input: {
+  publishJobId: string;
+  assetKey: string;
+  spaceId: string;
+  slug: string;
+}) {
+  await db.insert(workAssetReservations).values({
+    ...input,
+    state: "pending",
+    leaseExpiresAt: new Date(Date.now() + RESERVATION_LEASE_MS),
+  });
+
+  let healthy = true;
+  let stopped = false;
+  let heartbeatInFlight: Promise<void> = Promise.resolve();
+
+  const refresh = async () => {
+    const [reservation] = await db
+      .update(workAssetReservations)
+      .set({
+        leaseExpiresAt: new Date(Date.now() + RESERVATION_LEASE_MS),
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(workAssetReservations.publishJobId, input.publishJobId),
+        eq(workAssetReservations.state, "pending"),
+      ))
+      .returning({ publishJobId: workAssetReservations.publishJobId });
+    if (!reservation) throw new Error("work asset reservation is no longer pending");
+  };
+
+  const timer = setInterval(() => {
+    if (stopped) return;
+    heartbeatInFlight = refresh().catch((error) => {
+      healthy = false;
+      throw error;
+    });
+    heartbeatInFlight.catch(() => undefined);
+  }, RESERVATION_HEARTBEAT_MS);
+  timer.unref();
+
+  const stopHeartbeat = async () => {
+    stopped = true;
+    clearInterval(timer);
+    await heartbeatInFlight.catch(() => undefined);
+  };
+
+  return {
+    publishJobId: input.publishJobId,
+    async assertHealthy() {
+      await heartbeatInFlight.catch(() => undefined);
+      if (!healthy) throw new Error("work asset reservation heartbeat failed");
+      await refresh();
+    },
+    async stop() {
+      await stopHeartbeat();
+    },
+    async abandon() {
+      await stopHeartbeat();
+      const [reservation] = await db
+        .update(workAssetReservations)
+        .set({ state: "abandoned", updatedAt: new Date() })
+        .where(and(
+          eq(workAssetReservations.publishJobId, input.publishJobId),
+          eq(workAssetReservations.state, "pending"),
+        ))
+        .returning({ publishJobId: workAssetReservations.publishJobId });
+      if (!reservation) throw new Error("failed to abandon work asset reservation");
+    },
+  };
+}
+
+export async function markWorkAssetReservationCleaned(publishJobId: string) {
+  const [reservation] = await db
+    .update(workAssetReservations)
+    .set({ state: "cleaned", updatedAt: new Date() })
+    .where(and(
+      eq(workAssetReservations.publishJobId, publishJobId),
+      inArray(workAssetReservations.state, ["abandoned", "claimed"]),
+    ))
+    .returning({ publishJobId: workAssetReservations.publishJobId });
+  if (!reservation) throw new Error("failed to complete work asset reservation cleanup");
+}

--- a/apps/api/src/work-asset-storage.ts
+++ b/apps/api/src/work-asset-storage.ts
@@ -1,6 +1,12 @@
 import { DeleteObjectsCommand, ListObjectsV2Command, S3Client } from "@aws-sdk/client-s3";
 import { buildPublicObjectUrl, type PresignStorageConfig } from "./object-presign.js";
 import { config } from "./config.js";
+import {
+  assertDeleteObjectsSucceeded,
+  createCloudflareWorkAssetPrefix,
+  purgeCloudflareWorkAssetPrefixes,
+  workAssetPrefixFromObjectKey,
+} from "./work-asset-delete.js";
 
 let s3Client: S3Client | null = null;
 
@@ -64,17 +70,8 @@ export const isConfiguredWorkAssetPublicUrl = (url: string) => {
   }
 };
 
-const workAssetPrefixFromObjectKey = (objectKey: string) => {
-  const normalized = objectKey.replace(/^\/+/, "");
-  const slash = normalized.lastIndexOf("/");
-  if (slash <= 0) return null;
-  return normalized.slice(0, slash + 1);
-};
-
-export const deleteWorkAssetsByObjectKey = async (objectKey: string | null | undefined) => {
-  if (!objectKey) return { deleted: 0 };
+const deleteWorkAssetObjectsByObjectKey = async (objectKey: string) => {
   const prefix = workAssetPrefixFromObjectKey(objectKey);
-  if (!prefix) return { deleted: 0 };
   const storage = requireStorage();
   const client = getS3Client();
   let continuationToken: string | undefined;
@@ -91,13 +88,40 @@ export const deleteWorkAssetsByObjectKey = async (objectKey: string | null | und
     for (let i = 0; i < objects.length; i += 1000) {
       const batch = objects.slice(i, i + 1000);
       if (batch.length === 0) continue;
-      await client.send(new DeleteObjectsCommand({
+      const result = await client.send(new DeleteObjectsCommand({
         Bucket: storage.bucket,
         Delete: { Objects: batch.map((Key) => ({ Key })), Quiet: true },
       }));
-      deleted += batch.length;
+      deleted += assertDeleteObjectsSucceeded(batch, result);
     }
     continuationToken = listed.IsTruncated ? listed.NextContinuationToken : undefined;
   } while (continuationToken);
+
+  return { deleted };
+};
+
+export const deleteWorkAssetsByObjectKeys = async (objectKeys: string[]) => {
+  const uniqueObjectKeys = Array.from(new Set(objectKeys));
+  if (uniqueObjectKeys.length === 0) return { deleted: 0 };
+
+  const failures: Error[] = [];
+  let deleted = 0;
+  for (const objectKey of uniqueObjectKeys) {
+    try {
+      deleted += (await deleteWorkAssetObjectsByObjectKey(objectKey)).deleted;
+    } catch (error) {
+      failures.push(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+  if (failures.length > 0) throw new AggregateError(failures, "work asset storage cleanup failed");
+
+  const cdnBaseUrl = config.workAssetCdnBaseUrl || config.publicAssetCdnBaseUrl;
+  if (cdnBaseUrl) {
+    await purgeCloudflareWorkAssetPrefixes({
+      zoneId: config.workAssetCdnCloudflareZoneId ?? "",
+      apiToken: config.workAssetCdnCloudflareApiToken ?? "",
+      prefixes: uniqueObjectKeys.map((objectKey) => createCloudflareWorkAssetPrefix(cdnBaseUrl, objectKey)),
+    });
+  }
   return { deleted };
 };

--- a/apps/api/src/work-publish-asset-queue.ts
+++ b/apps/api/src/work-publish-asset-queue.ts
@@ -9,6 +9,7 @@ export const WORK_PUBLISH_ASSET_JOB = "work.publish_asset";
 export type WorkPublishAssetJobData = {
   spaceId: string;
   slug: string;
+  assetKey: string;
   targetType: "file" | "directory";
   targetRef: string;
   requestId?: string | null;
@@ -25,6 +26,7 @@ export type WorkPublishAssetJobResult = {
   status: number;
   message: string;
   code?: string;
+  cleanupAssetKey?: string;
 };
 
 const workPublishAssetQueue = createBullmqQueue<WorkPublishAssetJobData, WorkPublishAssetJobResult>(COHUB_SYSTEM_QUEUE, {
@@ -36,13 +38,16 @@ const workPublishAssetQueueEvents = new QueueEvents(COHUB_SYSTEM_QUEUE, {
   connection: createBullmqConnectionOptions(config.bullmqRedisUrl),
 });
 
-export async function publishWorkAssetInWorker(input: Omit<WorkPublishAssetJobData, "requestId" | "trace">) {
+export async function publishWorkAssetInWorker(
+  input: Omit<WorkPublishAssetJobData, "requestId" | "trace">,
+  options: { jobId: string },
+) {
   const job = await workPublishAssetQueue.add(WORK_PUBLISH_ASSET_JOB, {
     ...input,
     requestId: getCurrentRequestId() ?? null,
     trace: injectTrace(),
   }, {
-    jobId: `work-publish-asset-${input.spaceId}-${input.slug}-${Date.now()}`,
+    jobId: options.jobId,
     attempts: 1,
     ...defaultJobRetention,
   });

--- a/apps/api/src/work-publish-target.test.ts
+++ b/apps/api/src/work-publish-target.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+
+const { hasSameWorkPublishTarget } = await import("./work-publish-target.js");
+
+const target = {
+  spaceId: "11111111-1111-4111-8111-111111111111",
+  slug: "control-room",
+  targetType: "directory",
+  targetRef: "dist",
+};
+assert.equal(hasSameWorkPublishTarget(target, { ...target }), true);
+assert.equal(hasSameWorkPublishTarget(target, { ...target, slug: "renamed" }), false);
+assert.equal(hasSameWorkPublishTarget(target, { ...target, targetRef: "other" }), false);
+
+console.log("api work publish target fencing checks passed");

--- a/apps/api/src/work-publish-target.ts
+++ b/apps/api/src/work-publish-target.ts
@@ -1,0 +1,15 @@
+type WorkPublishTarget = {
+  spaceId: string;
+  slug: string;
+  targetType: string;
+  targetRef: string;
+};
+
+export function hasSameWorkPublishTarget(expected: WorkPublishTarget, actual: WorkPublishTarget) {
+  return (
+    expected.spaceId === actual.spaceId &&
+    expected.slug === actual.slug &&
+    expected.targetType === actual.targetType &&
+    expected.targetRef === actual.targetRef
+  );
+}

--- a/apps/api/src/work-update-state.test.ts
+++ b/apps/api/src/work-update-state.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+
+const { getWorkUpdateVersionState } = await import("./work-update-state.js");
+
+const publishedAt = new Date("2026-07-13T08:00:00Z");
+const locked = {
+  assetKey: "w/space/work/0123456789ab/index.html",
+  currentVersionId: "version-42",
+  latestVersion: 42,
+  publishedAt,
+};
+assert.deepEqual(getWorkUpdateVersionState(locked, "published", new Date()), locked);
+assert.deepEqual(getWorkUpdateVersionState(locked, "disabled", new Date()), {
+  assetKey: null,
+  currentVersionId: "version-42",
+  latestVersion: 42,
+  publishedAt: null,
+});
+
+console.log("api work update version fencing checks passed");

--- a/apps/api/src/work-update-state.ts
+++ b/apps/api/src/work-update-state.ts
@@ -1,0 +1,17 @@
+export function getWorkUpdateVersionState(
+  lockedWork: {
+    assetKey: string | null;
+    currentVersionId: string | null;
+    latestVersion: number;
+    publishedAt: Date | null;
+  },
+  nextStatus: string,
+  now: Date,
+) {
+  return {
+    assetKey: nextStatus === "published" ? lockedWork.assetKey : null,
+    currentVersionId: lockedWork.currentVersionId,
+    latestVersion: lockedWork.latestVersion,
+    publishedAt: nextStatus === "published" ? (lockedWork.publishedAt ?? now) : null,
+  };
+}

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -37,6 +37,7 @@
     "@opentelemetry/sdk-trace-base": "^2.7.1",
     "@opentelemetry/sdk-trace-node": "^2.7.1",
     "@opentelemetry/semantic-conventions": "^1.41.1",
+    "@smithy/node-http-handler": "^4.7.5",
     "bullmq": "^5.77.6",
     "bullmq-otel": "^1.3.1",
     "dotenv": "^17.4.2",

--- a/apps/worker/src/config.ts
+++ b/apps/worker/src/config.ts
@@ -2,6 +2,7 @@ export interface WorkerConfig {
   redisUrl: string;
   bullmqRedisUrl: string;
   databaseUrl: string;
+  internalApiBaseUrl: string;
   giteaBaseUrl: string;
   giteaToken?: string;
   giteaOrg: string;
@@ -56,6 +57,7 @@ export const config: WorkerConfig = {
   redisUrl: process.env.REDIS_URL ?? "",
   bullmqRedisUrl: process.env.BULLMQ_REDIS_URL ?? "",
   databaseUrl: process.env.DATABASE_URL ?? "",
+  internalApiBaseUrl: (process.env.INTERNAL_API_BASE_URL ?? "").replace(/\/+$/, ""),
   giteaBaseUrl: process.env.GITEA_BASE_URL ?? "",
   giteaToken: process.env.GITEA_TOKEN,
   giteaOrg: process.env.GITEA_ORG ?? "cohub-spaces",
@@ -96,6 +98,7 @@ export const assertRequiredConfig = () => {
   assertRedisUrl(config.redisUrl, "REDIS_URL");
   assertRedisUrl(config.bullmqRedisUrl, "BULLMQ_REDIS_URL");
   if (!config.databaseUrl) throw new Error("Missing required env: DATABASE_URL");
+  if (!config.internalApiBaseUrl) throw new Error("Missing required env: INTERNAL_API_BASE_URL");
   if (!config.giteaBaseUrl) throw new Error("Missing required env: GITEA_BASE_URL");
   if (!config.workerSecret) throw new Error("Missing required env: WORKER_SECRET");
   if (!config.appEncryptionKey) throw new Error("Missing required env: APP_ENCRYPTION_KEY");

--- a/apps/worker/src/system/jobs/index.ts
+++ b/apps/worker/src/system/jobs/index.ts
@@ -4,3 +4,4 @@ import "./sandbox-idle-check/index.js";
 import "./sandbox-idle-reaper/index.js";
 import "./session-message-postprocess/index.js";
 import "./work-publish-asset/index.js";
+import "./work-asset-cleanup/index.js";

--- a/apps/worker/src/system/jobs/work-asset-cleanup/index.ts
+++ b/apps/worker/src/system/jobs/work-asset-cleanup/index.ts
@@ -1,0 +1,55 @@
+import type { Job } from "bullmq";
+import { COHUB_SYSTEM_QUEUE, createBullmqQueue } from "@cohub/infra/bullmq";
+import { config } from "../../../config.js";
+import { registerSystemJob } from "../../registry.js";
+import { isWorkAssetPublishJobTerminal } from "./job-state.js";
+import { WORK_ASSET_CLEANUP_JOB, type WorkAssetCleanupJobData } from "./types.js";
+
+const systemQueue = createBullmqQueue(COHUB_SYSTEM_QUEUE, {
+  redisUrl: config.bullmqRedisUrl,
+  telemetryServiceName: "cohub-worker-work-asset-cleanup-state",
+});
+
+async function ensurePublishJobTerminal(publishJobId: string | undefined) {
+  if (!publishJobId) return;
+  const publishJob = await systemQueue.getJob(publishJobId);
+  if (!publishJob) return;
+  if (publishJob.name !== "work.publish_asset") {
+    throw new Error(`work asset cleanup referenced unexpected job ${publishJobId}`);
+  }
+  const state = await publishJob.getState();
+  if (!isWorkAssetPublishJobTerminal(state)) {
+    throw new Error(`work asset publish job ${publishJobId} is not terminal: ${state}`);
+  }
+}
+
+async function processWorkAssetCleanup(job: Job<WorkAssetCleanupJobData>) {
+  await ensurePublishJobTerminal(job.data.publishJobId);
+  if (job.data.publishJobId && !job.id) throw new Error("work asset cleanup job id is missing");
+  const response = await fetch(`${config.internalApiBaseUrl}/internal/works/cleanup-assets`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Worker-Secret": config.workerSecret,
+    },
+    body: JSON.stringify({
+      assetKeys: job.data.assetKeys,
+      scope: job.data.scope,
+      publishJobId: job.data.publishJobId,
+      deferWhileReferenced: job.data.deferWhileReferenced,
+      claimant: job.id,
+      reason: job.data.reason,
+    }),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`work asset cleanup API failed with status ${response.status}: ${text}`);
+  }
+  const result: unknown = JSON.parse(text);
+  if (!result || typeof result !== "object" || !("ok" in result) || result.ok !== true) {
+    throw new Error("work asset cleanup API returned an invalid response");
+  }
+  return result as Record<string, unknown>;
+}
+
+registerSystemJob(WORK_ASSET_CLEANUP_JOB, processWorkAssetCleanup);

--- a/apps/worker/src/system/jobs/work-asset-cleanup/job-state.test.ts
+++ b/apps/worker/src/system/jobs/work-asset-cleanup/job-state.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+
+const { isWorkAssetPublishJobTerminal } = await import("./job-state.js");
+
+assert.equal(isWorkAssetPublishJobTerminal("completed"), true);
+assert.equal(isWorkAssetPublishJobTerminal("failed"), true);
+assert.equal(isWorkAssetPublishJobTerminal("active"), false);
+assert.equal(isWorkAssetPublishJobTerminal("waiting"), false);
+assert.equal(isWorkAssetPublishJobTerminal("delayed"), false);
+assert.equal(isWorkAssetPublishJobTerminal("prioritized"), false);
+assert.equal(isWorkAssetPublishJobTerminal("waiting-children"), false);
+assert.equal(isWorkAssetPublishJobTerminal("unknown"), false);
+
+console.log("worker work asset cleanup job state checks passed");

--- a/apps/worker/src/system/jobs/work-asset-cleanup/job-state.ts
+++ b/apps/worker/src/system/jobs/work-asset-cleanup/job-state.ts
@@ -1,0 +1,5 @@
+const TERMINAL_PUBLISH_JOB_STATES = new Set(["completed", "failed"]);
+
+export function isWorkAssetPublishJobTerminal(state: string) {
+  return TERMINAL_PUBLISH_JOB_STATES.has(state);
+}

--- a/apps/worker/src/system/jobs/work-asset-cleanup/types.ts
+++ b/apps/worker/src/system/jobs/work-asset-cleanup/types.ts
@@ -1,0 +1,15 @@
+export const WORK_ASSET_CLEANUP_JOB = "work.cleanup_asset";
+
+export type WorkAssetCleanupJobData = {
+  assetKeys: string[];
+  scope: {
+    env: "dev" | "prod";
+    spaceId: string;
+    slug: string;
+  };
+  reason: string;
+  publishJobId?: string;
+  deferWhileReferenced?: boolean;
+  requestId?: string | null;
+  trace?: Record<string, unknown>;
+};

--- a/apps/worker/src/system/jobs/work-publish-asset/asset-key.test.ts
+++ b/apps/worker/src/system/jobs/work-publish-asset/asset-key.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+
+const { resolveWorkAssetObjectKey, usesReservedWorkAssetProtocol } = await import("./asset-key.js");
+
+let generated = 0;
+assert.equal(
+  resolveWorkAssetObjectKey("w/space/work/0123456789ab/index.html", () => {
+    generated += 1;
+    return "legacy";
+  }),
+  "w/space/work/0123456789ab/index.html",
+);
+assert.equal(generated, 0);
+assert.equal(resolveWorkAssetObjectKey(undefined, () => "legacy"), "legacy");
+assert.equal(usesReservedWorkAssetProtocol("reserved"), true);
+assert.equal(usesReservedWorkAssetProtocol(undefined), false);
+
+console.log("worker work asset publish protocol compatibility checks passed");

--- a/apps/worker/src/system/jobs/work-publish-asset/asset-key.ts
+++ b/apps/worker/src/system/jobs/work-publish-asset/asset-key.ts
@@ -1,0 +1,10 @@
+export function usesReservedWorkAssetProtocol(assetKey: string | undefined) {
+  return typeof assetKey === "string";
+}
+
+export function resolveWorkAssetObjectKey(
+  assetKey: string | undefined,
+  createLegacyObjectKey: () => string,
+) {
+  return assetKey ?? createLegacyObjectKey();
+}

--- a/apps/worker/src/system/jobs/work-publish-asset/index.ts
+++ b/apps/worker/src/system/jobs/work-publish-asset/index.ts
@@ -3,10 +3,15 @@ import { constants } from "node:fs";
 import { lstat, open, readdir, realpath } from "node:fs/promises";
 import { basename, extname, isAbsolute, relative, resolve } from "node:path";
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
 import type { Job } from "bullmq";
 import { config } from "../../../config.js";
 import { registerSystemJob } from "../../registry.js";
 import { WORK_PUBLISH_ASSET_JOB, type WorkPublishAssetJobData, type WorkPublishAssetJobResult } from "./types.js";
+import { resolveWorkAssetObjectKey, usesReservedWorkAssetProtocol } from "./asset-key.js";
+import { WorkAssetUploadError, withWorkAssetUploadCleanupKey } from "./upload-failure.js";
+import { WORK_ASSET_S3_REQUEST_HANDLER_OPTIONS } from "./request-timeout.js";
+import { startWorkAssetWriterLease } from "./writer-lease.js";
 
 const MAX_WORK_ASSET_BYTES = 5 * 1024 * 1024;
 const MAX_WORK_SITE_BYTES = 100 * 1024 * 1024;
@@ -92,6 +97,11 @@ type WorkSiteFile = {
   mimeType: string | null;
 };
 
+type WorkAssetWriterLease = {
+  assertHealthy: () => void;
+  release?: () => Promise<void>;
+};
+
 let s3Client: S3Client | null = null;
 
 function getStorage() {
@@ -124,6 +134,8 @@ function getS3Client() {
     endpoint: storage.endpoint,
     region: storage.region,
     forcePathStyle: false,
+    maxAttempts: 1,
+    requestHandler: new NodeHttpHandler(WORK_ASSET_S3_REQUEST_HANDLER_OPTIONS),
     credentials: {
       accessKeyId: storage.accessKeyId,
       secretAccessKey: storage.secretAccessKey,
@@ -132,10 +144,22 @@ function getS3Client() {
   return s3Client;
 }
 
-const cacheBuster = () => randomUUID().replaceAll("-", "").slice(0, 12);
 const envPrefix = () => (config.env === "prod" ? "" : `${config.env}/`);
-const buildWorkAssetPrefix = (input: { spaceId: string; workSlug: string }) => `${envPrefix()}w/${input.spaceId}/${input.workSlug}/${cacheBuster()}`;
-const buildWorkAssetObjectKey = (input: { spaceId: string; workSlug: string }) => `${buildWorkAssetPrefix(input)}/index.html`;
+const WORK_ASSET_VERSION_RE = /^[a-f0-9]{12}$/;
+const buildLegacyWorkAssetObjectKey = (input: { spaceId: string; workSlug: string }) =>
+  `${envPrefix()}w/${input.spaceId}/${input.workSlug}/${randomUUID().replaceAll("-", "").slice(0, 12)}/index.html`;
+
+function requireWorkAssetObjectKey(input: { spaceId: string; workSlug: string; assetKey: string }) {
+  const expectedPrefix = `${envPrefix()}w/${input.spaceId}/${input.workSlug}/`;
+  if (!input.assetKey.startsWith(expectedPrefix) || !input.assetKey.endsWith("/index.html")) {
+    throw new WorkPublishAssetError(400, "invalid work asset key", "asset_key_invalid");
+  }
+  const versionSegment = input.assetKey.slice(expectedPrefix.length, -"/index.html".length);
+  if (!WORK_ASSET_VERSION_RE.test(versionSegment)) {
+    throw new WorkPublishAssetError(400, "invalid work asset key", "asset_key_invalid");
+  }
+  return input.assetKey;
+}
 
 function getMimeType(path: string) {
   const lower = basename(path).toLowerCase();
@@ -268,10 +292,21 @@ async function mapWithConcurrency<T>(items: T[], concurrency: number, mapper: (i
       await mapper(items[index] as T);
     }
   });
-  await Promise.all(workers);
+  const results = await Promise.allSettled(workers);
+  const failures = results
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+  if (failures.length > 0) throw new AggregateError(failures, "work asset upload failed");
 }
 
-async function putWorkAssetObject(input: { objectKey: string; body: Buffer | string; contentType: string; sha256: string }) {
+async function putWorkAssetObject(input: {
+  objectKey: string;
+  body: Buffer | string;
+  contentType: string;
+  sha256: string;
+  writerLease: WorkAssetWriterLease;
+}) {
+  input.writerLease.assertHealthy();
   await getS3Client().send(new PutObjectCommand({
     Bucket: requireStorage().bucket,
     Key: input.objectKey,
@@ -282,20 +317,35 @@ async function putWorkAssetObject(input: { objectKey: string; body: Buffer | str
   }));
 }
 
-async function writeWorkHtmlAsset(input: { spaceId: string; workSlug: string; html: string }) {
+async function writeWorkHtmlAsset(input: {
+  spaceId: string;
+  workSlug: string;
+  assetKey: string;
+  html: string;
+  writerLease: WorkAssetWriterLease;
+}) {
   const sizeBytes = Buffer.byteLength(input.html, "utf8");
   if (sizeBytes <= 0 || sizeBytes > MAX_WORK_ASSET_BYTES) throw new WorkPublishAssetError(400, "work asset must be 1 byte to 5MB");
-  const objectKey = buildWorkAssetObjectKey({ spaceId: input.spaceId, workSlug: input.workSlug });
-  await putWorkAssetObject({
-    objectKey,
-    body: input.html,
-    contentType: "text/html; charset=utf-8",
-    sha256: createHash("sha256").update(input.html).digest("hex"),
-  });
+  const objectKey = requireWorkAssetObjectKey(input);
+  await withWorkAssetUploadCleanupKey(objectKey, () =>
+    putWorkAssetObject({
+      objectKey,
+      body: input.html,
+      contentType: "text/html; charset=utf-8",
+      sha256: createHash("sha256").update(input.html).digest("hex"),
+      writerLease: input.writerLease,
+    }),
+  );
   return { assetKey: objectKey, sizeBytes };
 }
 
-async function writeWorkSiteAssets(input: { spaceId: string; workSlug: string; files: WorkSiteFile[] }) {
+async function writeWorkSiteAssets(input: {
+  spaceId: string;
+  workSlug: string;
+  assetKey: string;
+  files: WorkSiteFile[];
+  writerLease: WorkAssetWriterLease;
+}) {
   if (input.files.length <= 0 || input.files.length > MAX_WORK_SITE_FILES) {
     throw new WorkPublishAssetError(400, `work site must contain 1 to ${MAX_WORK_SITE_FILES} files`);
   }
@@ -305,46 +355,73 @@ async function writeWorkSiteAssets(input: { spaceId: string; workSlug: string; f
   const totalBytes = input.files.reduce((sum, file) => sum + file.content.byteLength, 0);
   if (totalBytes <= 0 || totalBytes > MAX_WORK_SITE_BYTES) throw new WorkPublishAssetError(400, "work site must be 1 byte to 100MB");
 
-  const prefix = buildWorkAssetPrefix({ spaceId: input.spaceId, workSlug: input.workSlug });
-  await mapWithConcurrency(input.files, WORK_SITE_UPLOAD_CONCURRENCY, async (file) => {
-    const objectKey = `${prefix}/${file.relativePath}`;
-    await putWorkAssetObject({
-      objectKey,
-      body: file.content,
-      contentType: file.mimeType ?? "application/octet-stream",
-      sha256: createHash("sha256").update(file.content).digest("hex"),
-    });
-  });
+  const assetKey = requireWorkAssetObjectKey(input);
+  const prefix = assetKey.slice(0, -"/index.html".length);
+  await withWorkAssetUploadCleanupKey(assetKey, () =>
+    mapWithConcurrency(input.files, WORK_SITE_UPLOAD_CONCURRENCY, async (file) => {
+      const objectKey = `${prefix}/${file.relativePath}`;
+      await putWorkAssetObject({
+        objectKey,
+        body: file.content,
+        contentType: file.mimeType ?? "application/octet-stream",
+        sha256: createHash("sha256").update(file.content).digest("hex"),
+        writerLease: input.writerLease,
+      });
+    }),
+  );
 
   return {
-    assetKey: `${prefix}/index.html`,
+    assetKey,
     sizeBytes: totalBytes,
     fileCount: input.files.length,
   };
 }
 
-async function processWorkPublishAsset(job: Job<WorkPublishAssetJobData>): Promise<WorkPublishAssetJobResult> {
-  const { spaceId, slug, targetType, targetRef } = job.data;
+async function processWorkPublishAsset(
+  job: Job<WorkPublishAssetJobData>,
+  writerLease: WorkAssetWriterLease,
+): Promise<WorkPublishAssetJobResult> {
+  const { spaceId, slug, assetKey, targetType, targetRef } = job.data;
+  const resolvedAssetKey = resolveWorkAssetObjectKey(assetKey, () =>
+    buildLegacyWorkAssetObjectKey({ spaceId, workSlug: slug }));
   if (targetType === "file") {
     const html = await readWorkHtmlFile(spaceId, targetRef);
-    const written = await writeWorkHtmlAsset({ spaceId, workSlug: slug, html });
+    const written = await writeWorkHtmlAsset({ spaceId, workSlug: slug, assetKey: resolvedAssetKey, html, writerLease });
     return { ok: true, ...written };
   }
   if (targetType === "directory") {
     const result = await readWorkDirectoryFiles(spaceId, targetRef);
-    const written = await writeWorkSiteAssets({ spaceId, workSlug: slug, files: result.files });
+    const written = await writeWorkSiteAssets({ spaceId, workSlug: slug, assetKey: resolvedAssetKey, files: result.files, writerLease });
     return { ok: true, ...written };
   }
   throw new WorkPublishAssetError(400, "target is invalid");
 }
 
 registerSystemJob(WORK_PUBLISH_ASSET_JOB, async (job: Job<WorkPublishAssetJobData>) => {
+  const reservedProtocol = usesReservedWorkAssetProtocol(job.data.assetKey);
+  if (reservedProtocol && !job.id) throw new Error("work asset publish job id is missing");
+  const writerLease: WorkAssetWriterLease = reservedProtocol
+    ? await startWorkAssetWriterLease(job.id as string)
+    : { assertHealthy() {} };
   try {
-    return await processWorkPublishAsset(job);
-  } catch (error) {
-    if (error instanceof WorkPublishAssetError) {
-      return { ok: false, status: error.status, message: error.message, code: error.code };
+    try {
+      return await processWorkPublishAsset(job, writerLease);
+    } catch (error) {
+      if (error instanceof WorkAssetUploadError) {
+        return {
+          ok: false,
+          status: 502,
+          message: error.message,
+          code: "work_asset_storage_failed",
+          cleanupAssetKey: error.cleanupAssetKey,
+        };
+      }
+      if (error instanceof WorkPublishAssetError) {
+        return { ok: false, status: error.status, message: error.message, code: error.code };
+      }
+      throw error;
     }
-    throw error;
+  } finally {
+    await writerLease.release?.();
   }
 });

--- a/apps/worker/src/system/jobs/work-publish-asset/request-timeout.test.ts
+++ b/apps/worker/src/system/jobs/work-publish-asset/request-timeout.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+
+const { WORK_ASSET_S3_REQUEST_HANDLER_OPTIONS } = await import("./request-timeout.js");
+
+assert.deepEqual(WORK_ASSET_S3_REQUEST_HANDLER_OPTIONS, {
+  connectionTimeout: 10_000,
+  requestTimeout: 60_000,
+  throwOnRequestTimeout: true,
+});
+
+console.log("worker work asset S3 request timeout checks passed");

--- a/apps/worker/src/system/jobs/work-publish-asset/request-timeout.ts
+++ b/apps/worker/src/system/jobs/work-publish-asset/request-timeout.ts
@@ -1,0 +1,5 @@
+export const WORK_ASSET_S3_REQUEST_HANDLER_OPTIONS = {
+  connectionTimeout: 10_000,
+  requestTimeout: 60_000,
+  throwOnRequestTimeout: true,
+};

--- a/apps/worker/src/system/jobs/work-publish-asset/types.ts
+++ b/apps/worker/src/system/jobs/work-publish-asset/types.ts
@@ -3,6 +3,7 @@ export const WORK_PUBLISH_ASSET_JOB = "work.publish_asset";
 export type WorkPublishAssetJobData = {
   spaceId: string;
   slug: string;
+  assetKey?: string;
   targetType: "file" | "directory";
   targetRef: string;
   requestId?: string | null;
@@ -19,4 +20,5 @@ export type WorkPublishAssetJobResult = {
   status: number;
   message: string;
   code?: string;
+  cleanupAssetKey?: string;
 };

--- a/apps/worker/src/system/jobs/work-publish-asset/upload-failure.test.ts
+++ b/apps/worker/src/system/jobs/work-publish-asset/upload-failure.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+
+const { WorkAssetUploadError, withWorkAssetUploadCleanupKey } = await import("./upload-failure.js");
+
+const cleanupAssetKey = "w/space/work/0123456789ab/index.html";
+await assert.rejects(
+  withWorkAssetUploadCleanupKey(cleanupAssetKey, async () => {
+    throw new Error("second object upload failed");
+  }),
+  (error: unknown) =>
+    error instanceof WorkAssetUploadError &&
+    error.cleanupAssetKey === cleanupAssetKey &&
+    error.cause instanceof Error &&
+    error.cause.message === "second object upload failed",
+);
+
+console.log("worker work asset upload cleanup metadata checks passed");

--- a/apps/worker/src/system/jobs/work-publish-asset/upload-failure.ts
+++ b/apps/worker/src/system/jobs/work-publish-asset/upload-failure.ts
@@ -1,0 +1,19 @@
+export class WorkAssetUploadError extends Error {
+  constructor(
+    public readonly cleanupAssetKey: string,
+    public override readonly cause: unknown,
+  ) {
+    super("work asset storage failed", { cause });
+  }
+}
+
+export async function withWorkAssetUploadCleanupKey<T>(
+  cleanupAssetKey: string,
+  upload: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await upload();
+  } catch (error) {
+    throw new WorkAssetUploadError(cleanupAssetKey, error);
+  }
+}

--- a/apps/worker/src/system/jobs/work-publish-asset/writer-lease-response.ts
+++ b/apps/worker/src/system/jobs/work-publish-asset/writer-lease-response.ts
@@ -1,0 +1,27 @@
+export function assertWorkAssetWriterLeaseResponse(value: unknown) {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    !("ok" in value) ||
+    value.ok !== true ||
+    !("leaseMs" in value) ||
+    typeof value.leaseMs !== "number" ||
+    !Number.isSafeInteger(value.leaseMs) ||
+    value.leaseMs <= 0
+  ) {
+    throw new Error("work asset writer lease API returned an invalid response");
+  }
+  return { ok: true as const, leaseMs: value.leaseMs };
+}
+
+export function isWorkAssetWriterLeaseUsable(
+  leaseExpiresAt: number,
+  now: number,
+  requiredRemainingMs: number,
+) {
+  return leaseExpiresAt - now > requiredRemainingMs;
+}
+
+export function getWorkAssetWriterLeaseExpiresAt(requestedAt: number, leaseMs: number) {
+  return requestedAt + leaseMs;
+}

--- a/apps/worker/src/system/jobs/work-publish-asset/writer-lease.test.ts
+++ b/apps/worker/src/system/jobs/work-publish-asset/writer-lease.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+
+const {
+  assertWorkAssetWriterLeaseResponse,
+  getWorkAssetWriterLeaseExpiresAt,
+  isWorkAssetWriterLeaseUsable,
+} = await import(
+  "./writer-lease-response.js"
+);
+
+assert.deepEqual(assertWorkAssetWriterLeaseResponse({ ok: true, leaseMs: 120000 }), {
+  ok: true,
+  leaseMs: 120000,
+});
+assert.throws(() => assertWorkAssetWriterLeaseResponse({ ok: true, leaseMs: 0 }));
+assert.throws(() => assertWorkAssetWriterLeaseResponse({ ok: false }));
+assert.equal(isWorkAssetWriterLeaseUsable(120000, 0, 70000), true);
+assert.equal(isWorkAssetWriterLeaseUsable(70000, 0, 70000), false);
+assert.equal(isWorkAssetWriterLeaseUsable(69999, 0, 70000), false);
+assert.equal(getWorkAssetWriterLeaseExpiresAt(1000, 120000), 121000);
+assert.notEqual(getWorkAssetWriterLeaseExpiresAt(1000, 120000), 151000);
+
+console.log("worker work asset writer lease response checks passed");

--- a/apps/worker/src/system/jobs/work-publish-asset/writer-lease.ts
+++ b/apps/worker/src/system/jobs/work-publish-asset/writer-lease.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from "node:crypto";
+import { config } from "../../../config.js";
+import {
+  assertWorkAssetWriterLeaseResponse,
+  getWorkAssetWriterLeaseExpiresAt,
+  isWorkAssetWriterLeaseUsable,
+} from "./writer-lease-response.js";
+
+const MIN_WRITER_LEASE_REMAINING_MS = 70_000;
+const WRITER_LEASE_REQUEST_TIMEOUT_MS = 10_000;
+
+async function requestWriterLease(
+  action: "acquire" | "heartbeat" | "release",
+  input: { publishJobId: string; writerId: string },
+) {
+  const requestedAt = Date.now();
+  const response = await fetch(`${config.internalApiBaseUrl}/internal/works/writer-lease/${action}`, {
+    method: "POST",
+    signal: AbortSignal.timeout(WRITER_LEASE_REQUEST_TIMEOUT_MS),
+    headers: {
+      "Content-Type": "application/json",
+      "X-Worker-Secret": config.workerSecret,
+    },
+    body: JSON.stringify(input),
+  });
+  const text = await response.text();
+  if (!response.ok) throw new Error(`work asset writer lease ${action} failed with status ${response.status}: ${text}`);
+  const result: unknown = JSON.parse(text);
+  if (action === "release") {
+    if (!result || typeof result !== "object" || !("ok" in result) || result.ok !== true) {
+      throw new Error("work asset writer lease release returned an invalid response");
+    }
+    return { ok: true as const, leaseMs: 0, leaseExpiresAt: 0 };
+  }
+  const lease = assertWorkAssetWriterLeaseResponse(result);
+  return {
+    ...lease,
+    leaseExpiresAt: getWorkAssetWriterLeaseExpiresAt(requestedAt, lease.leaseMs),
+  };
+}
+
+export async function startWorkAssetWriterLease(publishJobId: string) {
+  const writerId = randomUUID();
+  const acquired = await requestWriterLease("acquire", { publishJobId, writerId });
+  let healthy = true;
+  let stopped = false;
+  let leaseExpiresAt = acquired.leaseExpiresAt;
+  let heartbeatInFlight: Promise<void> = Promise.resolve();
+  const heartbeatMs = Math.max(1_000, Math.floor(acquired.leaseMs / 4));
+
+  const timer = setInterval(() => {
+    if (stopped) return;
+    heartbeatInFlight = requestWriterLease("heartbeat", { publishJobId, writerId })
+      .then((heartbeat) => {
+        leaseExpiresAt = Math.max(leaseExpiresAt, heartbeat.leaseExpiresAt);
+      })
+      .catch((error) => {
+        healthy = false;
+        throw error;
+      });
+    heartbeatInFlight.catch(() => undefined);
+  }, heartbeatMs);
+  timer.unref();
+
+  return {
+    assertHealthy() {
+      if (
+        !healthy ||
+        !isWorkAssetWriterLeaseUsable(
+          leaseExpiresAt,
+          Date.now(),
+          MIN_WRITER_LEASE_REMAINING_MS,
+        )
+      ) {
+        throw new Error("work asset writer lease was lost");
+      }
+    },
+    async release() {
+      stopped = true;
+      clearInterval(timer);
+      await heartbeatInFlight.catch(() => undefined);
+      await requestWriterLease("release", { publishJobId, writerId });
+    },
+  };
+}

--- a/deploy/api/dev/README.md
+++ b/deploy/api/dev/README.md
@@ -31,7 +31,10 @@ vim secrets.yaml
 - `WORKER_SECRET` - Worker 通信密钥
 - `TURN_OBJECT_S3_ACCESS_KEY_ID` / `TURN_OBJECT_S3_SECRET_ACCESS_KEY` - Turn 中间消息 OSS 写入凭证
 - `PUBLIC_ASSET_OSS_ACCESS_KEY_ID` / `PUBLIC_ASSET_OSS_SECRET_ACCESS_KEY` - 公开资产 OSS 写入凭证（用于用户 / Space 头像上传）
+- `WORK_ASSET_CDN_CLOUDFLARE_ZONE_ID` / `WORK_ASSET_CDN_CLOUDFLARE_API_TOKEN` - Work 资产删除后的 Cloudflare Prefix Purge 凭证
 - `LOGTO_M2M_APP_ID` / `LOGTO_M2M_APP_SECRET` - Logto M2M 应用凭证
+
+涉及 Work 资产预留协议的版本必须先完成 Worker 全量发布，再发布 API。新版 Worker 兼容旧版 API 的发布任务，反向顺序不兼容。
 
 可选字段：
 - `TALESOFAI_BILLING_BASE_URL` / `TALESOFAI_BILLING_BUSINESS_KEY` / `TALESOFAI_BILLING_ADMIN_API_KEY` - Talesofai Billing 插件配置，三项全部非空时启用；任意一项留空时禁用。Dev billing 地址通常是 `https://dev-billing.neta.art/v1`。

--- a/deploy/api/dev/secrets.template.yaml
+++ b/deploy/api/dev/secrets.template.yaml
@@ -34,6 +34,9 @@ stringData:
   # 必填：公开资产 OSS 写入 AccessKey（用于用户 / Space 头像上传）
   PUBLIC_ASSET_OSS_ACCESS_KEY_ID: "CHANGE_ME"
   PUBLIC_ASSET_OSS_SECRET_ACCESS_KEY: "CHANGE_ME"
+  # 必填：删除 Work 资产后按版本路径清理 Cloudflare 缓存
+  WORK_ASSET_CDN_CLOUDFLARE_ZONE_ID: "CHANGE_ME"
+  WORK_ASSET_CDN_CLOUDFLARE_API_TOKEN: "CHANGE_ME"
   # 必填：Logto M2M 应用凭证（用于 Management API 读写用户资料）
   LOGTO_M2M_APP_ID: "CHANGE_ME"
   LOGTO_M2M_APP_SECRET: "CHANGE_ME"

--- a/deploy/api/prod/README.md
+++ b/deploy/api/prod/README.md
@@ -34,7 +34,10 @@ vim secrets.yaml
 - `WORKER_SECRET` - Worker 通信密钥
 - `TURN_OBJECT_S3_ACCESS_KEY_ID` / `TURN_OBJECT_S3_SECRET_ACCESS_KEY` - Turn 中间消息 OSS 写入凭证
 - `PUBLIC_ASSET_OSS_ACCESS_KEY_ID` / `PUBLIC_ASSET_OSS_SECRET_ACCESS_KEY` - 公开资产 OSS 写入凭证（用于用户 / Space 头像上传）
+- `WORK_ASSET_CDN_CLOUDFLARE_ZONE_ID` / `WORK_ASSET_CDN_CLOUDFLARE_API_TOKEN` - Work 资产删除后的 Cloudflare Prefix Purge 凭证
 - `LOGTO_M2M_APP_ID` / `LOGTO_M2M_APP_SECRET` - Logto M2M 应用凭证
+
+涉及 Work 资产预留协议的版本必须先完成 Worker 全量发布，再发布 API。新版 Worker 兼容旧版 API 的发布任务，反向顺序不兼容。
 
 可选字段：
 - `TALESOFAI_BILLING_BASE_URL` / `TALESOFAI_BILLING_BUSINESS_KEY` / `TALESOFAI_BILLING_ADMIN_API_KEY` - Talesofai Billing 插件配置，三项全部非空时启用；任意一项留空时禁用。Prod billing 地址通常是 `https://billing.neta.art/v1`。

--- a/deploy/api/prod/secrets.template.yaml
+++ b/deploy/api/prod/secrets.template.yaml
@@ -33,6 +33,9 @@ stringData:
   # 必填：公开资产 OSS 写入 AccessKey（用于用户 / Space 头像上传）
   PUBLIC_ASSET_OSS_ACCESS_KEY_ID: "CHANGE_ME"
   PUBLIC_ASSET_OSS_SECRET_ACCESS_KEY: "CHANGE_ME"
+  # 必填：删除 Work 资产后按版本路径清理 Cloudflare 缓存
+  WORK_ASSET_CDN_CLOUDFLARE_ZONE_ID: "CHANGE_ME"
+  WORK_ASSET_CDN_CLOUDFLARE_API_TOKEN: "CHANGE_ME"
   # 必填：Logto M2M 应用凭证（用于 Management API 读写用户资料）
   LOGTO_M2M_APP_ID: "CHANGE_ME"
   LOGTO_M2M_APP_SECRET: "CHANGE_ME"

--- a/packages/db/src/schema-v2.ts
+++ b/packages/db/src/schema-v2.ts
@@ -302,6 +302,32 @@ export const workVersions = v2.table(
   }),
 );
 
+export const workAssetReservations = v2.table(
+  "work_asset_reservations",
+  {
+    publishJobId: varchar("publish_job_id", { length: 160 }).primaryKey(),
+    assetKey: text("asset_key").notNull(),
+    spaceId: uuid("space_id").notNull(),
+    slug: varchar("slug", { length: 80 }).notNull(),
+    state: varchar("state", { length: 20 }).notNull().default("pending"),
+    leaseExpiresAt: timestamp("lease_expires_at", { withTimezone: true }).notNull(),
+    claimant: varchar("claimant", { length: 160 }),
+    writerId: varchar("writer_id", { length: 160 }),
+    writerLeaseExpiresAt: timestamp("writer_lease_expires_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => ({
+    assetKeyUniqueIdx: uniqueIndex("v2_uq_work_asset_reservations_asset_key").on(table.assetKey),
+    stateLeaseIdx: index("v2_idx_work_asset_reservations_state_lease").on(table.state, table.leaseExpiresAt),
+    writerLeaseIdx: index("v2_idx_work_asset_reservations_writer_lease").on(table.writerLeaseExpiresAt),
+    stateCheck: check(
+      "v2_chk_work_asset_reservations_state",
+      sql`${table.state} in ('pending', 'committed', 'abandoned', 'claimed', 'cleaned')`,
+    ),
+  }),
+);
+
 export const workViewerGrants = v2.table(
   "work_viewer_grants",
   {

--- a/packages/infra/src/bullmq/index.ts
+++ b/packages/infra/src/bullmq/index.ts
@@ -37,7 +37,7 @@ export const queueDefinitions = [
     criticality: "normal",
     concurrencyEnv: "SYSTEM_WORKER_CONCURRENCY",
     defaultConcurrencyPerWorker: DEFAULT_SYSTEM_WORKER_CONCURRENCY,
-    registeredJobs: ["cdn_cache.warm_file", "sandbox.idle_check", "sandbox.idle_reaper", "work.publish_asset", "references.index", "session.message.postprocess"],
+    registeredJobs: ["cdn_cache.warm_file", "sandbox.idle_check", "sandbox.idle_reaper", "work.publish_asset", "work.cleanup_asset", "references.index", "session.message.postprocess"],
   },
 ] as const;
 

--- a/packages/sdk/src/apis/works.ts
+++ b/packages/sdk/src/apis/works.ts
@@ -171,6 +171,13 @@ export class WorksApi {
     });
   }
 
+  purgeHistoricalAssets(workId: string) {
+    return this.transport.request<{ ok: true; purgedVersions: number; deletedAssets: number }>(
+      `/api/works/${workId}/purge-historical-assets`,
+      { method: "POST" },
+    );
+  }
+
   createSession(workId: string) {
     return this.transport.request<WorkSessionResponse>(`/api/works/${workId}/session`, {
       method: "POST",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.41.1
         version: 1.41.1
+      '@smithy/node-http-handler':
+        specifier: ^4.7.5
+        version: 4.7.5
       bullmq:
         specifier: ^5.77.6
         version: 5.77.6


### PR DESCRIPTION
## Problem

Deleting or republishing a Work removed database references but left current and historical directory assets on the public immutable CDN. Anyone who knew a historical content hash could still fetch those files.

## Fix

- Purge every Work asset prefix from object storage and Cloudflare, including historical versions.
- Add the owner-only `POST /api/works/:id/purge-historical-assets` recovery endpoint.
- Make deletion fail closed, protect cross-Work references, and detach database references only after a durable cleanup job exists.
- Add persistent upload reservations, writer leases, cleanup retries, request timeouts, and publish/delete fencing so crashes and concurrent writes cannot recreate deleted assets.
- Preserve rolling compatibility with old publish jobs and gate API deployment until the matching system Worker has completed rollout.
- Add the Cloudflare purge secrets to API deployment templates.

## Rollout

The workflow now enforces system Worker rollout before API migration/deployment whenever the Work asset protocol changes. Configure `WORK_ASSET_CDN_CLOUDFLARE_ZONE_ID` and `WORK_ASSET_CDN_CLOUDFLARE_API_TOKEN` before deploying. After deployment, call the historical purge endpoint for affected Works.

## Verification

Twelve focused helper tests pass, including cleanup ordering, reference deferral, upload protocol compatibility, request timeout enforcement, writer fencing, target fencing, and concurrent update version preservation. Changed TypeScript files parse successfully, workflow YAML and migration JSON parse successfully, and `git diff --check` passes. Two independent clean-context reviews found no remaining P0/P1 issues.

Full workspace typecheck was not available in the isolated review clone because dependencies were intentionally not installed. This repository currently exposes no PR check suite; the service workflows run build, lint, and typecheck after merge or tag, before deployment.
