### PR TITLE
feat: enforce isolated worker execution lifecycle

### DIFF
--- a/apps/agent/src/api.ts
+++ b/apps/agent/src/api.ts
@@ -1,5 +1,6 @@
 import { buildTraceHeaders, getCurrentRequestId } from "@cohub/infra/tracing";
 import { env } from "./env.js";
+import type { IsolatedWorkerRevokeRequest } from "./isolated-worker-termination.js";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -105,4 +106,28 @@ export async function getSpace(input: { spaceId: string }) {
       meta?: Record<string, unknown> | null;
     } | null;
   } | null>;
+}
+
+export async function revokeIsolatedWorkerTurn(input: IsolatedWorkerRevokeRequest) {
+  const scheduled = await postJsonWithRetry({
+    url: `${INTERNAL_API_BASE_URL}/internal/spaces/${input.spaceId}/sessions/${input.sessionId}/turns/${input.turnId}/isolated-worker/termination`,
+    body: { terminalStatus: input.terminalStatus },
+    errorPrefix: "Schedule isolated worker termination failed",
+    maxAttempts: 5,
+  }) as Record<string, unknown> | null;
+  if (scheduled?.receipt) return { ok: true, receipt: scheduled.receipt };
+  const revokeTaskRunId = typeof scheduled?.revokeTaskRunId === "string" ? scheduled.revokeTaskRunId : null;
+  if (!revokeTaskRunId) throw new Error("Schedule isolated worker termination returned no revoke TaskRun ID");
+  const deadline = Date.now() + 20 * 60_000;
+  const url = `${INTERNAL_API_BASE_URL}/internal/spaces/${input.spaceId}/sessions/${input.sessionId}/turns/${input.turnId}/isolated-worker/termination?revokeTaskRunId=${encodeURIComponent(revokeTaskRunId)}`;
+  while (Date.now() < deadline) {
+    const response = await fetch(url, { method: "GET", headers: internalHeaders() });
+    const body = await response.json().catch(() => null) as Record<string, unknown> | null;
+    if (response.ok && body?.state === "terminated" && body.receipt) return { ok: true, receipt: body.receipt };
+    if (response.status >= 400 && response.status !== 404) {
+      throw new Error(`Read isolated worker termination failed ${response.status}: ${JSON.stringify(body)}`);
+    }
+    await sleep(500);
+  }
+  throw new Error("Timed out waiting for isolated worker termination receipt scan");
 }

--- a/apps/agent/src/batch.ts
+++ b/apps/agent/src/batch.ts
@@ -35,6 +35,7 @@ export type ClaimedTurnBatch = {
 export type ClaimResult =
   | { kind: "claimed"; batch: ClaimedTurnBatch }
   | { kind: "busy"; activeTurnId: string; activeUpdatedAt: Date | null; activeStatus: string }
+  | { kind: "stale_isolated"; turn: TurnRow }
   | { kind: "noop" };
 
 const STALE_ACTIVE_TURN_MS = env.AGENT_STALE_ACTIVE_TURN_MS;
@@ -165,6 +166,9 @@ export async function claimNextTurnBatch(input: Pick<AgentTurnJobData, "sessionI
     const active = activeRows[0] ? normalizeTurn(activeRows[0] as Record<string, unknown>) : null;
     if (active) {
       if (isStaleActiveTurn(active)) {
+        if (asRecord(active.meta).isolatedWorker) {
+          return { kind: "stale_isolated" as const, turn: active };
+        }
         await markStaleTurnInterrupted(tx, active);
       } else {
         return { kind: "busy" as const, activeTurnId: active.id, activeUpdatedAt: active.updatedAt, activeStatus: active.status };
@@ -193,7 +197,8 @@ export async function claimNextTurnBatch(input: Pick<AgentTurnJobData, "sessionI
     const followups = followupRows.map((row) => normalizeTurn(row as Record<string, unknown>));
     if (followups.length === 0) return { kind: "noop" as const };
 
-    const batch = await claimQueuedTurns(tx, followups);
+    const isolatedFollowup = followups.find((turn) => asRecord(turn.meta).isolatedWorker);
+    const batch = await claimQueuedTurns(tx, isolatedFollowup ? [isolatedFollowup] : followups);
     return batch ? { kind: "claimed" as const, batch } : { kind: "noop" as const };
   });
 }

--- a/apps/agent/src/isolated-worker-access.ts
+++ b/apps/agent/src/isolated-worker-access.ts
@@ -1,0 +1,17 @@
+import { parseAgentPromptAccessMode, type AgentPromptAccessMode } from "@cohub/core/sessions";
+
+export function resolvePromptAccessMode(ownerMeta: Record<string, unknown>): AgentPromptAccessMode {
+  return parseAgentPromptAccessMode(ownerMeta.accessMode);
+}
+
+export function assertSandboxAccessMode(
+  sandbox: { meta?: Record<string, unknown> | null } | null | undefined,
+  accessMode: "read_only" | "full_access" | "isolated_worker",
+) {
+  const meta = sandbox?.meta;
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) return;
+  const isolated = Boolean(meta.isolatedWorker || meta.isolatedWorkerPolicy || meta.worker_identity);
+  if (isolated && accessMode !== "isolated_worker") {
+    throw new Error("generic Agent execution is forbidden in an isolated disposable Space");
+  }
+}

--- a/apps/agent/src/isolated-worker-termination.ts
+++ b/apps/agent/src/isolated-worker-termination.ts
@@ -1,0 +1,101 @@
+export type IsolatedWorkerTerminalStatus = "completed" | "failed" | "interrupted" | "cancelled";
+
+export type IsolatedWorkerTerminalTurn = {
+  id: string;
+  sessionId: string;
+  status: string;
+  meta: Record<string, unknown> | null;
+};
+
+export type IsolatedWorkerRevokeRequest = {
+  spaceId: string;
+  sessionId: string;
+  turnId: string;
+  authoritySpaceId: string;
+  disposableSpaceId: string;
+  podUid: string;
+  terminalStatus: IsolatedWorkerTerminalStatus;
+};
+
+const TERMINAL_STATUSES = new Set<IsolatedWorkerTerminalStatus>([
+  "completed",
+  "failed",
+  "interrupted",
+  "cancelled",
+]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+export function getIsolatedWorkerRevokeRequest(
+  spaceId: string,
+  turn: IsolatedWorkerTerminalTurn,
+  terminalStatus: IsolatedWorkerTerminalStatus,
+): IsolatedWorkerRevokeRequest | null {
+  const handle = isRecord(turn.meta?.isolatedWorker) ? turn.meta.isolatedWorker : null;
+  if (!handle) return null;
+  if (!TERMINAL_STATUSES.has(terminalStatus)) {
+    throw new Error("isolated worker requested terminal status is invalid");
+  }
+  const policy = isRecord(handle.isolatedWorkerPolicy) ? handle.isolatedWorkerPolicy : null;
+  if (
+    handle.sessionId !== turn.sessionId
+    || handle.turnId !== turn.id
+    || !policy
+    || policy.disposableSpaceId !== spaceId
+    || typeof policy.authoritySpaceId !== "string"
+    || !policy.authoritySpaceId
+    || typeof policy.podUid !== "string"
+    || !policy.podUid
+  ) {
+    throw new Error("isolated worker terminal Turn binding mismatch");
+  }
+  return {
+    spaceId,
+    sessionId: turn.sessionId,
+    turnId: turn.id,
+    authoritySpaceId: policy.authoritySpaceId,
+    disposableSpaceId: spaceId,
+    podUid: policy.podUid,
+    terminalStatus,
+  };
+}
+
+export function createIsolatedWorkerTerminalFinalizer(deps: {
+  revoke(request: IsolatedWorkerRevokeRequest): Promise<unknown>;
+}) {
+  return async (
+    spaceId: string,
+    turn: IsolatedWorkerTerminalTurn,
+    terminalStatus: IsolatedWorkerTerminalStatus,
+  ) => {
+    const request = getIsolatedWorkerRevokeRequest(spaceId, turn, terminalStatus);
+    if (!request) return null;
+    const response = await deps.revoke(request);
+    const body = isRecord(response) ? response : null;
+    const receipt = body && isRecord(body.receipt) ? body.receipt : null;
+    if (
+      body?.ok !== true
+      || !receipt
+      || receipt.podUid !== request.podUid
+      || receipt.automaticTrigger !== "turn_terminal_event"
+      || receipt.manualEndpointInvoked !== false
+      || typeof receipt.revokeTaskRunId !== "string"
+      || !receipt.revokeTaskRunId
+      || receipt.podDeleted !== true
+      || receipt.credentialRevoked !== true
+      || receipt.sandboxTerminated !== true
+      || receipt.checkpointCreatedAfterPodDeletion !== true
+      || receipt.checkpointAdapter !== "trusted_production"
+      || typeof receipt.checkpointId !== "string"
+      || !receipt.checkpointId
+      || typeof receipt.checkpointCommit !== "string"
+      || !receipt.checkpointCommit
+      || typeof receipt.checkpointTreeSha256 !== "string"
+      || !/^[a-f0-9]{64}$/.test(receipt.checkpointTreeSha256)
+    ) {
+      throw new Error("isolated worker termination receipt is incomplete or mismatched");
+    }
+    return receipt;
+  };
+}

--- a/apps/agent/src/persistence.ts
+++ b/apps/agent/src/persistence.ts
@@ -17,6 +17,8 @@ import { logger } from "./logger.js";
 import { redis, publishRealtimeEnvelope, clearPersistedSessionStreamSnapshot, getGatewayNodeOutboundStreamKey, xaddWithMaxlen } from "./redis.js";
 import { buildTurnObjectPrefix, writeTurnObjectJson } from "./turn-object-storage.js";
 import { pickRealtimeMessageMeta } from "./realtime-message-meta.js";
+import { revokeIsolatedWorkerTurn } from "./api.js";
+import { createIsolatedWorkerTerminalFinalizer } from "./isolated-worker-termination.js";
 
 
 const INTERNAL_API_BASE_URL =
@@ -24,6 +26,9 @@ const INTERNAL_API_BASE_URL =
     ? "http://cohub-api.cohub.svc.cluster.local:8787"
     : "http://cohub-api-dev.cohub-dev.svc.cluster.local:8787";
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const finalizeIsolatedWorkerTerminalTurn = createIsolatedWorkerTerminalFinalizer({
+  revoke: revokeIsolatedWorkerTurn,
+});
 
 const stableSerialize = (value: unknown): string => {
   if (value === null || value === undefined) return JSON.stringify(value);
@@ -506,6 +511,15 @@ const buildIntermediateObjectsForTurn = async (input: { spaceId: string; session
 
 async function finalizeSessionTurnFromMessage(input: { spaceId: string; sessionId: string; turnId: string; status: Exclude<SessionTurnStatus, "running">; assistantContent: ContentBlock[]; assistantText: string | null; provider: string | null; model: string | null; stopReason: string | null; errorMessage: string | null; usage: Usage | null; metaPatch?: Record<string, unknown> | null }) {
   const intermediate = await buildIntermediateObjectsForTurn(input);
+  const [pendingTurn] = await db.select().from(sessionTurns).where(and(
+    eq(sessionTurns.id, input.turnId),
+    eq(sessionTurns.sessionId, input.sessionId),
+    inArray(sessionTurns.status, ["running", "abort_requested"]),
+  )).limit(1);
+  if (pendingTurn) {
+    const terminalStatus = input.status === "interrupted" ? "interrupted" : input.status === "failed" ? "failed" : "completed";
+    await finalizeIsolatedWorkerTerminalTurn(input.spaceId, toTurnRecord(pendingTurn), terminalStatus);
+  }
   const completedAt = new Date();
   const completedAtIso = completedAt.toISOString();
   const [row] = await db.update(sessionTurns).set({
@@ -526,7 +540,12 @@ async function finalizeSessionTurnFromMessage(input: { spaceId: string; sessionI
     durationMs: sql<number>`greatest(0, floor(extract(epoch from (${completedAtIso}::timestamptz - ${sessionTurns.startedAt})) * 1000)::int)`,
     updatedAt: completedAt,
   }).where(and(eq(sessionTurns.id, input.turnId), eq(sessionTurns.sessionId, input.sessionId), inArray(sessionTurns.status, ["running", "abort_requested"]))).returning();
-  return { turn: row ? toTurnRecord(row) : null, messages: intermediate.rows };
+  const [existingRow] = row ? [row] : await db.select().from(sessionTurns).where(and(
+    eq(sessionTurns.id, input.turnId),
+    eq(sessionTurns.sessionId, input.sessionId),
+  )).limit(1);
+  const turn = existingRow ? toTurnRecord(existingRow) : null;
+  return { turn, messages: intermediate.rows };
 }
 
 async function requestGatewayChannelReconcile(reason: string) {
@@ -653,6 +672,16 @@ export async function persistAssistantMessage(input: { spaceId: string; spaceSes
   const persisted = await persistMessageNode({ spaceId: input.spaceId, sessionId: input.spaceSessionId, previousMessageId: input.userMessageId, anchorUserMessageId: input.userMessageId, userId: input.userId ?? null, idempotencyKey: await buildAssistantIdempotencyKey({ previousMessageId: input.userMessageId, message }), message });
   const record = toMessageRecord(persisted.message);
   if (!persisted.created) {
+    const turnId = typeof record.meta?.turnId === "string" ? record.meta.turnId : input.turnId ?? null;
+    if (turnId) {
+      const [existingTurn] = await db.select().from(sessionTurns).where(and(
+        eq(sessionTurns.id, turnId),
+        eq(sessionTurns.sessionId, input.spaceSessionId),
+      )).limit(1);
+      if (existingTurn && ["completed", "failed", "interrupted", "cancelled"].includes(existingTurn.status)) {
+        await finalizeIsolatedWorkerTerminalTurn(input.spaceId, toTurnRecord(existingTurn), existingTurn.status as "completed" | "failed" | "interrupted" | "cancelled");
+      }
+    }
     await enqueueSessionMessagePostprocess({ sessionId: input.spaceSessionId, messageId: record.id });
     return { ok: true, message: record, created: false };
   }
@@ -677,13 +706,21 @@ export async function persistAssistantMessage(input: { spaceId: string; spaceSes
 async function finalizeInterruptedTurn(input: { spaceId: string; sessionId: string; turnId: string; stopReason: "interrupted" | "aborted"; summary: Record<string, unknown> }) {
   const [existing] = await db.select().from(sessionTurns).where(and(eq(sessionTurns.id, input.turnId), eq(sessionTurns.sessionId, input.sessionId))).limit(1);
   if (!existing) return { turn: null, messages: [] };
-  if (!["running", "abort_requested", "interrupted"].includes(existing.status)) return { turn: toTurnRecord(existing), messages: [] };
+  if (!["running", "abort_requested", "interrupted"].includes(existing.status)) {
+    const turn = toTurnRecord(existing);
+    if (["completed", "failed", "interrupted", "cancelled"].includes(turn.status)) {
+      await finalizeIsolatedWorkerTerminalTurn(input.spaceId, turn, turn.status as "completed" | "failed" | "interrupted" | "cancelled");
+    }
+    return { turn, messages: [] };
+  }
   const [last] = await db.select().from(sessionMessages).where(and(eq(sessionMessages.sessionId, input.sessionId), eq(sessionMessages.role, "assistant"), sql`${sessionMessages.meta}->>'turnId' = ${input.turnId}`)).orderBy(desc(sessionMessages.sequence)).limit(1);
   const intermediate = await buildIntermediateObjectsForTurn(input);
+  await finalizeIsolatedWorkerTerminalTurn(input.spaceId, toTurnRecord(existing), "interrupted");
   const completedAt = new Date();
   const completedAtIso = completedAt.toISOString();
   const [row] = await db.update(sessionTurns).set({ status: "interrupted", assistantContent: last?.content ?? null, assistantText: last?.text ?? null, provider: last?.provider ?? null, model: last?.model ?? null, stopReason: input.stopReason, errorMessage: null, finalUsage: last?.usage as Usage | null ?? null, totalUsage: intermediate?.summary.usage ?? null, summary: input.summary, intermediateIndex: intermediate?.index ?? null, intermediateSummary: intermediate?.summary ?? null, completedAt, durationMs: sql<number>`greatest(0, floor(extract(epoch from (${completedAtIso}::timestamptz - ${sessionTurns.startedAt})) * 1000)::int)`, updatedAt: completedAt }).where(and(eq(sessionTurns.id, input.turnId), eq(sessionTurns.sessionId, input.sessionId), inArray(sessionTurns.status, ["running", "abort_requested", "interrupted"]))).returning();
-  return { turn: row ? toTurnRecord(row) : null, messages: intermediate.rows };
+  const turn = row ? toTurnRecord(row) : null;
+  return { turn, messages: intermediate.rows };
 }
 
 export async function interruptSessionTurn(input: { spaceId: string; sessionId: string; turnId: string; continuedByTurnId: string }) {
@@ -704,12 +741,38 @@ export async function abortSessionTurn(input: { spaceId: string; sessionId: stri
   return turn;
 }
 
+export async function recoverStaleIsolatedWorkerTurn(input: { spaceId: string; sessionId: string; turnId: string }) {
+  const { turn, messages } = await finalizeInterruptedTurn({
+    ...input,
+    stopReason: "interrupted",
+    summary: { finishReason: "interrupted", reason: "stale_active_recovered" },
+  });
+  if (turn) {
+    indexTurnReferences({ spaceId: input.spaceId, sessionId: turn.sessionId, turnId: turn.id, userUuid: turn.userUuid, messages });
+    await publishTurnFinalized(input.spaceId, turn);
+  }
+  return turn;
+}
+
 export async function failSessionTurn(input: { spaceId: string; sessionId: string; turnId: string; errorMessage: string }) {
+  const [pendingTurn] = await db.select().from(sessionTurns).where(and(
+    eq(sessionTurns.id, input.turnId),
+    eq(sessionTurns.sessionId, input.sessionId),
+    inArray(sessionTurns.status, ["queued", "running", "abort_requested"]),
+  )).limit(1);
+  if (pendingTurn) await finalizeIsolatedWorkerTerminalTurn(input.spaceId, toTurnRecord(pendingTurn), "failed");
   const completedAt = new Date();
   const completedAtIso = completedAt.toISOString();
   const [row] = await db.update(sessionTurns).set({ status: "failed", errorMessage: input.errorMessage, summary: { finishReason: "failed", text: input.errorMessage }, completedAt, durationMs: sql<number>`greatest(0, floor(extract(epoch from (${completedAtIso}::timestamptz - ${sessionTurns.startedAt})) * 1000)::int)`, updatedAt: completedAt }).where(and(eq(sessionTurns.id, input.turnId), eq(sessionTurns.sessionId, input.sessionId), inArray(sessionTurns.status, ["queued", "running", "abort_requested"]))).returning();
-  const turn = row ? toTurnRecord(row) : null;
+  const [existingRow] = row ? [row] : await db.select().from(sessionTurns).where(and(
+    eq(sessionTurns.id, input.turnId),
+    eq(sessionTurns.sessionId, input.sessionId),
+  )).limit(1);
+  const turn = existingRow ? toTurnRecord(existingRow) : null;
   if (turn) {
+    if (["completed", "failed", "interrupted", "cancelled"].includes(turn.status)) {
+      await finalizeIsolatedWorkerTerminalTurn(input.spaceId, turn, turn.status as "completed" | "failed" | "interrupted" | "cancelled");
+    }
     // No message load on the failure path, so we skip live reference indexing
     // here (avoiding an extra query for a rare error case); the backfill script
     // reconciles any references from a failed turn's messages.

--- a/apps/agent/src/processor.ts
+++ b/apps/agent/src/processor.ts
@@ -10,8 +10,9 @@ import { getActiveTraceIdentifiers, getOrCreateRequestId, setRequestContextAttri
 import { wrapAgentTurn } from "@cohub/infra/tracing/agent";
 import { runInActiveSpan, extractTrace } from "@cohub/infra/tracing/propagator";
 import { getAgentTracer } from "@cohub/infra/tracing/agent";
-import { getSpace } from "./api.js";
-import { abortSessionTurn, failSessionTurn, interruptSessionTurn, persistAssistantMessage, persistUserMessage } from "./persistence.js";
+import { getSpace, getSpaceSandbox } from "./api.js";
+import { assertSandboxAccessMode, resolvePromptAccessMode } from "./isolated-worker-access.js";
+import { abortSessionTurn, failSessionTurn, interruptSessionTurn, persistAssistantMessage, persistUserMessage, recoverStaleIsolatedWorkerTurn } from "./persistence.js";
 import { ensureSandboxConnection } from "./sandbox-pool.js";
 import { createSandboxCodingTools } from "./sandbox/tools.js";
 import { CohubModelRegistry } from "./runtime/model-registry.js";
@@ -31,7 +32,7 @@ import { setActiveAbortController, clearActiveAbortController, getActiveAbortEve
 import { sendOutput } from "./redis.js";
 import { env } from "./env.js";
 import { logger } from "./logger.js";
-import { getPromptAuthScopes, parsePromptEnv, type PromptAccessMode } from "@cohub/core/sessions";
+import { getPromptAuthScopes, parsePromptEnv, type AgentPromptAccessMode } from "@cohub/core/sessions";
 import { createAgentExecutionToken } from "./execution-grants.js";
 
 
@@ -644,10 +645,6 @@ function resolveActorUserId(ownerMeta: Record<string, unknown>) {
   return typeof ownerMeta.userId === "string" && ownerMeta.userId.trim() ? ownerMeta.userId.trim() : null;
 }
 
-function resolvePromptAccessMode(ownerMeta: Record<string, unknown>): PromptAccessMode {
-  return ownerMeta.accessMode === "read_only" ? "read_only" : "full_access";
-}
-
 function resolvePromptEnv(ownerMeta: Record<string, unknown>) {
   try {
     return parsePromptEnv(ownerMeta.env);
@@ -657,14 +654,15 @@ function resolvePromptEnv(ownerMeta: Record<string, unknown>) {
   }
 }
 
-function resolveBatchAccessMode(batch: { turns: Array<{ meta: unknown }> }): PromptAccessMode {
-  return batch.turns.some((turn) => resolvePromptAccessMode(turn.meta && typeof turn.meta === "object" && !Array.isArray(turn.meta) ? turn.meta as Record<string, unknown> : {}) === "read_only")
-    ? "read_only"
-    : "full_access";
+function resolveBatchAccessMode(batch: { turns: Array<{ meta: unknown }> }): AgentPromptAccessMode {
+	const modes = batch.turns.map((turn) => resolvePromptAccessMode(turn.meta && typeof turn.meta === "object" && !Array.isArray(turn.meta) ? turn.meta as Record<string, unknown> : {}));
+	if (modes.some((mode) => mode === "read_only")) return "read_only";
+	if (modes.some((mode) => mode === "isolated_worker")) return "isolated_worker";
+	return "full_access";
 }
 
 async function createTurnExecutionToken(input: {
-  accessMode: PromptAccessMode;
+  accessMode: AgentPromptAccessMode;
   actorUserId: string;
   spaceId: string;
   sessionId: string;
@@ -683,13 +681,13 @@ async function createTurnExecutionToken(input: {
   });
 }
 
-function filterToolsForAccessMode(allTools: AgentTool[], accessMode: PromptAccessMode) {
-  if (accessMode === "full_access") return allTools;
+function filterToolsForAccessMode(allTools: AgentTool[], accessMode: AgentPromptAccessMode) {
+	if (accessMode === "full_access" || accessMode === "isolated_worker") return allTools;
   const readOnlyTools = new Set(["read", "ls", "find", "grep"]);
   return allTools.filter((tool) => readOnlyTools.has(tool.name));
 }
 
-async function configureHandleAccessMode(handle: SessionHandle, accessMode: PromptAccessMode) {
+async function configureHandleAccessMode(handle: SessionHandle, accessMode: AgentPromptAccessMode) {
   if (handle.currentAccessMode === accessMode) return;
   await handle.session.configureTools(filterToolsForAccessMode(tools, accessMode));
   handle.currentAccessMode = accessMode;
@@ -793,6 +791,15 @@ export async function processAgentTurnJob(job: Job<AgentTurnJobData>) {
         }
         return result;
       }
+      if (claim.kind === "stale_isolated") {
+        await recoverStaleIsolatedWorkerTurn({
+          spaceId: data.spaceId,
+          sessionId: data.sessionId,
+          turnId: claim.turn.id,
+        });
+        drainAfterRelease = { spaceId: data.spaceId, sessionId: data.sessionId, reason: "stale_isolated_recovered" };
+        return { skipped: "stale_isolated_recovered", turnId: claim.turn.id };
+      }
 
       clearRetryState(data);
       const { batch } = claim;
@@ -811,6 +818,8 @@ export async function processAgentTurnJob(job: Job<AgentTurnJobData>) {
         promptAuth: promptContext?.auth,
       });
       const accessMode = resolveBatchAccessMode(batch);
+      const sandboxState = await getSpaceSandbox({ spaceId: data.spaceId });
+      assertSandboxAccessMode(sandboxState?.sandbox, accessMode);
       const generationPolicy = normalizeGenerationPolicy(ownerMeta.generationPolicy);
       const promptEnv = resolvePromptEnv(ownerMeta);
       const abortEvent = await getAbortEvent(batch.ownerTurn.id);
@@ -850,7 +859,7 @@ export async function processAgentTurnJob(job: Job<AgentTurnJobData>) {
         throw error;
       }
 
-      if (accessMode === "full_access") warmupSandboxConnection(data.spaceId);
+      if (accessMode === "full_access" || accessMode === "isolated_worker") warmupSandboxConnection(data.spaceId);
 
       const rawTurnUserMessages: TurnUserMessage[] = buildUserMessagesForBatch(batch)
         .filter((item) => Boolean(item.userMessageId))
@@ -913,7 +922,7 @@ export async function processAgentTurnJob(job: Job<AgentTurnJobData>) {
         .filter((item) => !hasSessionUserMessage(activeHandle, item.userMessageId))
         .map((item) => contentToAgentMessage(item.content, normalizeTurnUserMeta(item))));
 
-      const directShellItem = accessMode === "full_access" && turnUserMessages.length === 1 ? turnUserMessages[0] : null;
+      const directShellItem = (accessMode === "full_access" || accessMode === "isolated_worker") && turnUserMessages.length === 1 ? turnUserMessages[0] : null;
       const directShellCommand = directShellItem ? getShellCommandBlock(directShellItem.content) : null;
       if (directShellItem && directShellCommand) {
         await wrapAgentTurn(agentTracer, {
@@ -938,6 +947,7 @@ export async function processAgentTurnJob(job: Job<AgentTurnJobData>) {
             llmRound: 0,
             actorUserId,
             executionToken,
+            accessMode,
             executionScopes,
             fileVisibility,
             requestId,
@@ -1007,6 +1017,7 @@ export async function processAgentTurnJob(job: Job<AgentTurnJobData>) {
           llmRound: 0,
           actorUserId,
           executionToken,
+          accessMode,
           executionScopes,
           fileVisibility,
           requestId,

--- a/apps/agent/src/run-command.ts
+++ b/apps/agent/src/run-command.ts
@@ -17,8 +17,11 @@ import { logger } from "./logger.js";
 import type { AgentRunCommandJobData } from "./queue.js";
 import { createAgentExecutionToken } from "./execution-grants.js";
 import { normalizePermissionScopes } from "@cohub/core/permissions";
+import { parseAgentPromptAccessMode } from "@cohub/core/sessions";
 import { getAbortEvent } from "./abort.js";
 import { clearActiveAbortController, setActiveAbortController, setActiveAbortEvent } from "./active-turns.js";
+import { getSpaceSandbox } from "./api.js";
+import { assertSandboxAccessMode } from "./isolated-worker-access.js";
 
 const tools = createSandboxCodingTools();
 const tracer = getAgentTracer();
@@ -99,7 +102,10 @@ export async function processRunCommandJob(job: Job<AgentRunCommandJobData>): Pr
   const contextSessionId = data.origin?.sessionId ?? data.sessionId ?? "";
   const actorUserId = data.userId?.trim();
   const executionScopes = normalizePermissionScopes(data.executionScopes ?? []);
-  const executionToken = actorUserId
+  const accessMode = parseAgentPromptAccessMode(data.accessMode);
+  const sandboxState = await getSpaceSandbox({ spaceId: data.spaceId });
+  assertSandboxAccessMode(sandboxState?.sandbox, accessMode);
+  const executionToken = actorUserId && accessMode === "full_access"
     ? await createAgentExecutionToken({
         actorUserId,
         spaceId: data.spaceId,
@@ -162,6 +168,7 @@ export async function processRunCommandJob(job: Job<AgentRunCommandJobData>): Pr
       actorUserId: data.userId ?? null,
       executionToken,
       executionScopes,
+      accessMode,
       generationPolicy: data.generationPolicy ?? null,
       env: data.env ?? null,
       llmRound: 0,

--- a/apps/agent/src/runtime/tools/space-aware-query-tools.ts
+++ b/apps/agent/src/runtime/tools/space-aware-query-tools.ts
@@ -53,6 +53,9 @@ function routeExecute(options: SpaceAwareToolOptions) {
     const requestedSpaceId = getRequestedSpaceId(params);
     const targetSpaceId = requestedSpaceId ?? ctx.spaceId;
     const isCrossSpace = targetSpaceId !== ctx.spaceId;
+    if (isCrossSpace && ctx.accessMode === "isolated_worker") {
+      throw new Error("isolated worker cross-space query is forbidden");
+    }
     let tool = sandboxTool;
     let visibility = ctx.fileVisibility;
 

--- a/apps/agent/src/sandbox-pool.ts
+++ b/apps/agent/src/sandbox-pool.ts
@@ -2,8 +2,10 @@ import { createLogger } from "@cohub/infra/logging";
 import { createHash } from "node:crypto";
 import type { SandboxHeartbeat } from "@cohub/protocol/sandbox";
 import {
+  assertSandboxCanAutoRecover,
   createSandboxLifecycleController,
   getSandboxPromptRecoveryReason,
+  isTerminatedIsolatedWorkerSandbox,
 } from "@cohub/sandbox-controller";
 import {
   disconnectSandboxWsClient,
@@ -143,10 +145,11 @@ async function resolveSandboxWsUrl(spaceId: string): Promise<string> {
   if (LOCAL_SANDBOX_SPACE_ID && LOCAL_SANDBOX_WS_URL && spaceId === LOCAL_SANDBOX_SPACE_ID) {
     return LOCAL_SANDBOX_WS_URL;
   }
-
   let sandbox = (await getSpaceSandbox({ spaceId }))?.sandbox ?? null;
+  if (isTerminatedIsolatedWorkerSandbox(sandbox)) assertSandboxCanAutoRecover(sandbox);
   const recoverReason = getSandboxPromptRecoveryReason(sandbox);
   if (recoverReason && sandbox?.status !== "stopping") {
+    assertSandboxCanAutoRecover(sandbox);
     await recoverSandboxOnce(spaceId, recoverReason);
     sandbox = (await getSpaceSandbox({ spaceId }))?.sandbox ?? null;
   }

--- a/apps/agent/src/sandbox/tools.ts
+++ b/apps/agent/src/sandbox/tools.ts
@@ -626,6 +626,7 @@ function createRemoteBashOperations(): BashOperations {
           ...(ctx.generationPolicy ? { generationPolicy: ctx.generationPolicy } : {}),
           ...(ctx.env ? { env: ctx.env } : {}),
           ...(executionScopes.length ? { executionScopes } : {}),
+          ...(ctx.accessMode ? { accessMode: ctx.accessMode } : {}),
           origin: {
             kind: "bash_tool_call",
             sessionId: ctx.sessionId,

--- a/apps/agent/src/session.ts
+++ b/apps/agent/src/session.ts
@@ -26,7 +26,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { refreshUserEnv } from "./runtime/env-cache.js";
 import type { createSandboxCodingTools } from "./sandbox/tools.js";
 import type { Permission } from "@cohub/core/permissions";
-import type { PromptAccessMode } from "@cohub/core/sessions";
+import type { AgentPromptAccessMode } from "@cohub/core/sessions";
 import {
   applyAssistantMessageEvent,
   applyToolExecutionEnd,
@@ -98,7 +98,7 @@ export type SessionHandle = {
   currentAssistantMessageOrdinal?: number | null;
   currentStreamMessageId?: string | null;
   currentLlmRound?: number | null;
-  currentAccessMode: PromptAccessMode | null;
+  currentAccessMode: AgentPromptAccessMode | null;
   ownerEpoch: number;
   lastActiveAt: number;
   idleTimer: ReturnType<typeof setTimeout> | null;

--- a/apps/agent/src/tests/isolated-worker-access-mode.test.ts
+++ b/apps/agent/src/tests/isolated-worker-access-mode.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { resolvePromptAccessMode } from "../isolated-worker-access.js";
+
+assert.equal(resolvePromptAccessMode({}), "full_access");
+assert.equal(resolvePromptAccessMode({ accessMode: null }), "full_access");
+assert.equal(resolvePromptAccessMode({ accessMode: "read_only" }), "read_only");
+assert.equal(resolvePromptAccessMode({ accessMode: "full_access" }), "full_access");
+assert.equal(resolvePromptAccessMode({ accessMode: "isolated_worker" }), "isolated_worker");
+assert.throws(() => resolvePromptAccessMode({ accessMode: "isolated-wroker" }), /invalid prompt access mode/);
+assert.throws(() => resolvePromptAccessMode({ accessMode: 1 }), /invalid prompt access mode/);
+
+console.log("isolated worker access mode checks passed");

--- a/apps/agent/src/tests/isolated-worker-forged-job.test.ts
+++ b/apps/agent/src/tests/isolated-worker-forged-job.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { assertSandboxAccessMode } from "../isolated-worker-access.js";
+
+const sandbox = {
+  meta: {
+    isolatedWorkerPolicy: { disposableSpaceId: "disposable-space", executionTokenIssued: false },
+    worker_identity: { access_mode: "isolated_worker" },
+  },
+};
+
+assert.throws(() => assertSandboxAccessMode(sandbox, "full_access"), /generic Agent execution is forbidden/);
+assert.throws(() => assertSandboxAccessMode(sandbox, "read_only"), /generic Agent execution is forbidden/);
+assert.doesNotThrow(() => assertSandboxAccessMode(sandbox, "isolated_worker"));
+assert.doesNotThrow(() => assertSandboxAccessMode({ meta: {} }, "full_access"));
+
+console.log("isolated worker forged Agent job checks passed");

--- a/apps/agent/src/tests/isolated-worker-termination.test.ts
+++ b/apps/agent/src/tests/isolated-worker-termination.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { createIsolatedWorkerTerminalFinalizer } from "../isolated-worker-termination.js";
+
+const statuses = ["completed", "failed", "interrupted", "cancelled"] as const;
+const calls: string[] = [];
+const finalizer = createIsolatedWorkerTerminalFinalizer({
+  async revoke(request) {
+    calls.push(`${request.turnId}:${request.podUid}`);
+    return {
+      ok: true,
+      receipt: {
+        revokeTaskRunId: "11111111-1111-4111-8111-111111111111",
+        automaticTrigger: "turn_terminal_event",
+        manualEndpointInvoked: false,
+        podUid: request.podUid,
+        podDeleted: true,
+        credentialRevoked: true,
+        sandboxTerminated: true,
+        checkpointCreatedAfterPodDeletion: true,
+        checkpointAdapter: "trusted_production",
+        checkpointId: `checkpoint-${request.turnId}`,
+        checkpointCommit: "a".repeat(40),
+        checkpointTreeSha256: "b".repeat(64),
+      },
+    };
+  },
+});
+
+for (const [index, status] of statuses.entries()) {
+  const turnId = `turn-${index}`;
+  const receipt = await finalizer("disposable-space", {
+    id: turnId,
+    sessionId: "session-1",
+    status: status === "cancelled" ? "queued" : "running",
+    meta: {
+      isolatedWorker: {
+        sessionId: "session-1",
+        turnId,
+        isolatedWorkerPolicy: {
+          authoritySpaceId: "authority-space",
+          disposableSpaceId: "disposable-space",
+          podUid: `pod-${index}`,
+        },
+      },
+    },
+  }, status);
+  assert.equal(receipt?.podUid, `pod-${index}`);
+}
+
+assert.deepEqual(calls, statuses.map((_, index) => `turn-${index}:pod-${index}`));
+assert.equal(await finalizer("ordinary-space", {
+  id: "ordinary-turn",
+  sessionId: "session-2",
+  status: "completed",
+  meta: null,
+}, "completed"), null);
+
+await assert.rejects(() => finalizer("disposable-space", {
+  id: "running-turn",
+  sessionId: "session-1",
+  status: "running",
+  meta: {
+    isolatedWorker: {
+      sessionId: "session-1",
+      turnId: "running-turn",
+      isolatedWorkerPolicy: {
+        authoritySpaceId: "authority-space",
+        disposableSpaceId: "disposable-space",
+        podUid: "pod-running",
+      },
+    },
+  },
+}, "not-terminal" as never), /requested terminal status is invalid/);
+
+console.log("isolated worker terminal finalization checks passed");

--- a/apps/agent/src/tests/space-aware-query-tools.test.ts
+++ b/apps/agent/src/tests/space-aware-query-tools.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { getCurrentToolExecutionContext, runWithToolExecutionContext } from "../tool-context.js";
-import { createSpaceAwareReadTool } from "../runtime/tools/space-aware-query-tools.js";
+import {
+  createSpaceAwareFindTool,
+  createSpaceAwareGrepTool,
+  createSpaceAwareLsTool,
+  createSpaceAwareReadTool,
+} from "../runtime/tools/space-aware-query-tools.js";
 import type { AgentFileVisibility } from "../runtime/workspace-visibility.js";
 
 function createStubTool(name: string): AgentTool {
@@ -63,5 +68,27 @@ await assert.rejects(
   runReadTool({ targetProvider: "cloud", spaceId: "limit\u200b=30" }),
   /Invalid space_id: expected a UUID/,
 );
+
+for (const [name, createTool, params] of [
+  ["read", createSpaceAwareReadTool, { path: "README.md", space_id: TARGET_SPACE_ID }],
+  ["ls", createSpaceAwareLsTool, { path: ".", space_id: TARGET_SPACE_ID }],
+  ["find", createSpaceAwareFindTool, { path: ".", pattern: "*", space_id: TARGET_SPACE_ID }],
+  ["grep", createSpaceAwareGrepTool, { path: ".", pattern: "secret", space_id: TARGET_SPACE_ID }],
+] as const) {
+  const tool = createTool({
+    sandboxTool: createStubTool(`sandbox-${name}`),
+    crossSpaceTool: createStubTool(`cross-${name}`),
+    checkAccess: async () => "full",
+    resolveSandboxProvider: async () => "cloud",
+  });
+  await assert.rejects(
+    runWithToolExecutionContext({
+      spaceId: CURRENT_SPACE_ID,
+      sessionId: "isolated-session",
+      accessMode: "isolated_worker",
+    }, () => tool.execute(`isolated-${name}`, params)),
+    /isolated worker cross-space query is forbidden/,
+  );
+}
 
 console.log("space-aware query tool routing checks passed");

--- a/apps/agent/src/tool-context.ts
+++ b/apps/agent/src/tool-context.ts
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { GenerationPolicy } from "@cohub/protocol/generation";
+import type { AgentPromptAccessMode } from "@cohub/core/sessions";
 import type { PromptEnv } from "@cohub/core/sessions";
 import type { Permission } from "@cohub/core/permissions";
 import type { AgentFileVisibility } from "./runtime/workspace-visibility.js";
@@ -23,6 +24,7 @@ export type ToolExecutionContext = {
   toolCallId?: string;
   actorUserId?: string | null;
   executionToken?: string | null;
+  accessMode?: AgentPromptAccessMode;
   executionScopes?: Permission[] | null;
   requestId?: string | null;
   metrics?: TurnTelemetryMetrics;

--- a/apps/api/src/isolated-worker-dispatch.test.ts
+++ b/apps/api/src/isolated-worker-dispatch.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import {
+  createIsolatedWorkerDispatch,
+  createIsolatedWorkerReuseProbe,
+  computeIsolatedWorkerInputManifestSha256,
+  type IsolatedWorkerDispatchStore,
+} from "./isolated-worker-dispatch.js";
+
+const ids = [
+  "11111111-1111-4111-8111-111111111111",
+  "22222222-2222-4222-8222-222222222222",
+  "33333333-3333-4333-8333-333333333333",
+];
+const nextId = (values: string[]) => {
+  const value = values.shift();
+  if (!value) throw new Error("test UUID sequence exhausted");
+  return value;
+};
+
+const reservations: unknown[] = [];
+const enqueued: unknown[] = [];
+const failures: unknown[] = [];
+const inputBundleBase = {
+  authorityCheckpointId: "99999999-9999-4999-8999-999999999999",
+  authorityCheckpointCommit: "a".repeat(40),
+  authorityTreeSha256: "c".repeat(64),
+  items: [{ sourcePath: "modules/task.md", destinationPath: "inputs/task.md", contentSha256: "d".repeat(64), sourceType: "regular_file" as const }],
+};
+const inputBundle = {
+  ...inputBundleBase,
+  inputManifestSha256: computeIsolatedWorkerInputManifestSha256(inputBundleBase),
+  runtimeAuthorityReadAllowed: false as const,
+};
+const store: IsolatedWorkerDispatchStore = {
+  async validateInputManifest() {},
+  async reserveTask(input) {
+    reservations.push(input);
+  },
+  async enqueue(input) {
+    enqueued.push(input);
+  },
+  async markEnqueueFailed(input) {
+    failures.push(input);
+  },
+  async assertReusableProbeTarget() {
+    return { status: "terminated", authoritySpaceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" };
+  },
+  async reserveReuseProbe(input) {
+    reservations.push(input);
+  },
+};
+
+const result = await createIsolatedWorkerDispatch({
+  authoritySpaceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  userId: "user-1",
+  input: {
+    clientMessageId: "client-1",
+    content: [{ type: "text", text: "build the declared output" }],
+    inputBundle,
+  },
+  randomUUID: () => nextId(ids),
+  store,
+});
+
+assert.equal(reservations.length, 1);
+assert.equal(enqueued.length, 1);
+assert.equal(failures.length, 0);
+assert.deepEqual(result, {
+  taskRunId: "33333333-3333-4333-8333-333333333333",
+  authoritySpaceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  disposableSpaceId: "11111111-1111-4111-8111-111111111111",
+  sessionId: "22222222-2222-4222-8222-222222222222",
+  policySha256: result.policySha256,
+  inputManifestSha256: result.inputManifestSha256,
+  creationPath: "dedicated_disposable_space_without_standard_sandbox",
+  ordinarySandboxProvisioned: false,
+  terminatedSpaceReused: false,
+  credentialMode: "engine_scoped_dispatch_authority",
+  engineInternalSecretIssued: false,
+  publicPromptUsed: false,
+  checkpointAdapter: "trusted_production",
+});
+assert.match(result.policySha256, /^[a-f0-9]{64}$/);
+
+const reservation = reservations[0] as {
+  taskRunId: string;
+  payload: { data: { disposableSpaceId: string } };
+};
+assert.equal(reservation.taskRunId, result.taskRunId);
+assert.equal(reservation.payload.data.disposableSpaceId, result.disposableSpaceId);
+const queued = enqueued[0] as {
+  taskRunId: string;
+  payload: {
+    type: string;
+    spaceId: string;
+    sessionId: string;
+    data: Record<string, unknown> & { disposableSpaceId: string; engineInternalSecretIssued: boolean };
+  };
+};
+assert.equal(queued.taskRunId, result.taskRunId);
+assert.equal(queued.payload.type, "isolated_worker_dispatch");
+assert.equal(queued.payload.spaceId, result.authoritySpaceId);
+assert.equal(queued.payload.sessionId, result.sessionId);
+assert.equal(queued.payload.data.disposableSpaceId, result.disposableSpaceId);
+assert.equal(queued.payload.data.engineInternalSecretIssued, false);
+assert.equal("authToken" in queued.payload.data, false);
+assert.equal("workerSecret" in queued.payload.data, false);
+
+const failedStore: IsolatedWorkerDispatchStore = {
+  ...store,
+  async enqueue() {
+    throw new Error("queue unavailable");
+  },
+};
+await assert.rejects(
+  createIsolatedWorkerDispatch({
+    authoritySpaceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    userId: "user-1",
+    input: { clientMessageId: "client-2", content: [{ type: "text", text: "preserve me" }], inputBundle },
+    randomUUID: (() => {
+      const failedIds = [
+        "44444444-4444-4444-8444-444444444444",
+        "55555555-5555-4555-8555-555555555555",
+        "66666666-6666-4666-8666-666666666666",
+      ];
+      return () => nextId(failedIds);
+    })(),
+    store: failedStore,
+  }),
+  /queue unavailable/,
+);
+assert.equal(failures.length, 1, "queue failure must be persisted without deleting the allocation");
+
+const reuse = await createIsolatedWorkerReuseProbe({
+  authoritySpaceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  disposableSpaceId: result.disposableSpaceId,
+  sessionId: "77777777-7777-4777-8777-777777777777",
+  userId: "user-1",
+  randomUUID: () => "88888888-8888-4888-8888-888888888888",
+  store,
+});
+assert.deepEqual(reuse, {
+  taskRunId: "88888888-8888-4888-8888-888888888888",
+  disposableSpaceId: result.disposableSpaceId,
+  rejected: true,
+  reason: "terminated_space_reuse_forbidden",
+});
+const reuseJob = enqueued.at(-1) as { payload: { data: { reuseRejected: boolean } } };
+assert.equal(reuseJob.payload.data.reuseRejected, true);
+
+await assert.rejects(
+  createIsolatedWorkerDispatch({
+    authoritySpaceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    userId: "user-1",
+    input: { content: [{ type: "text", text: "x" }], inputBundle, unexpected: true } as unknown as Parameters<typeof createIsolatedWorkerDispatch>[0]["input"],
+    randomUUID: () => "99999999-9999-4999-8999-999999999999",
+    store,
+  }),
+  /unknown isolated worker dispatch field: unexpected/,
+);
+
+const policyResults: string[] = [];
+for (const text of ["content-a", "content-b"]) {
+  const localIds = [
+    "aaaaaaaa-1111-4111-8111-111111111111",
+    "aaaaaaaa-2222-4222-8222-222222222222",
+    "aaaaaaaa-3333-4333-8333-333333333333",
+  ];
+  const local = await createIsolatedWorkerDispatch({
+    authoritySpaceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    userId: "user-1",
+    input: { clientMessageId: "same-client", content: [{ type: "text", text }], inputBundle },
+    randomUUID: () => nextId(localIds),
+    store,
+  });
+  policyResults.push(local.policySha256);
+}
+assert.notEqual(policyResults[0], policyResults[1], "policy hash must bind prompt content");
+
+console.log("isolated worker public dispatch allocation checks passed");

--- a/apps/api/src/isolated-worker-dispatch.ts
+++ b/apps/api/src/isolated-worker-dispatch.ts
@@ -1,0 +1,323 @@
+import { createHash } from "node:crypto";
+import type { TaskPayload } from "@cohub/protocol/task";
+import {
+  ISOLATED_WORKER_CREATION_PATH,
+  ISOLATED_WORKER_DISPATCH_TASK_TYPE,
+  type IsolatedWorkerDispatchInput,
+  type IsolatedWorkerDispatchResponse,
+  type IsolatedWorkerDispatchTaskData,
+  type IsolatedWorkerInputBundle,
+  type IsolatedWorkerReuseProbeResponse,
+  type IsolatedWorkerReuseRejectedTaskData,
+} from "@cohub/protocol/isolated-worker";
+
+const FIXED_PROOF = {
+  creationPath: ISOLATED_WORKER_CREATION_PATH,
+  ordinarySandboxProvisioned: false,
+  terminatedSpaceReused: false,
+  credentialMode: "engine_scoped_dispatch_authority",
+  engineInternalSecretIssued: false,
+  publicPromptUsed: false,
+  checkpointAdapter: "trusted_production",
+} as const;
+
+const PUBLIC_INPUT_FIELDS = new Set([
+  "content",
+  "inputBundle",
+  "clientMessageId",
+  "title",
+  "source",
+  "model",
+  "provider",
+  "repairOfDisposableSpaceId",
+]);
+const MAX_DISPATCH_BODY_BYTES = 1_048_576;
+const MAX_CONTENT_BLOCKS = 256;
+
+export function parseIsolatedWorkerDispatchInput(value: unknown): IsolatedWorkerDispatchInput {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("request body must be an object");
+  const record = value as Record<string, unknown>;
+  const unknownField = Object.keys(record).find((field) => !PUBLIC_INPUT_FIELDS.has(field));
+  if (unknownField) throw new Error(`unknown isolated worker dispatch field: ${unknownField}`);
+  if (!Array.isArray(record.content) || record.content.length === 0 || record.content.length > MAX_CONTENT_BLOCKS) {
+    throw new Error(`content must contain between 1 and ${MAX_CONTENT_BLOCKS} blocks`);
+  }
+  for (const block of record.content) {
+    if (!block || typeof block !== "object" || Array.isArray(block) || typeof (block as { type?: unknown }).type !== "string") {
+      throw new Error("content contains an invalid block");
+    }
+  }
+  validateInputBundle(record.inputBundle);
+  const encoded = JSON.stringify(record);
+  if (Buffer.byteLength(encoded, "utf8") > MAX_DISPATCH_BODY_BYTES) throw new Error("isolated worker dispatch body exceeds one MiB");
+  for (const field of ["clientMessageId", "title", "source", "model", "provider", "repairOfDisposableSpaceId"] as const) {
+    const fieldValue = record[field];
+    if (fieldValue !== undefined && fieldValue !== null && typeof fieldValue !== "string") {
+      throw new Error(`${field} must be a string or null`);
+    }
+    if (typeof fieldValue === "string" && fieldValue.length > 2048) throw new Error(`${field} is too long`);
+  }
+  return record as unknown as IsolatedWorkerDispatchInput;
+}
+
+function validateInputBundle(value: unknown): asserts value is IsolatedWorkerInputBundle {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("inputBundle is required");
+  const manifest = value as Record<string, unknown>;
+  const allowed = new Set([
+    "authorityCheckpointId",
+    "authorityCheckpointCommit",
+    "authorityTreeSha256",
+    "inputManifestSha256",
+    "runtimeAuthorityReadAllowed",
+    "items",
+  ]);
+  const unknown = Object.keys(manifest).find((field) => !allowed.has(field));
+  if (unknown) throw new Error(`unknown inputBundle field: ${unknown}`);
+  if (typeof manifest.authorityCheckpointId !== "string" || !/^[a-f0-9-]{36}$/.test(manifest.authorityCheckpointId)) {
+    throw new Error("inputBundle.authorityCheckpointId must be a UUID");
+  }
+  if (typeof manifest.authorityCheckpointCommit !== "string" || !/^[a-f0-9]{40}$/.test(manifest.authorityCheckpointCommit)) {
+    throw new Error("inputBundle.authorityCheckpointCommit must be a lowercase Git object id");
+  }
+  for (const field of ["authorityTreeSha256", "inputManifestSha256"] as const) {
+    if (typeof manifest[field] !== "string" || !/^[a-f0-9]{64}$/.test(manifest[field])) throw new Error(`inputBundle.${field} is invalid`);
+  }
+  if (manifest.runtimeAuthorityReadAllowed !== false) throw new Error("inputBundle.runtimeAuthorityReadAllowed must be false");
+  if (!Array.isArray(manifest.items) || manifest.items.length === 0 || manifest.items.length > 32) {
+    throw new Error("inputBundle.items must contain between 1 and 32 items");
+  }
+  const sources = new Set<string>();
+  const destinations = new Set<string>();
+  for (const [index, rawFile] of manifest.items.entries()) {
+    if (!rawFile || typeof rawFile !== "object" || Array.isArray(rawFile)) throw new Error(`inputBundle.items[${index}] is invalid`);
+    const file = rawFile as Record<string, unknown>;
+    const unknownFileField = Object.keys(file).find((field) => !["sourcePath", "destinationPath", "contentSha256", "sourceType"].includes(field));
+    if (unknownFileField) throw new Error(`unknown inputBundle item field: ${unknownFileField}`);
+    if (typeof file.sourcePath !== "string" || !file.sourcePath || file.sourcePath.length > 2048) throw new Error(`inputBundle.items[${index}].sourcePath is invalid`);
+    if (typeof file.destinationPath !== "string" || !file.destinationPath || file.destinationPath.length > 2048) throw new Error(`inputBundle.items[${index}].destinationPath is invalid`);
+    const source = file.sourcePath;
+    const destination = file.destinationPath;
+    if (sources.has(source)) throw new Error(`duplicate inputBundle sourcePath: ${source}`);
+    if (destinations.has(destination)) throw new Error(`duplicate inputBundle destinationPath: ${destination}`);
+    sources.add(source);
+    destinations.add(destination);
+    if (typeof file.contentSha256 !== "string" || !/^[a-f0-9]{64}$/.test(file.contentSha256)) throw new Error(`inputBundle.items[${index}].contentSha256 is invalid`);
+    if (file.sourceType !== "regular_file") throw new Error(`inputBundle.items[${index}].sourceType must be regular_file`);
+  }
+  const computed = computeIsolatedWorkerInputManifestSha256(manifest as unknown as IsolatedWorkerInputBundle);
+  if (computed !== manifest.inputManifestSha256) throw new Error("inputBundle.inputManifestSha256 mismatch");
+}
+
+export type IsolatedWorkerDispatchReservation = {
+  taskRunId: string;
+  payload: TaskPayload;
+  space: {
+    id: string;
+    userUuid: string;
+    name: string;
+    storageRepoName: string;
+    meta: Record<string, unknown>;
+  };
+  member: { spaceId: string; userId: string; role: "host"; createdBy: string; updatedBy: string };
+  session: {
+    id: string;
+    spaceId: string;
+    userUuid: string;
+    title: string;
+    source: "isolated_worker_dispatch";
+    status: "active";
+    meta: Record<string, unknown>;
+  };
+  sandbox: {
+    spaceId: string;
+    provider: "cloud";
+    status: "allocated";
+    runtimeStatus: "unknown";
+    podName: null;
+    meta: Record<string, unknown>;
+  };
+};
+
+export type IsolatedWorkerDispatchStore = {
+  validateInputManifest(input: { authoritySpaceId: string; userId: string; inputBundle: IsolatedWorkerInputBundle }): Promise<void>;
+  reserveTask(input: { taskRunId: string; payload: TaskPayload }): Promise<void>;
+  enqueue(input: { taskRunId: string; payload: TaskPayload }): Promise<void>;
+  markEnqueueFailed(input: { taskRunId: string; disposableSpaceId: string; error: unknown }): Promise<void>;
+  assertReusableProbeTarget(input: { authoritySpaceId: string; disposableSpaceId: string; userId: string }): Promise<{
+    status: string;
+    authoritySpaceId: string;
+  }>;
+  reserveReuseProbe(input: { taskRunId: string; payload: TaskPayload }): Promise<void>;
+};
+
+function requireText(value: unknown, field: string) {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${field} is required`);
+  return value.trim();
+}
+
+export function canonicalIsolatedWorkerJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalIsolatedWorkerJson).join(",")}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonicalIsolatedWorkerJson(record[key])}`).join(",")}}`;
+}
+
+export function computeIsolatedWorkerInputManifestSha256(inputBundle: Omit<IsolatedWorkerInputBundle, "inputManifestSha256" | "runtimeAuthorityReadAllowed">) {
+  return createHash("sha256").update(canonicalIsolatedWorkerJson({
+    authorityCheckpointId: inputBundle.authorityCheckpointId,
+    authorityCheckpointCommit: inputBundle.authorityCheckpointCommit,
+    authorityTreeSha256: inputBundle.authorityTreeSha256,
+    items: inputBundle.items,
+  })).digest("hex");
+}
+
+export function computeIsolatedWorkerPolicySha256(input: {
+  taskRunId: string;
+  authoritySpaceId: string;
+  disposableSpaceId: string;
+  sessionId: string;
+  clientMessageId: string;
+  content: unknown;
+  source: string;
+  model: string | null;
+  provider: string | null;
+  repairOfDisposableSpaceId?: string;
+  inputManifestSha256: string;
+}) {
+  const contentSha256 = createHash("sha256").update(canonicalIsolatedWorkerJson(input.content)).digest("hex");
+  const canonical = canonicalIsolatedWorkerJson({
+    taskRunId: input.taskRunId,
+    authoritySpaceId: input.authoritySpaceId,
+    disposableSpaceId: input.disposableSpaceId,
+    sessionId: input.sessionId,
+    clientMessageId: input.clientMessageId,
+    contentSha256,
+    source: input.source,
+    model: input.model,
+    provider: input.provider,
+    repairOfDisposableSpaceId: input.repairOfDisposableSpaceId ?? null,
+    inputManifestSha256: input.inputManifestSha256,
+    writableRoot: "/workspace/work",
+    workspaceReadOnly: true,
+    executionTokenIssued: false,
+    ...FIXED_PROOF,
+  });
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+export async function createIsolatedWorkerDispatch(input: {
+  authoritySpaceId: string;
+  userId: string;
+  input: IsolatedWorkerDispatchInput;
+  randomUUID?: () => string;
+  store: IsolatedWorkerDispatchStore;
+}): Promise<IsolatedWorkerDispatchResponse> {
+  const parsedInput = parseIsolatedWorkerDispatchInput(input.input);
+  const authoritySpaceId = requireText(input.authoritySpaceId, "authoritySpaceId");
+  const userId = requireText(input.userId, "userId");
+  const randomUUID = input.randomUUID ?? crypto.randomUUID;
+  const disposableSpaceId = randomUUID();
+  const sessionId = randomUUID();
+  const taskRunId = randomUUID();
+  const clientMessageId = parsedInput.clientMessageId?.trim() || randomUUID();
+  const repairOfDisposableSpaceId = parsedInput.repairOfDisposableSpaceId?.trim() || undefined;
+  if (repairOfDisposableSpaceId === disposableSpaceId || repairOfDisposableSpaceId === authoritySpaceId) {
+    throw new Error("repair target must be a prior disposable space");
+  }
+  if (repairOfDisposableSpaceId) {
+    const target = await input.store.assertReusableProbeTarget({ authoritySpaceId, disposableSpaceId: repairOfDisposableSpaceId, userId });
+    if (target.authoritySpaceId !== authoritySpaceId || !["stopping", "terminated"].includes(target.status)) {
+      throw new Error("repair target must be a stopped disposable space owned by the authority");
+    }
+  }
+  await input.store.validateInputManifest({ authoritySpaceId, userId, inputBundle: parsedInput.inputBundle });
+  const inputManifestSha256 = parsedInput.inputBundle.inputManifestSha256;
+  const source = parsedInput.source?.trim() || "isolated_worker_dispatch";
+  const model = parsedInput.model?.trim() || null;
+  const provider = parsedInput.provider?.trim() || null;
+  const policyHash = computeIsolatedWorkerPolicySha256({
+    taskRunId,
+    authoritySpaceId,
+    disposableSpaceId,
+    sessionId,
+    clientMessageId,
+    content: parsedInput.content,
+    source,
+    model,
+    provider,
+    repairOfDisposableSpaceId,
+    inputManifestSha256,
+  });
+
+  const taskData: IsolatedWorkerDispatchTaskData = {
+    authoritySpaceId,
+    disposableSpaceId,
+    sessionId,
+    clientMessageId,
+    content: parsedInput.content,
+    source,
+    model,
+    provider,
+    policySha256: policyHash,
+    inputBundle: parsedInput.inputBundle,
+    inputManifestSha256,
+    ...FIXED_PROOF,
+    ...(repairOfDisposableSpaceId ? { repairOfDisposableSpaceId } : {}),
+  };
+  const payload: TaskPayload = {
+    type: ISOLATED_WORKER_DISPATCH_TASK_TYPE,
+    spaceId: authoritySpaceId,
+    sessionId,
+    userId,
+    data: taskData,
+  };
+  await input.store.reserveTask({ taskRunId, payload });
+
+  try {
+    await input.store.enqueue({ taskRunId, payload });
+  } catch (error) {
+    await input.store.markEnqueueFailed({ taskRunId, disposableSpaceId, error });
+    throw error;
+  }
+
+  return {
+    taskRunId,
+    authoritySpaceId,
+    disposableSpaceId,
+    sessionId,
+    policySha256: policyHash,
+    inputManifestSha256,
+    ...FIXED_PROOF,
+  };
+}
+
+export async function createIsolatedWorkerReuseProbe(input: {
+  authoritySpaceId: string;
+  disposableSpaceId: string;
+  sessionId: string;
+  userId: string;
+  randomUUID?: () => string;
+  store: IsolatedWorkerDispatchStore;
+}): Promise<IsolatedWorkerReuseProbeResponse> {
+  const target = await input.store.assertReusableProbeTarget(input);
+  if (target.authoritySpaceId !== input.authoritySpaceId || target.status !== "terminated") {
+    throw new Error("reuse probe requires a terminated disposable space owned by the authority");
+  }
+  const taskRunId = (input.randomUUID ?? crypto.randomUUID)();
+  const data: IsolatedWorkerReuseRejectedTaskData = {
+    authoritySpaceId: input.authoritySpaceId,
+    disposableSpaceId: input.disposableSpaceId,
+    reuseRejected: true,
+    reason: "terminated_space_reuse_forbidden",
+  };
+  const payload: TaskPayload = {
+    type: ISOLATED_WORKER_DISPATCH_TASK_TYPE,
+    spaceId: input.authoritySpaceId,
+    sessionId: input.sessionId,
+    userId: input.userId,
+    data,
+  };
+  await input.store.reserveReuseProbe({ taskRunId, payload });
+  await input.store.enqueue({ taskRunId, payload });
+  return { taskRunId, disposableSpaceId: input.disposableSpaceId, rejected: true, reason: data.reason };
+}

--- a/apps/api/src/isolated-worker-disposable-guard-domain.ts
+++ b/apps/api/src/isolated-worker-disposable-guard-domain.ts
@@ -1,0 +1,113 @@
+import type { Context } from "hono";
+
+export type IsolatedWorkerDisposableState = "active" | "terminated";
+
+export type IsolatedWorkerDisposableOperation =
+  | "generic_mutation"
+  | "generic_prompt"
+  | "generic_task_dispatch"
+  | "cron_schedule"
+  | "sandbox_lifecycle"
+  | "isolated_worker_dispatch"
+  | "isolated_worker_runtime"
+  | "isolated_worker_revoke"
+  | "isolated_worker_checkpoint"
+  | "isolated_worker_receipt_scan"
+  | "isolated_worker_reuse_probe";
+
+export type IsolatedWorkerDisposableRecord = {
+  spaceMeta: unknown;
+  sandboxStatus: string | null;
+  sandboxMeta: unknown;
+};
+
+const ACTIVE_OPERATIONS = new Set<IsolatedWorkerDisposableOperation>([
+  "isolated_worker_dispatch",
+  "isolated_worker_runtime",
+  "isolated_worker_revoke",
+  "isolated_worker_checkpoint",
+  "isolated_worker_reuse_probe",
+]);
+
+const TERMINATED_OPERATIONS = new Set<IsolatedWorkerDisposableOperation>([
+  "isolated_worker_checkpoint",
+  "isolated_worker_receipt_scan",
+]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+const hasOwn = (value: Record<string, unknown>, key: string) =>
+  Object.hasOwn(value, key);
+
+export function classifyIsolatedWorkerDisposable(
+  input: IsolatedWorkerDisposableRecord | null,
+): IsolatedWorkerDisposableState | null {
+  if (!input) return null;
+  const spaceMeta = isRecord(input.spaceMeta) ? input.spaceMeta : null;
+  const sandboxMeta = isRecord(input.sandboxMeta) ? input.sandboxMeta : null;
+  const hasDisposableIdentity = Boolean(
+    (spaceMeta && hasOwn(spaceMeta, "isolatedWorkerDisposable"))
+    || (sandboxMeta && (
+      hasOwn(sandboxMeta, "isolatedWorker")
+      || hasOwn(sandboxMeta, "isolatedWorkerPolicy")
+      || hasOwn(sandboxMeta, "isolatedWorkerDisposable")
+    )),
+  );
+  if (!hasDisposableIdentity) return null;
+
+  const termination = sandboxMeta && isRecord(sandboxMeta.termination) ? sandboxMeta.termination : null;
+  const isolatedWorker = sandboxMeta && isRecord(sandboxMeta.isolatedWorker) ? sandboxMeta.isolatedWorker : null;
+  if (
+    input.sandboxStatus === "terminated"
+    || termination?.sandboxTerminated === true
+    || isolatedWorker?.state === "terminated"
+  ) return "terminated";
+  return "active";
+}
+
+export class IsolatedWorkerDisposableOperationError extends Error {
+  readonly code = "ISOLATED_WORKER_DISPOSABLE_OPERATION_FORBIDDEN";
+
+  constructor(
+    readonly spaceId: string,
+    readonly state: IsolatedWorkerDisposableState,
+    readonly operation: IsolatedWorkerDisposableOperation,
+  ) {
+    super(`generic ${operation} is forbidden for ${state} isolated worker disposable space`);
+    this.name = "IsolatedWorkerDisposableOperationError";
+  }
+}
+
+export function createIsolatedWorkerDisposableGuard(
+  read: (spaceId: string) => Promise<IsolatedWorkerDisposableRecord | null>,
+) {
+  return async (spaceId: string, operation: IsolatedWorkerDisposableOperation) => {
+    const state = classifyIsolatedWorkerDisposable(await read(spaceId));
+    if (!state) return;
+    if (state === "active" && ACTIVE_OPERATIONS.has(operation)) return;
+    if (state === "terminated" && TERMINATED_OPERATIONS.has(operation)) return;
+    throw new IsolatedWorkerDisposableOperationError(spaceId, state, operation);
+  };
+}
+
+export function createIsolatedWorkerDisposableRouteGuard(
+  assertAllowed: (spaceId: string, operation: IsolatedWorkerDisposableOperation) => Promise<void>,
+) {
+  return async (
+    c: Context,
+    input: { spaceId: string; operation: IsolatedWorkerDisposableOperation },
+  ): Promise<Response | null> => {
+    try {
+      await assertAllowed(input.spaceId, input.operation);
+      return null;
+    } catch (error) {
+      if (!(error instanceof IsolatedWorkerDisposableOperationError)) throw error;
+      return c.json({
+        message: "isolated worker disposable spaces only accept dedicated isolated worker lifecycle operations",
+        code: error.code,
+        state: error.state,
+      }, 409);
+    }
+  };
+}

--- a/apps/api/src/isolated-worker-disposable-guard.test.ts
+++ b/apps/api/src/isolated-worker-disposable-guard.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import {
+  classifyIsolatedWorkerDisposable,
+  createIsolatedWorkerDisposableGuard,
+  createIsolatedWorkerDisposableRouteGuard,
+  IsolatedWorkerDisposableOperationError,
+  type IsolatedWorkerDisposableRecord,
+} from "./isolated-worker-disposable-guard-domain.js";
+
+const ordinary: IsolatedWorkerDisposableRecord = {
+  spaceMeta: { config: {} },
+  sandboxStatus: "running",
+  sandboxMeta: {},
+};
+const active: IsolatedWorkerDisposableRecord = {
+  spaceMeta: { isolatedWorkerDisposable: { authoritySpaceId: "authority" } },
+  sandboxStatus: "running",
+  sandboxMeta: { isolatedWorker: { state: "running" } },
+};
+const terminated: IsolatedWorkerDisposableRecord = {
+  spaceMeta: { isolatedWorkerDisposable: null },
+  sandboxStatus: "running",
+  sandboxMeta: { termination: { sandboxTerminated: true } },
+};
+
+assert.equal(classifyIsolatedWorkerDisposable(null), null);
+assert.equal(classifyIsolatedWorkerDisposable(ordinary), null);
+assert.equal(classifyIsolatedWorkerDisposable(active), "active");
+assert.equal(classifyIsolatedWorkerDisposable(terminated), "terminated");
+assert.equal(classifyIsolatedWorkerDisposable({
+  spaceMeta: {},
+  sandboxStatus: "allocated",
+  sandboxMeta: { isolatedWorkerPolicy: null },
+}), "active", "a malformed persisted identity must fail closed");
+
+let reads = 0;
+const records = new Map<string, IsolatedWorkerDisposableRecord>([
+  ["ordinary", ordinary],
+  ["active", active],
+  ["terminated", terminated],
+]);
+const guard = createIsolatedWorkerDisposableGuard(async (spaceId) => {
+  reads += 1;
+  return records.get(spaceId) ?? null;
+});
+
+await guard("ordinary", "generic_prompt");
+await assert.rejects(
+  guard("active", "generic_task_dispatch"),
+  (error: unknown) => error instanceof IsolatedWorkerDisposableOperationError
+    && error.state === "active"
+    && error.operation === "generic_task_dispatch",
+);
+await assert.rejects(
+  guard("terminated", "sandbox_lifecycle"),
+  (error: unknown) => error instanceof IsolatedWorkerDisposableOperationError
+    && error.state === "terminated",
+);
+for (const operation of [
+  "isolated_worker_dispatch",
+  "isolated_worker_runtime",
+  "isolated_worker_revoke",
+  "isolated_worker_checkpoint",
+  "isolated_worker_reuse_probe",
+] as const) {
+  await guard("active", operation);
+}
+for (const operation of [
+  "isolated_worker_checkpoint",
+  "isolated_worker_receipt_scan",
+] as const) {
+  await guard("terminated", operation);
+}
+await assert.rejects(guard("terminated", "isolated_worker_revoke"), IsolatedWorkerDisposableOperationError);
+await assert.rejects(guard("terminated", "isolated_worker_reuse_probe"), IsolatedWorkerDisposableOperationError);
+await assert.rejects(guard("active", "isolated_worker_receipt_scan"), IsolatedWorkerDisposableOperationError);
+assert.equal(reads, 13);
+
+let sideEffects = 0;
+const routeGuard = createIsolatedWorkerDisposableRouteGuard(guard);
+const app = new Hono();
+app.post("/:id/generic", async (c) => {
+  const rejected = await routeGuard(c, { spaceId: c.req.param("id"), operation: "generic_mutation" });
+  if (rejected) return rejected;
+  sideEffects += 1;
+  return c.json({ ok: true });
+});
+
+const blocked = await app.request("http://test/active/generic", { method: "POST" });
+assert.equal(blocked.status, 409);
+assert.deepEqual(await blocked.json(), {
+  message: "isolated worker disposable spaces only accept dedicated isolated worker lifecycle operations",
+  code: "ISOLATED_WORKER_DISPOSABLE_OPERATION_FORBIDDEN",
+  state: "active",
+});
+assert.equal(sideEffects, 0, "a rejected route must not run downstream side effects");
+
+const allowed = await app.request("http://test/ordinary/generic", { method: "POST" });
+assert.equal(allowed.status, 200);
+assert.equal(sideEffects, 1);
+
+console.log("isolated worker disposable guard checks passed");

--- a/apps/api/src/isolated-worker-disposable-guard.ts
+++ b/apps/api/src/isolated-worker-disposable-guard.ts
@@ -1,0 +1,32 @@
+import { eq } from "drizzle-orm";
+import { spaceSandboxes, spaces } from "@cohub/db";
+import { db } from "./db/index.js";
+import {
+  createIsolatedWorkerDisposableGuard,
+  createIsolatedWorkerDisposableRouteGuard,
+} from "./isolated-worker-disposable-guard-domain.js";
+
+export {
+  IsolatedWorkerDisposableOperationError,
+  type IsolatedWorkerDisposableOperation,
+} from "./isolated-worker-disposable-guard-domain.js";
+
+export const assertIsolatedWorkerDisposableOperationAllowed = createIsolatedWorkerDisposableGuard(
+  async (spaceId) => {
+    const [row] = await db
+      .select({
+        spaceMeta: spaces.meta,
+        sandboxStatus: spaceSandboxes.status,
+        sandboxMeta: spaceSandboxes.meta,
+      })
+      .from(spaces)
+      .leftJoin(spaceSandboxes, eq(spaceSandboxes.spaceId, spaces.id))
+      .where(eq(spaces.id, spaceId))
+      .limit(1);
+    return row ?? null;
+  },
+);
+
+export const rejectIsolatedWorkerDisposableRouteMutation = createIsolatedWorkerDisposableRouteGuard(
+  assertIsolatedWorkerDisposableOperationAllowed,
+);

--- a/apps/api/src/isolated-worker-pods.test.ts
+++ b/apps/api/src/isolated-worker-pods.test.ts
@@ -1,0 +1,768 @@
+import assert from "node:assert/strict";
+import type { V1Pod } from "@kubernetes/client-node";
+import { config } from "./config.js";
+import {
+  buildIsolatedWorkerSandboxRegistration,
+  createIsolatedWorkerPodLifecycle,
+  type FrozenCheckpointReadback,
+  IsolatedWorkerCheckpointNoEffectError,
+  renderIsolatedWorkerPodTemplate,
+  type IsolatedWorkerRevocationReceipt,
+  validateFrozenCheckpointReadback,
+} from "./isolated-worker-pods.js";
+
+const binding = {
+  authoritySpaceId: "7d8f6814-b123-410f-861f-67c07717ac68",
+  disposableSpaceId: "6d8f6814-b123-410f-861f-67c07717ac69",
+  sessionId: "5212eda6-7336-4b30-8050-e9d27dbc77f0",
+  turnId: "0212eda6-7336-4b30-8050-e9d27dbc77f1",
+};
+const policySha256 = "a".repeat(64);
+const revocationContext = {
+  revokeTaskRunId: "1212eda6-7336-4b30-8050-e9d27dbc77f2",
+  automaticTrigger: "turn_terminal_event" as const,
+  manualEndpointInvoked: false as const,
+};
+
+const pod = renderIsolatedWorkerPodTemplate({
+  ...binding,
+  image: "registry.example/cohub-sandbox:test",
+  spaceStoragePvc: "cohub-spaces-pvc",
+  spaceStorageSubpath: "cohub-dev",
+  writableRoot: "/workspace/work",
+  policySha256,
+});
+
+assert.equal(pod.spec?.restartPolicy, "Never");
+assert.equal(pod.spec?.automountServiceAccountToken, false);
+assert.equal(pod.spec?.enableServiceLinks, false);
+assert.deepEqual(pod.spec?.containers?.[0]?.env?.map((item) => item.name), [
+  "COHUB_SPACE_ID",
+  "WORKSPACE_DIR",
+  "IMAGE_VERSION",
+  "POD_IP",
+]);
+assert.equal(pod.spec?.containers?.[0]?.env?.some((item) => /TOKEN|SECRET|KEY|CREDENTIAL/i.test(item.name)), false);
+assert.equal(pod.spec?.containers?.[0]?.envFrom, undefined);
+assert.deepEqual(pod.spec?.imagePullSecrets, [{ name: "gitea-registry" }]);
+assert.equal(pod.spec?.securityContext?.runAsNonRoot, true);
+assert.equal(pod.spec?.securityContext?.runAsUser, 1000);
+assert.equal(pod.spec?.securityContext?.seccompProfile?.type, "RuntimeDefault");
+assert.equal(pod.spec?.containers?.[0]?.securityContext?.allowPrivilegeEscalation, false);
+assert.equal(pod.spec?.containers?.[0]?.securityContext?.readOnlyRootFilesystem, true);
+assert.deepEqual(pod.spec?.containers?.[0]?.securityContext?.capabilities?.drop, ["ALL"]);
+assert.deepEqual(pod.spec?.containers?.[0]?.resources, {
+  requests: { cpu: "100m", memory: "256Mi" },
+  limits: { cpu: "2", memory: "4Gi" },
+});
+assert.deepEqual(
+  pod.spec?.nodeSelector,
+  Object.keys(config.sandboxNodeSelector).length > 0 ? config.sandboxNodeSelector : undefined,
+);
+assert.deepEqual(
+  pod.spec?.tolerations,
+  config.sandboxTolerations.length > 0 ? config.sandboxTolerations : undefined,
+);
+assert.deepEqual(pod.spec?.containers?.[0]?.volumeMounts, [
+  {
+    name: "space-storage",
+    mountPath: "/workspace",
+    subPath: `cohub-dev/${binding.disposableSpaceId}/workspace`,
+    readOnly: true,
+  },
+  {
+    name: "space-storage",
+    mountPath: "/workspace/work",
+    subPath: `cohub-dev/${binding.disposableSpaceId}/workspace/work`,
+    readOnly: false,
+  },
+  {
+    name: "runtime-tmp",
+    mountPath: "/tmp",
+  },
+]);
+assert.deepEqual(pod.spec?.volumes, [
+  {
+    name: "space-storage",
+    persistentVolumeClaim: { claimName: "cohub-spaces-pvc" },
+  },
+  {
+    name: "runtime-tmp",
+    emptyDir: {},
+  },
+]);
+assert.equal(pod.metadata?.labels?.["cohub.run/space-id"], binding.disposableSpaceId);
+assert.equal(pod.metadata?.labels?.["cohub.run/authority-space-id"], binding.authoritySpaceId);
+assert.equal(pod.metadata?.labels?.["cohub.run/session-id"], binding.sessionId);
+assert.equal(pod.metadata?.labels?.["cohub.run/turn-id"], binding.turnId);
+assert.equal(pod.metadata?.labels?.["cohub.run/disposable-space-id"], binding.disposableSpaceId);
+assert.deepEqual(pod.metadata?.annotations, {
+  "cohub.run/authority_space_id": binding.authoritySpaceId,
+  "cohub.run/worker_identity.access_mode": "isolated_worker",
+  "cohub.run/write_scope.mode": "isolated_task_space",
+  "cohub.run/write_scope.root": "work/",
+  "cohub.run/disposable_space_id": binding.disposableSpaceId,
+  "cohub.run/termination_required": "true",
+  "cohub.run/workflow_execution_token_issued": "false",
+  "cohub.run/policy_sha256": policySha256,
+});
+
+for (const writableRoot of [
+  "/workspace/tasks/work",
+  "/workspace/tasks/not-work",
+  "/workspace/tasks/work/child",
+  "/workspace/tasks/../work",
+  "/tmp/tasks/work",
+]) {
+  assert.throws(() => renderIsolatedWorkerPodTemplate({
+    ...binding,
+    image: "sandbox:test",
+    spaceStoragePvc: "cohub-spaces-pvc",
+    spaceStorageSubpath: "cohub-dev",
+    writableRoot,
+    policySha256,
+  }), /writableRoot/);
+}
+assert.throws(() => renderIsolatedWorkerPodTemplate({
+  ...binding,
+  image: "sandbox:test",
+  spaceStoragePvc: "cohub-spaces-pvc",
+  spaceStorageSubpath: "cohub-dev",
+  writableRoot: "/workspace/work",
+  policySha256: "not-a-hash",
+}), /policySha256/);
+
+const calls: string[] = [];
+let createdPod: V1Pod | null = null;
+let persistedReceipt: IsolatedWorkerRevocationReceipt | null = null;
+let persistedCheckpoint: FrozenCheckpointReadback | null = null;
+const lifecycle = createIsolatedWorkerPodLifecycle({
+  namespace: "cohub-dev",
+  infra: {
+    async createPod(input) {
+      calls.push(`create:${input.namespace}`);
+      createdPod = {
+        ...input.pod,
+        metadata: { ...input.pod.metadata, uid: "pod-uid-1", creationTimestamp: new Date("2026-07-15T00:00:00.500Z") },
+      };
+      return createdPod;
+    },
+    async readPod(input) {
+      calls.push(`read:${input.podName}`);
+      return createdPod;
+    },
+    async waitForPodReady(input) {
+      calls.push(`ready:${input.podName}`);
+      if (!createdPod) return null;
+      createdPod = {
+        ...createdPod,
+        status: {
+          podIP: "10.0.0.5",
+          conditions: [{ type: "Ready", status: "True" }],
+        },
+      };
+      return createdPod;
+    },
+    async deletePod(input) {
+      calls.push(`delete:${input.podUid}`);
+      createdPod = null;
+    },
+    async waitForPodDeleted(input) {
+      calls.push(`wait:${input.podName}`);
+      return createdPod === null;
+    },
+  },
+  state: {
+    async claimCreate() { calls.push("claim-create"); return true; },
+    async markCreateFailed() { calls.push("mark-create-failed"); return true; },
+    async markRunning() { calls.push("mark-running"); },
+    async readTerminationReceipt() { return persistedReceipt; },
+    async claimTermination() {
+      calls.push("claim-termination");
+      return persistedReceipt === null;
+    },
+    async markPodDeleted(input) { calls.push("mark-pod-deleted"); return input.podDeletedAt; },
+    async claimCheckpoint() { calls.push("claim-checkpoint"); return true; },
+    async readCheckpoint() { return persistedCheckpoint; },
+    async persistCheckpoint(input) { calls.push("persist-checkpoint"); persistedCheckpoint = input.checkpoint; return true; },
+    async completeTermination(input) {
+      calls.push("complete-termination");
+      persistedReceipt = input.receipt;
+      return true;
+    },
+  },
+  async createFrozenCheckpoint() {
+    calls.push("checkpoint");
+    return {
+      disposableSpaceId: binding.disposableSpaceId,
+      checkpointId: "checkpoint-1",
+      commit: "abc123",
+      tree: "tree123",
+      treeSha256: "b".repeat(64),
+      currentHead: "abc123",
+      checkpointCreatedAt: "2099-01-01T00:00:00.000Z",
+    };
+  },
+});
+
+const handle = await lifecycle.create({
+  ...binding,
+  image: "sandbox:test",
+  spaceStoragePvc: "cohub-spaces-pvc",
+  spaceStorageSubpath: "cohub-dev",
+  writableRoot: "/workspace/work",
+  policySha256,
+});
+assert.deepEqual(handle.metadata, {
+  worker_identity: { access_mode: "isolated_worker" },
+  write_scope: { mode: "isolated_task_space", root: "work/" },
+  disposable_space_id: binding.disposableSpaceId,
+  termination_required: true,
+  workflow_execution_token_issued: false,
+});
+assert.deepEqual(handle.isolatedWorkerPolicy, {
+  authoritySpaceId: binding.authoritySpaceId,
+  disposableSpaceId: binding.disposableSpaceId,
+  writableRoot: "/workspace/work",
+  workspaceReadOnly: true,
+  executionTokenIssued: false,
+  podUid: "pod-uid-1",
+  policySha256,
+});
+assert.equal(handle.resumable, false);
+assert.equal(handle.status, "running");
+assert.equal(handle.podCreatedAt, "2026-07-15T00:00:00.500Z");
+if (!createdPod) throw new Error("ready pod was not retained by the test infra");
+const boundPod: V1Pod = createdPod;
+const registration = buildIsolatedWorkerSandboxRegistration(handle, boundPod);
+assert.equal(registration.spaceId, binding.disposableSpaceId);
+assert.equal(registration.status, "ready");
+assert.equal(registration.runtimeStatus, "healthy");
+assert.equal(registration.meta.podIp, "10.0.0.5");
+assert.equal(registration.meta.wsEndpoint, "ws://10.0.0.5:8788/sandbox");
+
+const receipt = await lifecycle.revoke(handle, revocationContext);
+assert.deepEqual(calls.map((call) => call.split(":")[0]), ["claim-create", "create", "ready", "mark-running", "claim-termination", "read", "delete", "wait", "mark-pod-deleted", "claim-checkpoint", "checkpoint", "persist-checkpoint", "complete-termination"]);
+assert.equal(receipt.podUid, "pod-uid-1");
+assert.equal(receipt.podDeleted, true);
+assert.ok(receipt.podDeletedAt.length > 0);
+assert.equal(receipt.credentialRevoked, true);
+assert.equal(receipt.sandboxTerminated, true);
+assert.equal(receipt.checkpointCreatedAfterPodDeletion, true);
+assert.equal(receipt.checkpointAdapter, "trusted_production");
+assert.ok(receipt.terminatedAt.length > 0);
+assert.equal(receipt.checkpointId, "checkpoint-1");
+assert.equal(receipt.checkpointCommit, "abc123");
+assert.equal(receipt.checkpointTreeSha256, "b".repeat(64));
+assert.equal(receipt.revokeTaskRunId, revocationContext.revokeTaskRunId);
+assert.equal(receipt.automaticTrigger, "turn_terminal_event");
+assert.equal(receipt.manualEndpointInvoked, false);
+
+const callsAfterFirstRevocation = calls.length;
+const repeatedReceipt = await lifecycle.revoke(handle, revocationContext);
+assert.deepEqual(repeatedReceipt, receipt, "repeated revocation must return the exact persisted receipt");
+assert.equal(calls.length, callsAfterFirstRevocation, "repeated revocation must not delete or checkpoint again");
+await assert.rejects(
+  () => lifecycle.revoke(handle, {
+    ...revocationContext,
+    revokeTaskRunId: "2212eda6-7336-4b30-8050-e9d27dbc77f3",
+  }),
+  /TaskRun binding mismatch/,
+);
+await assert.rejects(
+  () => lifecycle.revoke(handle, {
+    ...revocationContext,
+    manualEndpointInvoked: true as never,
+  }),
+  /automatic terminal Turn event/,
+);
+
+let inProgressSideEffect = false;
+const inProgressLifecycle = createIsolatedWorkerPodLifecycle({
+  infra: {
+    async createPod() { throw new Error("not used"); },
+    async readPod() { inProgressSideEffect = true; return null; },
+    async waitForPodReady() { throw new Error("not used"); },
+    async deletePod() { inProgressSideEffect = true; },
+    async waitForPodDeleted() { inProgressSideEffect = true; return true; },
+  },
+  state: {
+    async claimCreate() { throw new Error("not used"); },
+    async markCreateFailed() { throw new Error("not used"); },
+    async markRunning() { throw new Error("not used"); },
+    async readTerminationReceipt() { return null; },
+    async claimTermination() { return false; },
+    async markPodDeleted() { inProgressSideEffect = true; return null; },
+    async claimCheckpoint() { inProgressSideEffect = true; return false; },
+    async readCheckpoint() { inProgressSideEffect = true; return null; },
+    async persistCheckpoint() { inProgressSideEffect = true; return false; },
+    async completeTermination() { inProgressSideEffect = true; return true; },
+  },
+  async createFrozenCheckpoint() {
+    inProgressSideEffect = true;
+    throw new Error("must not checkpoint an already claimed revocation");
+  },
+});
+await assert.rejects(() => inProgressLifecycle.revoke(handle, revocationContext), /already in progress/);
+assert.equal(inProgressSideEffect, false);
+
+let concurrentClaims = 0;
+let concurrentCheckpoints = 0;
+let concurrentReceipt: IsolatedWorkerRevocationReceipt | null = null;
+const concurrentLifecycle = createIsolatedWorkerPodLifecycle({
+  infra: {
+    async createPod() { throw new Error("not used"); },
+    async readPod() { return null; },
+    async waitForPodReady() { throw new Error("not used"); },
+    async deletePod() {},
+    async waitForPodDeleted() { return true; },
+  },
+  state: {
+    async claimCreate() { throw new Error("not used"); },
+    async markCreateFailed() { throw new Error("not used"); },
+    async markRunning() { throw new Error("not used"); },
+    async readTerminationReceipt() { return concurrentReceipt; },
+    async claimTermination() { concurrentClaims += 1; return true; },
+    async markPodDeleted(input) { return input.podDeletedAt; },
+    async claimCheckpoint() { return true; },
+    async readCheckpoint() { return null; },
+    async persistCheckpoint() { return true; },
+    async completeTermination(input) { concurrentReceipt = input.receipt; return true; },
+  },
+  async createFrozenCheckpoint() {
+    concurrentCheckpoints += 1;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    return {
+      disposableSpaceId: binding.disposableSpaceId,
+      checkpointId: "checkpoint-concurrent",
+      commit: "concurrent123",
+      tree: "tree-concurrent",
+      treeSha256: "c".repeat(64),
+      currentHead: "concurrent123",
+      checkpointCreatedAt: "2099-01-01T00:00:00.000Z",
+    };
+  },
+});
+const [concurrentFirst, concurrentSecond] = await Promise.all([
+  concurrentLifecycle.revoke(handle, revocationContext),
+  concurrentLifecycle.revoke(handle, revocationContext),
+]);
+assert.deepEqual(concurrentSecond, concurrentFirst);
+assert.equal(concurrentClaims, 1);
+assert.equal(concurrentCheckpoints, 1);
+
+let restartClaimId: string | null = null;
+let restartPodDeletedAt: string | null = null;
+let restartCheckpointAttemptId: string | null = null;
+let restartCheckpointTaskRunId: string | null = null;
+let restartCheckpoint: FrozenCheckpointReadback | null = null;
+let restartReceipt: IsolatedWorkerRevocationReceipt | null = null;
+let restartCheckpointCalls = 0;
+let crashBeforeReceipt = true;
+const restartState = {
+  async claimCreate() { throw new Error("not used"); },
+  async markCreateFailed() { throw new Error("not used"); },
+  async markRunning() { throw new Error("not used"); },
+  async readTerminationReceipt() { return restartReceipt; },
+  async claimTermination(input: { claimId: string }) {
+    if (restartClaimId && restartClaimId !== input.claimId) return false;
+    restartClaimId = input.claimId;
+    return true;
+  },
+  async markPodDeleted(input: { podDeletedAt: string }) {
+    restartPodDeletedAt ??= input.podDeletedAt;
+    return restartPodDeletedAt;
+  },
+  async claimCheckpoint(input: { checkpointAttemptId: string; checkpointTaskRunId: string }) {
+    if (restartCheckpointAttemptId && restartCheckpointAttemptId !== input.checkpointAttemptId) return false;
+    if (restartCheckpointTaskRunId && restartCheckpointTaskRunId !== input.checkpointTaskRunId) return false;
+    restartCheckpointAttemptId = input.checkpointAttemptId;
+    restartCheckpointTaskRunId = input.checkpointTaskRunId;
+    return true;
+  },
+  async readCheckpoint() { return restartCheckpoint; },
+  async persistCheckpoint(input: { checkpoint: FrozenCheckpointReadback }) {
+    restartCheckpoint = input.checkpoint;
+    return true;
+  },
+  async completeTermination(input: { receipt: IsolatedWorkerRevocationReceipt }) {
+    if (crashBeforeReceipt) {
+      crashBeforeReceipt = false;
+      throw new Error("simulated crash before receipt persistence");
+    }
+    restartReceipt = input.receipt;
+    return true;
+  },
+};
+const restartInfra = {
+  async createPod() { throw new Error("not used"); },
+  async readPod() { return null; },
+  async waitForPodReady() { throw new Error("not used"); },
+  async deletePod() {},
+  async waitForPodDeleted() { return true; },
+};
+const restartCheckpointFactory = async () => {
+  restartCheckpointCalls += 1;
+  return {
+    disposableSpaceId: binding.disposableSpaceId,
+    checkpointId: "checkpoint-restart",
+    commit: "restart123",
+    tree: "tree-restart",
+    treeSha256: "d".repeat(64),
+    currentHead: "restart123",
+    checkpointCreatedAt: "2099-01-01T00:00:00.000Z",
+  };
+};
+await assert.rejects(
+  () => createIsolatedWorkerPodLifecycle({ infra: restartInfra, state: restartState, createFrozenCheckpoint: restartCheckpointFactory }).revoke(handle, revocationContext),
+  /simulated crash/,
+);
+const restartedReceipt = await createIsolatedWorkerPodLifecycle({
+  infra: restartInfra,
+  state: restartState,
+  createFrozenCheckpoint: restartCheckpointFactory,
+}).revoke(handle, revocationContext);
+assert.equal(restartCheckpointCalls, 1, "restart after checkpoint must reuse persisted checkpoint readback");
+assert.equal(restartedReceipt.checkpointId, "checkpoint-restart");
+assert.ok(restartClaimId);
+assert.ok(restartPodDeletedAt);
+assert.ok(restartCheckpointAttemptId);
+assert.match(restartCheckpointTaskRunId ?? "", /^[a-f0-9-]{36}$/);
+
+let retryAttemptBinding: { checkpointAttemptId: string; checkpointTaskRunId: string } | null = null;
+let retryRotations = 0;
+let retryCheckpoint: FrozenCheckpointReadback | null = null;
+const retryState = {
+  async claimCreate() { throw new Error("not used"); },
+  async markCreateFailed() { throw new Error("not used"); },
+  async markRunning() { throw new Error("not used"); },
+  async readTerminationReceipt() { return null; },
+  async claimTermination() { return true; },
+  async markPodDeleted(input: { podDeletedAt: string }) { return input.podDeletedAt; },
+  async claimCheckpoint(input: { checkpointAttemptId: string; checkpointTaskRunId: string }) {
+    retryAttemptBinding ??= input;
+    return retryAttemptBinding;
+  },
+  async rotateCheckpoint(input: {
+    checkpointAttemptId: string;
+    checkpointTaskRunId: string;
+    nextCheckpointAttemptId: string;
+    nextCheckpointTaskRunId: string;
+  }) {
+    if (
+      retryAttemptBinding?.checkpointAttemptId !== input.checkpointAttemptId
+      || retryAttemptBinding.checkpointTaskRunId !== input.checkpointTaskRunId
+    ) return retryAttemptBinding;
+    retryRotations += 1;
+    retryAttemptBinding = {
+      checkpointAttemptId: input.nextCheckpointAttemptId,
+      checkpointTaskRunId: input.nextCheckpointTaskRunId,
+    };
+    return retryAttemptBinding;
+  },
+  async readCheckpoint() { return retryCheckpoint; },
+  async persistCheckpoint(input: { checkpoint: FrozenCheckpointReadback }) {
+    retryCheckpoint = input.checkpoint;
+    return true;
+  },
+  async completeTermination() { return true; },
+};
+const retryTaskRunIds: string[] = [];
+const retryReceipt = await createIsolatedWorkerPodLifecycle({
+  infra: restartInfra,
+  state: retryState,
+  createFrozenCheckpoint: async (_handle, _attemptId, taskRunId) => {
+    retryTaskRunIds.push(taskRunId);
+    if (retryTaskRunIds.length === 1) {
+      throw new IsolatedWorkerCheckpointNoEffectError("checkpoint TaskRun failed with proven no effect");
+    }
+    return {
+      disposableSpaceId: binding.disposableSpaceId,
+      checkpointId: "checkpoint-after-cas-retry",
+      commit: "retry123",
+      tree: "tree-retry",
+      treeSha256: "e".repeat(64),
+      currentHead: "retry123",
+      checkpointCreatedAt: "2099-01-01T00:00:00.000Z",
+    };
+  },
+}).revoke(handle, revocationContext);
+assert.equal(retryRotations, 1, "proven no-effect failure must CAS to a new persisted checkpoint attempt");
+assert.equal(new Set(retryTaskRunIds).size, 2, "checkpoint retry must use a new deterministic TaskRun ID");
+assert.equal(retryReceipt.checkpointId, "checkpoint-after-cas-retry");
+
+let responseCrashReceipt: IsolatedWorkerRevocationReceipt | null = null;
+let responseCrashCheckpoint: FrozenCheckpointReadback | null = null;
+let responseCrashPersist = true;
+const responseCrashTaskRunIds: string[] = [];
+const responseCrashState = {
+  async claimCreate() { throw new Error("not used"); },
+  async markCreateFailed() { throw new Error("not used"); },
+  async markRunning() { throw new Error("not used"); },
+  async readTerminationReceipt() { return responseCrashReceipt; },
+  async claimTermination() { return true; },
+  async markPodDeleted() { return "2026-01-01T00:00:00.000Z"; },
+  async claimCheckpoint(input: { checkpointAttemptId: string; checkpointTaskRunId: string }) { return input; },
+  async readCheckpoint() { return responseCrashCheckpoint; },
+  async persistCheckpoint(input: { checkpoint: FrozenCheckpointReadback }) {
+    if (responseCrashPersist) {
+      responseCrashPersist = false;
+      throw new Error("simulated crash after checkpoint response before sandbox persistence");
+    }
+    responseCrashCheckpoint = input.checkpoint;
+    return true;
+  },
+  async completeTermination(input: { receipt: IsolatedWorkerRevocationReceipt }) {
+    responseCrashReceipt = input.receipt;
+    return true;
+  },
+};
+const authoritativeResponseCrashCheckpoint = {
+  disposableSpaceId: binding.disposableSpaceId,
+  checkpointId: "checkpoint-response-crash",
+  commit: "response123",
+  tree: "tree-response-crash",
+  treeSha256: "f".repeat(64),
+  currentHead: "response123",
+  checkpointCreatedAt: "2099-01-01T00:00:00.000Z",
+};
+const responseCrashFactory = async (_handle: unknown, _attemptId: string, taskRunId: string) => {
+  responseCrashTaskRunIds.push(taskRunId);
+  return authoritativeResponseCrashCheckpoint;
+};
+await assert.rejects(
+  () => createIsolatedWorkerPodLifecycle({
+    infra: restartInfra,
+    state: responseCrashState,
+    createFrozenCheckpoint: responseCrashFactory,
+  }).revoke(handle, revocationContext),
+  /simulated crash after checkpoint response/,
+);
+const responseCrashRecovered = await createIsolatedWorkerPodLifecycle({
+  infra: restartInfra,
+  state: responseCrashState,
+  createFrozenCheckpoint: responseCrashFactory,
+}).revoke(handle, revocationContext);
+assert.equal(new Set(responseCrashTaskRunIds).size, 1, "restart before sandbox persistence must reuse the persisted TaskRun binding");
+assert.equal(responseCrashRecovered.checkpointId, authoritativeResponseCrashCheckpoint.checkpointId);
+
+let doubleWorkerReceipt: IsolatedWorkerRevocationReceipt | null = null;
+let doubleWorkerCheckpoint: FrozenCheckpointReadback | null = null;
+let doubleWorkerCompletionClaims = 0;
+const doubleWorkerState = {
+  async claimCreate() { throw new Error("not used"); },
+  async markCreateFailed() { throw new Error("not used"); },
+  async markRunning() { throw new Error("not used"); },
+  async readTerminationReceipt() { return doubleWorkerReceipt; },
+  async claimTermination() { return true; },
+  async markPodDeleted() { return "2026-01-01T00:00:00.000Z"; },
+  async claimCheckpoint(input: { checkpointAttemptId: string; checkpointTaskRunId: string }) { return input; },
+  async readCheckpoint() { return doubleWorkerCheckpoint; },
+  async persistCheckpoint(input: { checkpoint: FrozenCheckpointReadback }) {
+    doubleWorkerCheckpoint ??= input.checkpoint;
+    return true;
+  },
+  async completeTermination(input: { receipt: IsolatedWorkerRevocationReceipt }) {
+    doubleWorkerCompletionClaims += 1;
+    if (doubleWorkerReceipt) return false;
+    doubleWorkerReceipt = input.receipt;
+    return true;
+  },
+};
+const doubleWorkerTaskRunIds: string[] = [];
+const doubleWorkerFactory = async (_handle: unknown, _attemptId: string, taskRunId: string) => {
+  doubleWorkerTaskRunIds.push(taskRunId);
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  return {
+    disposableSpaceId: binding.disposableSpaceId,
+    checkpointId: "checkpoint-double-worker",
+    commit: "double123",
+    tree: "tree-double-worker",
+    treeSha256: "1".repeat(64),
+    currentHead: "double123",
+    checkpointCreatedAt: "2099-01-01T00:00:00.000Z",
+  };
+};
+const doubleWorkerA = createIsolatedWorkerPodLifecycle({ infra: restartInfra, state: doubleWorkerState, createFrozenCheckpoint: doubleWorkerFactory });
+const doubleWorkerB = createIsolatedWorkerPodLifecycle({ infra: restartInfra, state: doubleWorkerState, createFrozenCheckpoint: doubleWorkerFactory });
+const [doubleWorkerReceiptA, doubleWorkerReceiptB] = await Promise.all([
+  doubleWorkerA.revoke(handle, revocationContext),
+  doubleWorkerB.revoke(handle, revocationContext),
+]);
+assert.deepEqual(doubleWorkerReceiptB, doubleWorkerReceiptA, "losing termination CAS must return the exact winning receipt");
+assert.equal(new Set(doubleWorkerTaskRunIds).size, 1, "double workers must share one deterministic checkpoint TaskRun binding");
+assert.equal(doubleWorkerCompletionClaims, 2);
+
+let terminalCreateAttempted = false;
+const terminalCreateLifecycle = createIsolatedWorkerPodLifecycle({
+  infra: {
+    async createPod() { terminalCreateAttempted = true; throw new Error("pod must not be created"); },
+    async readPod() { return null; },
+    async waitForPodReady() { return null; },
+    async deletePod() {},
+    async waitForPodDeleted() { return true; },
+  },
+  state: {
+    async claimCreate() { return false; },
+    async markCreateFailed() { return false; },
+    async markRunning() {},
+    async readTerminationReceipt() { return null; },
+    async claimTermination() { return false; },
+    async markPodDeleted() { return null; },
+    async claimCheckpoint() { return false; },
+    async readCheckpoint() { return null; },
+    async persistCheckpoint() { return false; },
+    async completeTermination() { return false; },
+  },
+});
+await assert.rejects(() => terminalCreateLifecycle.create({
+  ...binding,
+  image: "sandbox:test",
+  spaceStoragePvc: "cohub-spaces-pvc",
+  spaceStorageSubpath: "cohub-dev",
+  writableRoot: "/workspace/work",
+  policySha256,
+}), /not allocated or has already been used/);
+assert.equal(terminalCreateAttempted, false);
+
+let createFailureMarked = false;
+const failedCreateLifecycle = createIsolatedWorkerPodLifecycle({
+  infra: {
+    async createPod() { throw new Error("kubernetes rejected pod"); },
+    async readPod() { return null; },
+    async waitForPodReady() { throw new Error("not used"); },
+    async deletePod() {},
+    async waitForPodDeleted() { return true; },
+  },
+  state: {
+    async claimCreate() { return true; },
+    async markCreateFailed() { createFailureMarked = true; return true; },
+    async markRunning() { throw new Error("not used"); },
+    async readTerminationReceipt() { return null; },
+    async claimTermination() { return false; },
+    async markPodDeleted() { return null; },
+    async claimCheckpoint() { return false; },
+    async readCheckpoint() { return null; },
+    async persistCheckpoint() { return false; },
+    async completeTermination() { return false; },
+  },
+});
+await assert.rejects(() => failedCreateLifecycle.create({
+  ...binding,
+  image: "sandbox:test",
+  spaceStoragePvc: "cohub-spaces-pvc",
+  spaceStorageSubpath: "cohub-dev",
+  writableRoot: "/workspace/work",
+  policySha256,
+}), /kubernetes rejected pod/);
+assert.equal(createFailureMarked, true, "a proven no-pod create failure must leave a terminal allocation state");
+
+let lostResponsePod: V1Pod | null = null;
+let lostResponseMarkedRunning = false;
+const lostResponseLifecycle = createIsolatedWorkerPodLifecycle({
+  infra: {
+    async createPod(input) {
+      lostResponsePod = { ...input.pod, metadata: { ...input.pod.metadata, uid: "pod-uid-lost", creationTimestamp: new Date("2026-07-15T00:00:00.750Z") } };
+      throw new Error("response lost after server create");
+    },
+    async readPod() { return lostResponsePod; },
+    async waitForPodReady() {
+      return lostResponsePod
+        ? { ...lostResponsePod, status: { podIP: "10.0.0.9", conditions: [{ type: "Ready", status: "True" }] } }
+        : null;
+    },
+    async deletePod() { lostResponsePod = null; },
+    async waitForPodDeleted() { return lostResponsePod === null; },
+  },
+  state: {
+    async claimCreate() { return true; },
+    async markCreateFailed() { throw new Error("must not mark reconciled pod failed"); },
+    async markRunning() { lostResponseMarkedRunning = true; },
+    async readTerminationReceipt() { return null; },
+    async claimTermination() { return false; },
+    async markPodDeleted() { return null; },
+    async claimCheckpoint() { return false; },
+    async readCheckpoint() { return null; },
+    async persistCheckpoint() { return false; },
+    async completeTermination() { return false; },
+  },
+});
+const lostResponseHandle = await lostResponseLifecycle.create({
+  ...binding,
+  image: "sandbox:test",
+  spaceStoragePvc: "cohub-spaces-pvc",
+  spaceStorageSubpath: "cohub-dev",
+  writableRoot: "/workspace/work",
+  policySha256,
+});
+assert.equal(lostResponseHandle.isolatedWorkerPolicy.podUid, "pod-uid-lost");
+assert.equal(lostResponseMarkedRunning, true);
+
+const timeoutLifecycle = createIsolatedWorkerPodLifecycle({
+  namespace: "cohub-dev",
+  infra: {
+    async createPod() { throw new Error("not used"); },
+    async readPod() { return { metadata: { ...pod.metadata, uid: "pod-uid-1" } }; },
+    async waitForPodReady() { throw new Error("not used"); },
+    async deletePod() {},
+    async waitForPodDeleted() { return false; },
+  },
+  state: {
+    async claimCreate() { throw new Error("not used"); },
+    async markCreateFailed() { throw new Error("not used"); },
+    async markRunning() { throw new Error("not used"); },
+    async readTerminationReceipt() { return null; },
+    async claimTermination() { return true; },
+    async markPodDeleted() { throw new Error("must not mark deleted before deletion"); },
+    async claimCheckpoint() { throw new Error("must not checkpoint before deletion"); },
+    async readCheckpoint() { throw new Error("must not checkpoint before deletion"); },
+    async persistCheckpoint() { throw new Error("must not checkpoint before deletion"); },
+    async completeTermination() { throw new Error("must not mark terminated before deletion"); },
+  },
+  async createFrozenCheckpoint() { throw new Error("must not checkpoint before deletion"); },
+});
+await assert.rejects(() => timeoutLifecycle.revoke(handle, revocationContext), /timed out/);
+
+let wrongUidDeleted = false;
+const wrongUidLifecycle = createIsolatedWorkerPodLifecycle({
+  namespace: "cohub-dev",
+  infra: {
+    async createPod() { throw new Error("not used"); },
+    async readPod() {
+      return { ...boundPod, metadata: { ...boundPod.metadata, uid: "different-pod-uid" } };
+    },
+    async waitForPodReady() { throw new Error("not used"); },
+    async deletePod() { wrongUidDeleted = true; },
+    async waitForPodDeleted() { throw new Error("must not wait after binding mismatch"); },
+  },
+  state: {
+    async claimCreate() { throw new Error("not used"); },
+    async markCreateFailed() { throw new Error("not used"); },
+    async markRunning() { throw new Error("not used"); },
+    async readTerminationReceipt() { return null; },
+    async claimTermination() { return true; },
+    async markPodDeleted() { throw new Error("must not mark mismatched pod deleted"); },
+    async claimCheckpoint() { throw new Error("must not checkpoint mismatched pod"); },
+    async readCheckpoint() { throw new Error("must not checkpoint mismatched pod"); },
+    async persistCheckpoint() { throw new Error("must not checkpoint mismatched pod"); },
+    async completeTermination() { throw new Error("must not terminate mismatched pod"); },
+  },
+  async createFrozenCheckpoint() { throw new Error("must not checkpoint mismatched pod"); },
+});
+await assert.rejects(() => wrongUidLifecycle.revoke(handle, revocationContext), /UID mismatch/);
+assert.equal(wrongUidDeleted, false);
+
+const validCheckpoint = {
+  disposableSpaceId: binding.disposableSpaceId,
+  checkpointId: "checkpoint-1",
+  commit: "abc123",
+  tree: "tree123",
+  treeSha256: "b".repeat(64),
+  currentHead: "abc123",
+  checkpointCreatedAt: "2099-01-01T00:00:00.000Z",
+};
+assert.throws(() => validateFrozenCheckpointReadback(handle, { ...validCheckpoint, disposableSpaceId: binding.authoritySpaceId }), /binding mismatch/);
+assert.throws(() => validateFrozenCheckpointReadback(handle, { ...validCheckpoint, commit: "" }), /incomplete/);
+assert.throws(() => validateFrozenCheckpointReadback(handle, { ...validCheckpoint, currentHead: "older-head" }), /current head/);
+
+console.log("isolated worker pod template and lifecycle checks passed");

--- a/apps/api/src/isolated-worker-pods.ts
+++ b/apps/api/src/isolated-worker-pods.ts
@@ -1,0 +1,1003 @@
+import type { V1Pod } from "@kubernetes/client-node";
+import { SANDBOX_SPECS } from "@cohub/sandbox-controller";
+import { createHash } from "node:crypto";
+import { config, sessionsNamespace } from "./config.js";
+import { and, eq, sql } from "drizzle-orm";
+
+const BINDING_LABELS = {
+  spaceId: "cohub.run/space-id",
+  sessionId: "cohub.run/session-id",
+  turnId: "cohub.run/turn-id",
+} as const;
+
+type IsolatedWorkerBinding = {
+  authoritySpaceId: string;
+  disposableSpaceId: string;
+  sessionId: string;
+  turnId: string;
+};
+
+export type IsolatedWorkerPodInput = IsolatedWorkerBinding & {
+  image: string;
+  spaceStoragePvc: string;
+  spaceStorageSubpath: string;
+  writableRoot: string;
+  policySha256: string;
+};
+
+export type IsolatedWorkerMetadata = {
+  worker_identity: { access_mode: "isolated_worker" };
+  write_scope: { mode: "isolated_task_space"; root: "work/" };
+  disposable_space_id: string;
+  termination_required: true;
+  workflow_execution_token_issued: false;
+};
+
+export type IsolatedWorkerPolicy = {
+  authoritySpaceId: string;
+  disposableSpaceId: string;
+  writableRoot: string;
+  workspaceReadOnly: true;
+  executionTokenIssued: false;
+  podUid: string;
+  policySha256: string;
+};
+
+export type IsolatedWorkerPodHandle = {
+  sessionId: string;
+  turnId: string;
+  podName: string;
+  podCreatedAt: string;
+  isolatedWorkerPolicy: IsolatedWorkerPolicy;
+  metadata: IsolatedWorkerMetadata;
+  status: "running";
+  resumable: false;
+};
+
+export type IsolatedWorkerRevocationReceipt = {
+  revokeTaskRunId: string;
+  automaticTrigger: "turn_terminal_event";
+  manualEndpointInvoked: false;
+  podUid: string;
+  podDeleted: true;
+  podDeletedAt: string;
+  credentialRevoked: true;
+  sandboxTerminated: true;
+  checkpointCreatedAfterPodDeletion: true;
+  checkpointAdapter: "trusted_production";
+  terminatedAt: string;
+  checkpointId: string;
+  checkpointCommit: string;
+  checkpointTreeSha256: string;
+};
+
+export type IsolatedWorkerRevocationContext = Pick<
+  IsolatedWorkerRevocationReceipt,
+  "revokeTaskRunId" | "automaticTrigger" | "manualEndpointInvoked"
+>;
+
+export type IsolatedWorkerPodInfra = {
+  createPod(input: { namespace: string; pod: V1Pod }): Promise<V1Pod>;
+  readPod(input: { namespace: string; podName: string }): Promise<V1Pod | null>;
+  waitForPodReady(input: { namespace: string; podName: string; timeoutMs?: number }): Promise<V1Pod | null>;
+  deletePod(input: { namespace: string; podName: string; podUid: string }): Promise<void>;
+  waitForPodDeleted(input: { namespace: string; podName: string; timeoutMs?: number }): Promise<boolean>;
+};
+
+export type IsolatedWorkerPodState = {
+  claimCreate(input: { podInput: IsolatedWorkerPodInput; podName: string }): Promise<boolean>;
+  markCreateFailed(input: { podInput: IsolatedWorkerPodInput; podName: string; reason: string }): Promise<boolean>;
+  markRunning(input: { handle: IsolatedWorkerPodHandle; pod: V1Pod }): Promise<void>;
+  readTerminationReceipt(input: { handle: IsolatedWorkerPodHandle }): Promise<IsolatedWorkerRevocationReceipt | null>;
+  claimTermination(input: { handle: IsolatedWorkerPodHandle; claimId: string; startedAt: string }): Promise<boolean>;
+  markPodDeleted(input: { handle: IsolatedWorkerPodHandle; claimId: string; podDeletedAt: string }): Promise<string | null>;
+  claimCheckpoint(input: { handle: IsolatedWorkerPodHandle; claimId: string; checkpointAttemptId: string; checkpointTaskRunId: string }): Promise<boolean | IsolatedWorkerCheckpointAttempt | null>;
+  rotateCheckpoint?(input: {
+    handle: IsolatedWorkerPodHandle;
+    claimId: string;
+    checkpointAttemptId: string;
+    checkpointTaskRunId: string;
+    nextCheckpointAttemptId: string;
+    nextCheckpointTaskRunId: string;
+  }): Promise<IsolatedWorkerCheckpointAttempt | null>;
+  readCheckpoint(input: { handle: IsolatedWorkerPodHandle; claimId: string; checkpointAttemptId: string }): Promise<FrozenCheckpointReadback | null>;
+  persistCheckpoint(input: { handle: IsolatedWorkerPodHandle; claimId: string; checkpointAttemptId: string; checkpoint: FrozenCheckpointReadback }): Promise<boolean>;
+  completeTermination(input: { handle: IsolatedWorkerPodHandle; claimId: string; checkpointAttemptId: string; receipt: IsolatedWorkerRevocationReceipt }): Promise<boolean>;
+};
+
+export type IsolatedWorkerCheckpointAttempt = {
+  checkpointAttemptId: string;
+  checkpointTaskRunId: string;
+};
+
+export type FrozenCheckpointReadback = {
+  disposableSpaceId: string;
+  checkpointId: string;
+  commit: string;
+  tree: string;
+  treeSha256: string;
+  currentHead: string;
+  checkpointCreatedAt: string;
+};
+
+export class IsolatedWorkerCheckpointNoEffectError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IsolatedWorkerCheckpointNoEffectError";
+  }
+}
+
+export function validateFrozenCheckpointReadback(handle: IsolatedWorkerPodHandle, checkpoint: FrozenCheckpointReadback) {
+  if (checkpoint.disposableSpaceId !== handle.isolatedWorkerPolicy.disposableSpaceId) {
+    throw new Error("frozen checkpoint disposable space binding mismatch");
+  }
+  if (!checkpoint.checkpointId.trim() || !checkpoint.commit.trim() || !checkpoint.tree.trim() || !/^[a-f0-9]{64}$/.test(checkpoint.treeSha256) || !checkpoint.currentHead.trim()) {
+    throw new Error("frozen checkpoint readback is incomplete");
+  }
+  if (checkpoint.commit !== checkpoint.currentHead) {
+    throw new Error("frozen checkpoint does not match the disposable space current head");
+  }
+  if (!Number.isFinite(Date.parse(checkpoint.checkpointCreatedAt))) {
+    throw new Error("frozen checkpoint creation timestamp is invalid");
+  }
+  return checkpoint;
+}
+
+export function buildIsolatedWorkerSandboxRegistration(handle: IsolatedWorkerPodHandle, pod: V1Pod) {
+  const podIp = pod.status?.podIP?.trim();
+  if (!podIp) throw new Error("isolated worker pod IP is missing");
+  return {
+    spaceId: handle.isolatedWorkerPolicy.disposableSpaceId,
+    status: "ready" as const,
+    runtimeStatus: "healthy" as const,
+    podName: handle.podName,
+    meta: {
+      ...handle.metadata,
+      isolatedWorkerPolicy: handle.isolatedWorkerPolicy,
+      authoritySpaceId: handle.isolatedWorkerPolicy.authoritySpaceId,
+      sessionId: handle.sessionId,
+      turnId: handle.turnId,
+      podIp,
+      wsEndpoint: `ws://${podIp}:8788/sandbox`,
+    },
+  };
+}
+
+const getStatusCode = (error: unknown) =>
+  (error as { statusCode?: number; code?: number }).statusCode
+  ?? (error as { statusCode?: number; code?: number }).code
+  ?? null;
+
+function assertLabelValue(value: string, fieldName: string) {
+  if (!/^[a-z0-9](?:[-_.a-z0-9]{0,61}[a-z0-9])?$/.test(value)) {
+    throw new Error(`${fieldName} must be a Kubernetes label value`);
+  }
+}
+
+function assertDnsLabel(value: string, fieldName: string) {
+  if (!/^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$/.test(value)) {
+    throw new Error(`${fieldName} must be a Kubernetes DNS label`);
+  }
+}
+
+function validateRelativeSubpath(value: string) {
+  const segments = value.split("/");
+  if (!value || value.startsWith("/") || segments.some((segment) => !segment || segment === "." || segment === "..")) {
+    throw new Error("spaceStorageSubpath must be a clean relative path");
+  }
+  return value;
+}
+
+function getWritableRelativePath(writableRoot: string) {
+  if (writableRoot !== "/workspace/work") {
+    throw new Error("writableRoot must be /workspace/work");
+  }
+  return "work";
+}
+
+function getPodName(disposableSpaceId: string) {
+  const podName = `sandbox-${disposableSpaceId}`;
+  assertDnsLabel(podName, "isolated worker pod name");
+  return podName;
+}
+
+function assertBinding(binding: IsolatedWorkerBinding) {
+  assertLabelValue(binding.authoritySpaceId, "authoritySpaceId");
+  assertLabelValue(binding.disposableSpaceId, "disposableSpaceId");
+  assertLabelValue(binding.sessionId, "sessionId");
+  assertLabelValue(binding.turnId, "turnId");
+}
+
+function assertHandle(handle: IsolatedWorkerPodHandle) {
+  const policy = handle.isolatedWorkerPolicy;
+  assertBinding({
+    authoritySpaceId: policy.authoritySpaceId,
+    disposableSpaceId: policy.disposableSpaceId,
+    sessionId: handle.sessionId,
+    turnId: handle.turnId,
+  });
+  if (handle.podName !== getPodName(policy.disposableSpaceId)) throw new Error("isolated worker pod name mismatch");
+  if (!policy.podUid.trim()) throw new Error("isolated worker pod UID is missing");
+  if (!Number.isFinite(Date.parse(handle.podCreatedAt))) throw new Error("isolated worker Pod creation timestamp is invalid");
+  if (policy.writableRoot !== "/workspace/work" || policy.workspaceReadOnly !== true || policy.executionTokenIssued !== false) {
+    throw new Error("isolated worker policy invariant mismatch");
+  }
+  if (!/^[a-f0-9]{64}$/.test(policy.policySha256)) throw new Error("isolated worker policy hash is malformed");
+}
+
+function readPodCreatedAt(pod: V1Pod) {
+  const raw = pod.metadata?.creationTimestamp;
+  const date = raw instanceof Date ? raw : typeof raw === "string" ? new Date(raw) : null;
+  if (!date || !Number.isFinite(date.getTime())) throw new Error("isolated worker Pod metadata.creationTimestamp is missing");
+  return date.toISOString();
+}
+
+function assertRevocationContext(context: IsolatedWorkerRevocationContext) {
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(context.revokeTaskRunId)) {
+    throw new Error("isolated worker revoke TaskRun ID is malformed");
+  }
+  if (context.automaticTrigger !== "turn_terminal_event" || context.manualEndpointInvoked !== false) {
+    throw new Error("isolated worker revocation must be bound to an automatic terminal Turn event");
+  }
+}
+
+function assertReceiptContext(receipt: IsolatedWorkerRevocationReceipt, context: IsolatedWorkerRevocationContext) {
+  if (
+    receipt.revokeTaskRunId !== context.revokeTaskRunId
+    || receipt.automaticTrigger !== context.automaticTrigger
+    || receipt.manualEndpointInvoked !== context.manualEndpointInvoked
+  ) {
+    throw new Error("isolated worker revocation receipt TaskRun binding mismatch");
+  }
+}
+
+function parseTerminationReceipt(value: unknown, expectedPodUid: string): IsolatedWorkerRevocationReceipt | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const receipt = value as Record<string, unknown>;
+  if (
+    typeof receipt.revokeTaskRunId !== "string"
+    || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(receipt.revokeTaskRunId)
+    || receipt.automaticTrigger !== "turn_terminal_event"
+    || receipt.manualEndpointInvoked !== false
+    || receipt.podUid !== expectedPodUid
+    || receipt.podDeleted !== true
+    || typeof receipt.podDeletedAt !== "string"
+    || !receipt.podDeletedAt.trim()
+    || receipt.credentialRevoked !== true
+    || receipt.sandboxTerminated !== true
+    || receipt.checkpointCreatedAfterPodDeletion !== true
+    || receipt.checkpointAdapter !== "trusted_production"
+    || typeof receipt.terminatedAt !== "string"
+    || !receipt.terminatedAt.trim()
+    || typeof receipt.checkpointId !== "string"
+    || !receipt.checkpointId.trim()
+    || typeof receipt.checkpointCommit !== "string"
+    || !receipt.checkpointCommit.trim()
+    || typeof receipt.checkpointTreeSha256 !== "string"
+    || !/^[a-f0-9]{64}$/.test(receipt.checkpointTreeSha256)
+    || !Number.isFinite(Date.parse(receipt.podDeletedAt))
+    || !Number.isFinite(Date.parse(receipt.terminatedAt))
+  ) {
+    throw new Error("persisted isolated worker termination receipt is malformed");
+  }
+  return receipt as IsolatedWorkerRevocationReceipt;
+}
+
+export function renderIsolatedWorkerPodTemplate(input: IsolatedWorkerPodInput): V1Pod {
+  assertBinding(input);
+  if (!input.image.trim()) throw new Error("image is required");
+  assertDnsLabel(input.spaceStoragePvc, "spaceStoragePvc");
+  if (!/^[a-f0-9]{64}$/.test(input.policySha256)) throw new Error("policySha256 must be a lowercase SHA-256 digest");
+  const storageSubpath = validateRelativeSubpath(input.spaceStorageSubpath);
+  const writableRelativePath = getWritableRelativePath(input.writableRoot);
+  const workspaceSubpath = `${storageSubpath}/${input.disposableSpaceId}/workspace`;
+
+  return {
+    apiVersion: "v1",
+    kind: "Pod",
+    metadata: {
+      name: getPodName(input.disposableSpaceId),
+      labels: {
+        "app": "isolated-worker",
+        "cohub.run/workload": "isolated-worker",
+        [BINDING_LABELS.spaceId]: input.disposableSpaceId,
+        [BINDING_LABELS.sessionId]: input.sessionId,
+        [BINDING_LABELS.turnId]: input.turnId,
+        "cohub.run/authority-space-id": input.authoritySpaceId,
+        "cohub.run/disposable-space-id": input.disposableSpaceId,
+      },
+      annotations: {
+        "cohub.run/authority_space_id": input.authoritySpaceId,
+        "cohub.run/worker_identity.access_mode": "isolated_worker",
+        "cohub.run/write_scope.mode": "isolated_task_space",
+        "cohub.run/write_scope.root": "work/",
+        "cohub.run/disposable_space_id": input.disposableSpaceId,
+        "cohub.run/termination_required": "true",
+        "cohub.run/workflow_execution_token_issued": "false",
+        "cohub.run/policy_sha256": input.policySha256,
+      },
+    },
+    spec: {
+      restartPolicy: "Never",
+      imagePullSecrets: [{ name: "gitea-registry" }],
+      enableServiceLinks: false,
+      automountServiceAccountToken: false,
+      ...(Object.keys(config.sandboxNodeSelector).length > 0
+        ? { nodeSelector: config.sandboxNodeSelector }
+        : {}),
+      ...(config.sandboxTolerations.length > 0
+        ? { tolerations: config.sandboxTolerations }
+        : {}),
+      securityContext: {
+        runAsNonRoot: true,
+        runAsUser: 1000,
+        runAsGroup: 1000,
+        fsGroup: 1000,
+        seccompProfile: { type: "RuntimeDefault" },
+      },
+      containers: [{
+        name: "worker",
+        image: input.image,
+        env: [
+          { name: "COHUB_SPACE_ID", value: input.disposableSpaceId },
+          { name: "WORKSPACE_DIR", value: "/workspace" },
+          { name: "IMAGE_VERSION", value: input.image },
+          { name: "POD_IP", valueFrom: { fieldRef: { fieldPath: "status.podIP" } } },
+        ],
+        ports: [{ name: "sandbox", containerPort: 8788, protocol: "TCP" }],
+        securityContext: {
+          runAsNonRoot: true,
+          runAsUser: 1000,
+          runAsGroup: 1000,
+          allowPrivilegeEscalation: false,
+          capabilities: { drop: ["ALL"] },
+          readOnlyRootFilesystem: true,
+          seccompProfile: { type: "RuntimeDefault" },
+        },
+        readinessProbe: {
+          httpGet: { path: "/readyz", port: 8788 },
+          initialDelaySeconds: 2,
+          periodSeconds: 2,
+          timeoutSeconds: 1,
+          failureThreshold: 30,
+        },
+        resources: SANDBOX_SPECS.standard.resources,
+        volumeMounts: [
+          {
+            name: "space-storage",
+            mountPath: "/workspace",
+            subPath: workspaceSubpath,
+            readOnly: true,
+          },
+          {
+            name: "space-storage",
+            mountPath: input.writableRoot,
+            subPath: `${workspaceSubpath}/${writableRelativePath}`,
+            readOnly: false,
+          },
+          {
+            name: "runtime-tmp",
+            mountPath: "/tmp",
+          },
+        ],
+      }],
+      volumes: [
+        {
+          name: "space-storage",
+          persistentVolumeClaim: { claimName: input.spaceStoragePvc },
+        },
+        {
+          name: "runtime-tmp",
+          emptyDir: {},
+        },
+      ],
+    },
+  };
+}
+
+function assertPodBinding(pod: V1Pod, binding: IsolatedWorkerBinding, expectedUid?: string) {
+  const labels = pod.metadata?.labels;
+  if (
+    labels?.[BINDING_LABELS.spaceId] !== binding.disposableSpaceId
+    || labels?.[BINDING_LABELS.sessionId] !== binding.sessionId
+    || labels?.[BINDING_LABELS.turnId] !== binding.turnId
+    || labels?.["cohub.run/authority-space-id"] !== binding.authoritySpaceId
+    || labels?.["cohub.run/disposable-space-id"] !== binding.disposableSpaceId
+  ) {
+    throw new Error("isolated worker pod binding mismatch");
+  }
+  const podUid = pod.metadata?.uid?.trim();
+  if (!podUid) throw new Error("isolated worker pod UID is missing");
+  if (expectedUid && podUid !== expectedUid) throw new Error("isolated worker pod UID mismatch");
+  return podUid;
+}
+
+const defaultInfra: IsolatedWorkerPodInfra = {
+  async createPod(input) {
+    const { k8sCoreApi } = await import("./k8s.js");
+    return k8sCoreApi.createNamespacedPod({ namespace: input.namespace, body: input.pod });
+  },
+  async readPod(input) {
+    const { k8sCoreApi } = await import("./k8s.js");
+    try {
+      return await k8sCoreApi.readNamespacedPod({ name: input.podName, namespace: input.namespace });
+    } catch (error) {
+      if (getStatusCode(error) === 404) return null;
+      throw error;
+    }
+  },
+  async waitForPodReady(input) {
+    const { k8sCoreApi } = await import("./k8s.js");
+    const startedAt = Date.now();
+    const timeoutMs = input.timeoutMs ?? 120_000;
+    while (Date.now() - startedAt < timeoutMs) {
+      try {
+        const pod = await k8sCoreApi.readNamespacedPod({ name: input.podName, namespace: input.namespace });
+        const ready = pod.status?.conditions?.some((condition) => condition.type === "Ready" && condition.status === "True") === true;
+        if (ready && pod.status?.podIP) return pod;
+      } catch (error) {
+        if (getStatusCode(error) !== 404) throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    return null;
+  },
+  async deletePod(input) {
+    const { k8sCoreApi } = await import("./k8s.js");
+    try {
+      await k8sCoreApi.deleteNamespacedPod({
+        name: input.podName,
+        namespace: input.namespace,
+        body: { preconditions: { uid: input.podUid } },
+      });
+    } catch (error) {
+      if (getStatusCode(error) !== 404) throw error;
+    }
+  },
+  async waitForPodDeleted(input) {
+    const { k8sCoreApi } = await import("./k8s.js");
+    const startedAt = Date.now();
+    const timeoutMs = input.timeoutMs ?? 120_000;
+    while (Date.now() - startedAt < timeoutMs) {
+      try {
+        await k8sCoreApi.readNamespacedPod({ name: input.podName, namespace: input.namespace });
+      } catch (error) {
+        if (getStatusCode(error) === 404) return true;
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    return false;
+  },
+};
+
+const defaultState: IsolatedWorkerPodState = {
+  async claimCreate(input) {
+    const { claimIsolatedWorkerSandboxAllocation } = await import("./space-sandboxes.js");
+    return claimIsolatedWorkerSandboxAllocation({
+      authoritySpaceId: input.podInput.authoritySpaceId,
+      disposableSpaceId: input.podInput.disposableSpaceId,
+      sessionId: input.podInput.sessionId,
+      turnId: input.podInput.turnId,
+      policySha256: input.podInput.policySha256,
+      podName: input.podName,
+    });
+  },
+  async markRunning(input) {
+    const registration = buildIsolatedWorkerSandboxRegistration(input.handle, input.pod);
+    const { completeIsolatedWorkerSandboxAllocation } = await import("./space-sandboxes.js");
+    const completed = await completeIsolatedWorkerSandboxAllocation({
+      registration,
+      authoritySpaceId: input.handle.isolatedWorkerPolicy.authoritySpaceId,
+      sessionId: input.handle.sessionId,
+      turnId: input.handle.turnId,
+      policySha256: input.handle.isolatedWorkerPolicy.policySha256,
+      podUid: input.handle.isolatedWorkerPolicy.podUid,
+    });
+    if (!completed) throw new Error("isolated worker allocation changed before pod registration");
+  },
+  async markCreateFailed(input) {
+    const { markIsolatedWorkerSandboxCreateFailed } = await import("./space-sandboxes.js");
+    return markIsolatedWorkerSandboxCreateFailed({
+      authoritySpaceId: input.podInput.authoritySpaceId,
+      disposableSpaceId: input.podInput.disposableSpaceId,
+      sessionId: input.podInput.sessionId,
+      turnId: input.podInput.turnId,
+      policySha256: input.podInput.policySha256,
+      podName: input.podName,
+      reason: input.reason,
+    });
+  },
+  async readTerminationReceipt(input) {
+    const { getSpaceSandboxBySpaceId } = await import("./space-sandboxes.js");
+    const sandbox = await getSpaceSandboxBySpaceId(input.handle.isolatedWorkerPolicy.disposableSpaceId);
+    const meta = sandbox?.meta && typeof sandbox.meta === "object" && !Array.isArray(sandbox.meta)
+      ? sandbox.meta as Record<string, unknown>
+      : null;
+    return parseTerminationReceipt(meta?.termination, input.handle.isolatedWorkerPolicy.podUid);
+  },
+  async claimTermination(input) {
+    const { claimIsolatedWorkerTermination } = await import("./space-sandboxes.js");
+    return claimIsolatedWorkerTermination({
+      spaceId: input.handle.isolatedWorkerPolicy.disposableSpaceId,
+      podUid: input.handle.isolatedWorkerPolicy.podUid,
+      claimId: input.claimId,
+      startedAt: input.startedAt,
+    });
+  },
+  async completeTermination(input) {
+    const { completeIsolatedWorkerTermination } = await import("./space-sandboxes.js");
+    return completeIsolatedWorkerTermination({
+      spaceId: input.handle.isolatedWorkerPolicy.disposableSpaceId,
+      podUid: input.handle.isolatedWorkerPolicy.podUid,
+      claimId: input.claimId,
+      checkpointAttemptId: input.checkpointAttemptId,
+      receipt: input.receipt,
+    });
+  },
+  async markPodDeleted(input) {
+    const { markIsolatedWorkerPodDeleted } = await import("./space-sandboxes.js");
+    return markIsolatedWorkerPodDeleted({
+      spaceId: input.handle.isolatedWorkerPolicy.disposableSpaceId,
+      podUid: input.handle.isolatedWorkerPolicy.podUid,
+      claimId: input.claimId,
+      podDeletedAt: input.podDeletedAt,
+    });
+  },
+  async claimCheckpoint(input) {
+    const { claimIsolatedWorkerCheckpoint } = await import("./space-sandboxes.js");
+    return claimIsolatedWorkerCheckpoint({
+      spaceId: input.handle.isolatedWorkerPolicy.disposableSpaceId,
+      podUid: input.handle.isolatedWorkerPolicy.podUid,
+      claimId: input.claimId,
+      checkpointAttemptId: input.checkpointAttemptId,
+      checkpointTaskRunId: input.checkpointTaskRunId,
+    });
+  },
+  async rotateCheckpoint(input) {
+    const { rotateIsolatedWorkerCheckpointAttempt } = await import("./space-sandboxes.js");
+    return rotateIsolatedWorkerCheckpointAttempt({
+      spaceId: input.handle.isolatedWorkerPolicy.disposableSpaceId,
+      podUid: input.handle.isolatedWorkerPolicy.podUid,
+      claimId: input.claimId,
+      checkpointAttemptId: input.checkpointAttemptId,
+      checkpointTaskRunId: input.checkpointTaskRunId,
+      nextCheckpointAttemptId: input.nextCheckpointAttemptId,
+      nextCheckpointTaskRunId: input.nextCheckpointTaskRunId,
+    });
+  },
+  async readCheckpoint(input) {
+    const { readIsolatedWorkerTerminationCheckpoint } = await import("./space-sandboxes.js");
+    return readIsolatedWorkerTerminationCheckpoint({
+      spaceId: input.handle.isolatedWorkerPolicy.disposableSpaceId,
+      podUid: input.handle.isolatedWorkerPolicy.podUid,
+      claimId: input.claimId,
+      checkpointAttemptId: input.checkpointAttemptId,
+    }) as Promise<FrozenCheckpointReadback | null>;
+  },
+  async persistCheckpoint(input) {
+    const { persistIsolatedWorkerTerminationCheckpoint } = await import("./space-sandboxes.js");
+    return persistIsolatedWorkerTerminationCheckpoint({
+      spaceId: input.handle.isolatedWorkerPolicy.disposableSpaceId,
+      podUid: input.handle.isolatedWorkerPolicy.podUid,
+      claimId: input.claimId,
+      checkpointAttemptId: input.checkpointAttemptId,
+      checkpoint: input.checkpoint,
+    });
+  },
+};
+
+function getTerminationClaimId(handle: IsolatedWorkerPodHandle) {
+  return createHash("sha256").update(JSON.stringify({
+    authoritySpaceId: handle.isolatedWorkerPolicy.authoritySpaceId,
+    disposableSpaceId: handle.isolatedWorkerPolicy.disposableSpaceId,
+    sessionId: handle.sessionId,
+    turnId: handle.turnId,
+    podUid: handle.isolatedWorkerPolicy.podUid,
+    policySha256: handle.isolatedWorkerPolicy.policySha256,
+  })).digest("hex");
+}
+
+function getCheckpointTaskRunId(checkpointAttemptId: string) {
+  const hex = createHash("sha256").update(`${checkpointAttemptId}:task-run`).digest("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
+}
+
+export function createIsolatedWorkerPodLifecycle(input?: {
+  namespace?: string;
+  infra?: IsolatedWorkerPodInfra;
+  state?: IsolatedWorkerPodState;
+  createFrozenCheckpoint?: (handle: IsolatedWorkerPodHandle, checkpointAttemptId: string, checkpointTaskRunId: string) => Promise<FrozenCheckpointReadback>;
+  readyTimeoutMs?: number;
+  deletionTimeoutMs?: number;
+}) {
+  const namespace = input?.namespace ?? sessionsNamespace;
+  const infra = input?.infra ?? defaultInfra;
+  const state = input?.state ?? defaultState;
+  const createFrozenCheckpoint = input?.createFrozenCheckpoint ?? (async () => {
+    throw new Error("isolated worker frozen checkpoint adapter is not configured");
+  });
+  const readyTimeoutMs = input?.readyTimeoutMs ?? 120_000;
+  const deletionTimeoutMs = input?.deletionTimeoutMs ?? 120_000;
+  const revocations = new Map<string, Promise<IsolatedWorkerRevocationReceipt>>();
+
+  return {
+    async create(podInput: IsolatedWorkerPodInput): Promise<IsolatedWorkerPodHandle> {
+      const requestedPod = renderIsolatedWorkerPodTemplate(podInput);
+      const requestedPodName = requestedPod.metadata?.name;
+      if (!requestedPodName) throw new Error("isolated worker pod name is missing");
+      const claimed = await state.claimCreate({ podInput, podName: requestedPodName });
+      if (!claimed) throw new Error("disposable worker space is not allocated or has already been used");
+      let createdPod: V1Pod;
+      try {
+        createdPod = await infra.createPod({ namespace, pod: requestedPod });
+      } catch (createError) {
+        const observedPod = await infra.readPod({ namespace, podName: requestedPodName });
+        if (observedPod) {
+          assertPodBinding(observedPod, podInput);
+          createdPod = observedPod;
+        } else {
+          const markedFailed = await state.markCreateFailed({
+            podInput,
+            podName: requestedPodName,
+            reason: createError instanceof Error ? createError.message : String(createError),
+          });
+          if (!markedFailed) throw new AggregateError([createError], "isolated worker pod create failed and allocation state changed");
+          throw createError;
+        }
+      }
+      const podUid = assertPodBinding(createdPod, podInput);
+      const podCreatedAt = readPodCreatedAt(createdPod);
+      const podName = createdPod.metadata?.name;
+      if (!podName || podName !== requestedPod.metadata?.name) throw new Error("isolated worker pod name mismatch");
+      const metadata: IsolatedWorkerMetadata = {
+        worker_identity: { access_mode: "isolated_worker" },
+        write_scope: { mode: "isolated_task_space", root: "work/" },
+        disposable_space_id: podInput.disposableSpaceId,
+        termination_required: true,
+        workflow_execution_token_issued: false,
+      };
+      const handle: IsolatedWorkerPodHandle = {
+        sessionId: podInput.sessionId,
+        turnId: podInput.turnId,
+        podName,
+        podCreatedAt,
+        isolatedWorkerPolicy: {
+          authoritySpaceId: podInput.authoritySpaceId,
+          disposableSpaceId: podInput.disposableSpaceId,
+          writableRoot: podInput.writableRoot,
+          workspaceReadOnly: true,
+          executionTokenIssued: false,
+          podUid,
+          policySha256: podInput.policySha256,
+        },
+        metadata,
+        status: "running",
+        resumable: false,
+      };
+      const readyPod = await infra.waitForPodReady({ namespace, podName, timeoutMs: readyTimeoutMs });
+      try {
+        if (!readyPod) throw new Error(`timed out waiting for isolated worker pod readiness: ${podName}`);
+        assertPodBinding(readyPod, podInput, podUid);
+        if (readPodCreatedAt(readyPod) !== podCreatedAt) throw new Error("isolated worker Pod creation timestamp changed before readiness");
+        await state.markRunning({ handle, pod: readyPod });
+      } catch (error) {
+        try {
+          await infra.deletePod({ namespace, podName, podUid });
+          const deleted = await infra.waitForPodDeleted({ namespace, podName, timeoutMs: deletionTimeoutMs });
+          if (!deleted) throw new Error(`timed out cleaning up isolated worker pod: ${podName}`);
+          const markedFailed = await state.markCreateFailed({
+            podInput,
+            podName,
+            reason: error instanceof Error ? error.message : String(error),
+          });
+          if (!markedFailed) throw new Error("isolated worker pod cleanup completed but allocation state changed");
+        } catch (cleanupError) {
+          throw new AggregateError([error, cleanupError], `isolated worker creation failed and pod cleanup did not complete: ${podName}`);
+        }
+        throw error;
+      }
+      return handle;
+    },
+
+    async revoke(
+      handle: IsolatedWorkerPodHandle,
+      context: IsolatedWorkerRevocationContext,
+    ): Promise<IsolatedWorkerRevocationReceipt> {
+      assertRevocationContext(context);
+      const revocationKey = `${handle.isolatedWorkerPolicy.disposableSpaceId}:${handle.isolatedWorkerPolicy.podUid}`;
+      const activeRevocation = revocations.get(revocationKey);
+      if (activeRevocation) {
+        const receipt = await activeRevocation;
+        assertReceiptContext(receipt, context);
+        return receipt;
+      }
+      const operation = (async () => {
+      assertHandle(handle);
+      const persistedReceipt = await state.readTerminationReceipt({ handle });
+      if (persistedReceipt) {
+        assertReceiptContext(persistedReceipt, context);
+        return persistedReceipt;
+      }
+      const claimId = getTerminationClaimId(handle);
+      const claimed = await state.claimTermination({ handle, claimId, startedAt: new Date().toISOString() });
+      if (!claimed) {
+        const racedReceipt = await state.readTerminationReceipt({ handle });
+        if (racedReceipt) return racedReceipt;
+        throw new Error("isolated worker revocation is already in progress or its state binding changed");
+      }
+      const binding = {
+        authoritySpaceId: handle.isolatedWorkerPolicy.authoritySpaceId,
+        disposableSpaceId: handle.isolatedWorkerPolicy.disposableSpaceId,
+        sessionId: handle.sessionId,
+        turnId: handle.turnId,
+      };
+      const currentPod = await infra.readPod({ namespace, podName: handle.podName });
+      if (currentPod) {
+        assertPodBinding(currentPod, binding, handle.isolatedWorkerPolicy.podUid);
+        await infra.deletePod({ namespace, podName: handle.podName, podUid: handle.isolatedWorkerPolicy.podUid });
+      }
+      const deleted = await infra.waitForPodDeleted({ namespace, podName: handle.podName, timeoutMs: deletionTimeoutMs });
+      if (!deleted) throw new Error(`timed out waiting for isolated worker pod deletion: ${handle.podName}`);
+      const observedPodDeletedAt = new Date().toISOString();
+      const podDeletedAt = await state.markPodDeleted({ handle, claimId, podDeletedAt: observedPodDeletedAt });
+      if (!podDeletedAt) throw new Error("isolated worker pod deletion state changed before checkpoint");
+      const initialCheckpointAttemptId = createHash("sha256").update(`${claimId}:checkpoint`).digest("hex");
+      const initialCheckpointTaskRunId = getCheckpointTaskRunId(initialCheckpointAttemptId);
+      const checkpointClaim = await state.claimCheckpoint({
+        handle,
+        claimId,
+        checkpointAttemptId: initialCheckpointAttemptId,
+        checkpointTaskRunId: initialCheckpointTaskRunId,
+      });
+      if (!checkpointClaim) throw new Error("isolated worker checkpoint is already in progress");
+      let checkpointAttempt = typeof checkpointClaim === "boolean"
+        ? { checkpointAttemptId: initialCheckpointAttemptId, checkpointTaskRunId: initialCheckpointTaskRunId }
+        : checkpointClaim;
+      let checkpoint = await state.readCheckpoint({ handle, claimId, checkpointAttemptId: checkpointAttempt.checkpointAttemptId });
+      for (let retries = 0; !checkpoint; retries += 1) {
+        try {
+          const createdCheckpoint = validateFrozenCheckpointReadback(
+            handle,
+            await createFrozenCheckpoint(handle, checkpointAttempt.checkpointAttemptId, checkpointAttempt.checkpointTaskRunId),
+          );
+          const persisted = await state.persistCheckpoint({
+            handle,
+            claimId,
+            checkpointAttemptId: checkpointAttempt.checkpointAttemptId,
+            checkpoint: createdCheckpoint,
+          });
+          if (!persisted) {
+            checkpoint = await state.readCheckpoint({ handle, claimId, checkpointAttemptId: checkpointAttempt.checkpointAttemptId });
+            if (!checkpoint) throw new Error("isolated worker checkpoint state changed before persistence");
+          } else {
+            checkpoint = createdCheckpoint;
+          }
+        } catch (error) {
+          if (!(error instanceof IsolatedWorkerCheckpointNoEffectError)) throw error;
+          if (!state.rotateCheckpoint || retries >= 2) {
+            throw new Error("isolated worker checkpoint exhausted CAS retries after proven no-effect failures", { cause: error });
+          }
+          const nextCheckpointAttemptId = createHash("sha256")
+            .update(`${checkpointAttempt.checkpointAttemptId}:retry`)
+            .digest("hex");
+          const nextCheckpointTaskRunId = getCheckpointTaskRunId(nextCheckpointAttemptId);
+          const rotated = await state.rotateCheckpoint({
+            handle,
+            claimId,
+            checkpointAttemptId: checkpointAttempt.checkpointAttemptId,
+            checkpointTaskRunId: checkpointAttempt.checkpointTaskRunId,
+            nextCheckpointAttemptId,
+            nextCheckpointTaskRunId,
+          });
+          if (!rotated) throw new Error("isolated worker checkpoint retry CAS changed unexpectedly");
+          checkpointAttempt = rotated;
+          checkpoint = await state.readCheckpoint({ handle, claimId, checkpointAttemptId: checkpointAttempt.checkpointAttemptId });
+        }
+      }
+      checkpoint = validateFrozenCheckpointReadback(handle, checkpoint);
+      if (Date.parse(checkpoint.checkpointCreatedAt) <= Date.parse(podDeletedAt)) {
+        throw new Error("isolated worker checkpoint was not created after pod deletion");
+      }
+      const receipt: IsolatedWorkerRevocationReceipt = {
+        ...context,
+        podUid: handle.isolatedWorkerPolicy.podUid,
+        podDeleted: true,
+        podDeletedAt,
+        credentialRevoked: true,
+        sandboxTerminated: true,
+        checkpointCreatedAfterPodDeletion: true,
+        checkpointAdapter: "trusted_production",
+        terminatedAt: new Date().toISOString(),
+        checkpointId: checkpoint.checkpointId,
+        checkpointCommit: checkpoint.commit,
+        checkpointTreeSha256: checkpoint.treeSha256,
+      };
+      const completed = await state.completeTermination({
+        handle,
+        claimId,
+        checkpointAttemptId: checkpointAttempt.checkpointAttemptId,
+        receipt,
+      });
+      if (!completed) {
+        const racedReceipt = await state.readTerminationReceipt({ handle });
+        if (!racedReceipt) throw new Error("isolated worker termination state changed before receipt persistence");
+        assertReceiptContext(racedReceipt, context);
+        return racedReceipt;
+      }
+      return receipt;
+      })();
+      revocations.set(revocationKey, operation);
+      try {
+        return await operation;
+      } finally {
+        if (revocations.get(revocationKey) === operation) revocations.delete(revocationKey);
+      }
+    },
+  };
+}
+
+async function createTrustedFrozenCheckpoint(
+  handle: IsolatedWorkerPodHandle,
+  _checkpointAttemptId: string,
+  checkpointTaskRunId: string,
+): Promise<FrozenCheckpointReadback> {
+  const { enqueueTask, taskQueue } = await import("./tasks.js");
+  const { db } = await import("./db/index.js");
+  const { checkpoints, spaces, taskRuns } = await import("@cohub/db");
+  const disposableSpaceId = handle.isolatedWorkerPolicy.disposableSpaceId;
+  const [space] = await db.select({
+    id: spaces.id,
+    userUuid: spaces.userUuid,
+  }).from(spaces).where(eq(spaces.id, disposableSpaceId)).limit(1);
+  if (!space) throw new Error("isolated worker disposable space not found");
+
+  const readCheckpointCreatedByTask = async (): Promise<FrozenCheckpointReadback | null> => {
+    const [frozen] = await db.select({
+      checkpointId: checkpoints.id,
+      commit: checkpoints.commitHash,
+      meta: checkpoints.meta,
+      currentHeadCheckpointId: spaces.headCheckpointId,
+      checkpointCreatedAt: checkpoints.createdAt,
+    }).from(checkpoints)
+      .innerJoin(spaces, eq(spaces.id, checkpoints.spaceId))
+      .where(and(
+        eq(checkpoints.spaceId, disposableSpaceId),
+        sql`${checkpoints.meta}->>'sourceTaskRunId' = ${checkpointTaskRunId}`,
+      ))
+      .limit(1);
+    if (!frozen) return null;
+    if (frozen.currentHeadCheckpointId !== frozen.checkpointId || !frozen.checkpointCreatedAt) {
+      throw new Error("IN_DOUBT: isolated worker checkpoint task left a partial checkpoint record");
+    }
+    const meta = frozen.meta && typeof frozen.meta === "object" && !Array.isArray(frozen.meta)
+      ? frozen.meta as Record<string, unknown>
+      : null;
+    const gitTree = meta?.gitTree && typeof meta.gitTree === "object" && !Array.isArray(meta.gitTree)
+      ? meta.gitTree as Record<string, unknown>
+      : null;
+    if (typeof gitTree?.hash !== "string" || !gitTree.hash || typeof gitTree.sha256 !== "string" || !/^[a-f0-9]{64}$/.test(gitTree.sha256)) {
+      throw new Error("isolated worker checkpoint task recovery readback is malformed");
+    }
+    return {
+      disposableSpaceId,
+      checkpointId: frozen.checkpointId,
+      commit: frozen.commit,
+      tree: gitTree.hash,
+      treeSha256: gitTree.sha256,
+      currentHead: frozen.commit,
+      checkpointCreatedAt: frozen.checkpointCreatedAt.toISOString(),
+    };
+  };
+  const recoveredCheckpoint = await readCheckpointCreatedByTask();
+  if (recoveredCheckpoint) return recoveredCheckpoint;
+
+  const checkpointPayload = {
+    type: "save_checkpoint" as const,
+    spaceId: disposableSpaceId,
+    sessionId: handle.sessionId,
+    turnId: handle.turnId,
+    userId: space.userUuid,
+    data: {
+      reason: "isolated_worker_revocation",
+      description: `Frozen isolated worker turn ${handle.turnId}`,
+    },
+  };
+  const [existingTask] = await db.select({ id: taskRuns.id, status: taskRuns.status }).from(taskRuns)
+    .where(eq(taskRuns.id, checkpointTaskRunId)).limit(1);
+  if (!existingTask) {
+    await enqueueTask(checkpointPayload, {
+      attempts: 1,
+      removeOnComplete: true,
+      taskRunId: checkpointTaskRunId,
+    });
+  } else if (existingTask.status === "failed") {
+    const checkpointAfterFailure = await readCheckpointCreatedByTask();
+    if (checkpointAfterFailure) return checkpointAfterFailure;
+    throw new IsolatedWorkerCheckpointNoEffectError(
+      `isolated worker checkpoint TaskRun ${checkpointTaskRunId} failed with no authoritative checkpoint effect`,
+    );
+  } else if (existingTask.status === "pending") {
+    const existingJob = await taskQueue.getJob(checkpointTaskRunId);
+    if (!existingJob) {
+      await taskQueue.add(checkpointPayload.type, checkpointPayload, {
+        attempts: 1,
+        removeOnComplete: true,
+        removeOnFail: true,
+        jobId: checkpointTaskRunId,
+      });
+    }
+  }
+  const taskRunId = checkpointTaskRunId;
+
+  const deadline = Date.now() + 300_000;
+  let completedResult: Record<string, unknown> | null = null;
+  while (Date.now() < deadline) {
+    const [task] = await db.select({
+      status: taskRuns.status,
+      result: taskRuns.result,
+      errorMessage: taskRuns.errorMessage,
+    }).from(taskRuns).where(eq(taskRuns.id, taskRunId)).limit(1);
+    if (!task) throw new Error("isolated worker checkpoint task disappeared");
+    if (task.status === "failed") throw new Error(`isolated worker checkpoint failed: ${task.errorMessage ?? "unknown error"}`);
+    if (task.status === "completed") {
+      if (!task.result || typeof task.result !== "object" || Array.isArray(task.result)) {
+        throw new Error("isolated worker checkpoint returned malformed result");
+      }
+      completedResult = task.result as Record<string, unknown>;
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  if (!completedResult) throw new Error("timed out waiting for isolated worker checkpoint");
+
+  const checkpointId = typeof completedResult.checkpointId === "string" ? completedResult.checkpointId : "";
+  const commit = typeof completedResult.commitHash === "string" ? completedResult.commitHash : "";
+  const tree = typeof completedResult.treeHash === "string" ? completedResult.treeHash : "";
+  const treeSha256 = typeof completedResult.checkpointTreeSha256 === "string" ? completedResult.checkpointTreeSha256 : "";
+  if (!checkpointId || !commit || !tree || !/^[a-f0-9]{64}$/.test(treeSha256) || completedResult.spaceId !== disposableSpaceId) {
+    throw new Error("isolated worker checkpoint result binding mismatch");
+  }
+  const [frozen] = await db.select({
+    checkpointId: checkpoints.id,
+    commit: checkpoints.commitHash,
+    currentHeadCheckpointId: spaces.headCheckpointId,
+    checkpointCreatedAt: checkpoints.createdAt,
+    checkpointMeta: checkpoints.meta,
+  }).from(checkpoints)
+    .innerJoin(spaces, eq(spaces.id, checkpoints.spaceId))
+    .where(and(eq(checkpoints.id, checkpointId), eq(checkpoints.spaceId, disposableSpaceId)))
+    .limit(1);
+  const frozenMeta = frozen?.checkpointMeta && typeof frozen.checkpointMeta === "object" && !Array.isArray(frozen.checkpointMeta)
+    ? frozen.checkpointMeta as Record<string, unknown>
+    : null;
+  const gitTree = frozenMeta?.gitTree && typeof frozenMeta.gitTree === "object" && !Array.isArray(frozenMeta.gitTree)
+    ? frozenMeta.gitTree as Record<string, unknown>
+    : null;
+  if (!frozen?.checkpointCreatedAt || frozen.commit !== commit || frozen.currentHeadCheckpointId !== checkpointId || gitTree?.hash !== tree || gitTree.sha256 !== treeSha256) {
+    throw new Error("IN_DOUBT: isolated worker frozen checkpoint does not match disposable space head");
+  }
+  return {
+    disposableSpaceId,
+    checkpointId,
+    commit,
+    tree,
+    treeSha256,
+    currentHead: frozen.commit,
+    checkpointCreatedAt: frozen.checkpointCreatedAt.toISOString(),
+  };
+}
+
+export const isolatedWorkerPodLifecycle = createIsolatedWorkerPodLifecycle({
+  createFrozenCheckpoint: createTrustedFrozenCheckpoint,
+});
+
+export function renderConfiguredIsolatedWorkerPodTemplate(input: IsolatedWorkerBinding & { writableRoot: string; policySha256: string }) {
+  return renderIsolatedWorkerPodTemplate({
+    ...input,
+    writableRoot: input.writableRoot,
+    image: config.sandboxImage,
+    spaceStoragePvc: config.spaceStoragePvc,
+    spaceStorageSubpath: config.spaceStorageSubpath,
+  });
+}

--- a/apps/api/src/isolated-worker-prompt.test.ts
+++ b/apps/api/src/isolated-worker-prompt.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import type { SubmitSessionPromptHooks } from "@cohub/core/sessions";
 import {
+  assertExactIsolatedWorkerPromptBody,
   parseIsolatedWorkerPolicyInput,
   submitIsolatedWorkerPrompt,
 } from "./isolated-worker-prompt.js";
@@ -23,6 +24,24 @@ assert.throws(() => parseIsolatedWorkerPolicyInput({ ...policy, workspaceReadOnl
 assert.throws(() => parseIsolatedWorkerPolicyInput({ ...policy, authoritySpaceId: disposableSpaceId }, disposableSpaceId), /differ/);
 assert.throws(() => parseIsolatedWorkerPolicyInput({ ...policy, disposableSpaceId: authoritySpaceId }, disposableSpaceId), /binding mismatch/);
 assert.throws(() => parseIsolatedWorkerPolicyInput({ ...policy, extra: true }, disposableSpaceId), /unknown field/);
+
+assert.throws(
+  () => assertExactIsolatedWorkerPromptBody({
+    content: [{ type: "text", text: "work" }],
+    userId: "user-1",
+    clientMessageId: "client-1",
+    source: "isolated_worker_dispatch",
+    model: null,
+    provider: null,
+    accessMode: "isolated_worker",
+    isolatedWorkerPolicy: policy,
+    inputsMaterializedAt: "2026-07-15T00:00:00.000Z",
+    dispatchTaskRunId: "44444444-4444-4444-8444-444444444444",
+    context: { kind: "scheduled_task", taskRunId: "44444444-4444-4444-8444-444444444444" },
+    inputBundle: { callerSupplied: true },
+  }),
+  /isolated worker prompt contains unknown field: inputBundle/,
+);
 
 const events: string[] = [];
 const handle = {

--- a/apps/api/src/isolated-worker-prompt.test.ts
+++ b/apps/api/src/isolated-worker-prompt.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import type { SubmitSessionPromptHooks } from "@cohub/core/sessions";
+import {
+  parseIsolatedWorkerPolicyInput,
+  submitIsolatedWorkerPrompt,
+} from "./isolated-worker-prompt.js";
+
+const authoritySpaceId = "7d8f6814-b123-410f-861f-67c07717ac68";
+const disposableSpaceId = "6d8f6814-b123-410f-861f-67c07717ac69";
+const sessionId = "5212eda6-7336-4b30-8050-e9d27dbc77f0";
+const policySha256 = "a".repeat(64);
+
+const policy = parseIsolatedWorkerPolicyInput({
+  authoritySpaceId,
+  disposableSpaceId,
+  writableRoot: "/workspace/work",
+  workspaceReadOnly: true,
+  executionTokenIssued: false,
+  policySha256,
+}, disposableSpaceId);
+
+assert.throws(() => parseIsolatedWorkerPolicyInput({ ...policy, workspaceReadOnly: false }, disposableSpaceId), /workspaceReadOnly/);
+assert.throws(() => parseIsolatedWorkerPolicyInput({ ...policy, authoritySpaceId: disposableSpaceId }, disposableSpaceId), /differ/);
+assert.throws(() => parseIsolatedWorkerPolicyInput({ ...policy, disposableSpaceId: authoritySpaceId }, disposableSpaceId), /binding mismatch/);
+assert.throws(() => parseIsolatedWorkerPolicyInput({ ...policy, extra: true }, disposableSpaceId), /unknown field/);
+
+const events: string[] = [];
+const handle = {
+  sessionId,
+  turnId: "turn-1",
+  podName: `sandbox-${disposableSpaceId}`,
+  podCreatedAt: "2026-07-15T00:00:01.000Z",
+  isolatedWorkerPolicy: {
+    ...policy,
+    podUid: "pod-uid-1",
+  },
+  metadata: {
+    worker_identity: { access_mode: "isolated_worker" as const },
+    write_scope: { mode: "isolated_task_space" as const, root: "work/" as const },
+    disposable_space_id: disposableSpaceId,
+    termination_required: true as const,
+    workflow_execution_token_issued: false as const,
+  },
+  status: "running" as const,
+  resumable: false as const,
+};
+
+let submittedHook: SubmitSessionPromptHooks["beforeEnqueue"];
+const result = await submitIsolatedWorkerPrompt({
+  policy,
+  sessionId,
+  turnMeta: { isolatedWorkerDispatch: { taskRunId: "dispatch-1" } },
+  submitPrompt: async (promptInput, hooks) => {
+    assert.equal(promptInput.spaceId, disposableSpaceId);
+    events.push("turn-created");
+    submittedHook = hooks.beforeEnqueue;
+    const patch = await submittedHook?.({ turnId: "turn-1", userMessageId: "message-1", content: [], meta: {} });
+    await hooks.afterMetaPersistedBeforeEnqueue?.({ turnId: "turn-1", userMessageId: "message-1", content: [], meta: {} });
+    events.push("enqueued");
+    assert.deepEqual(patch, {
+      isolatedWorkerDispatch: { taskRunId: "dispatch-1" },
+      isolatedWorker: handle,
+      isolatedWorkerPolicy: handle.isolatedWorkerPolicy,
+    });
+    return { turnId: "turn-1", userMessageId: "message-1" };
+  },
+  createPod: async (input) => {
+    events.push(`pod-created:${input.turnId}`);
+    return handle;
+  },
+  onPodCreatedBeforeEnqueue: async () => ({ podCreatedAt: "2026-07-15T00:00:01.000Z" }),
+  revokePod: async () => { throw new Error("must not revoke successful prompt"); },
+  prompt: {
+    spaceId: disposableSpaceId,
+    sessionId,
+    userId: "user-1",
+    clientMessageId: "client-1",
+    content: [{ type: "text", text: "work" }],
+    source: "internal",
+    accessMode: "isolated_worker",
+  },
+});
+assert.deepEqual(result, { turnId: "turn-1", userMessageId: "message-1", podUid: "pod-uid-1", policySha256, podCreatedAt: "2026-07-15T00:00:01.000Z" });
+assert.deepEqual(events, ["turn-created", "pod-created:turn-1", "enqueued"]);
+
+events.length = 0;
+await assert.rejects(() => submitIsolatedWorkerPrompt({
+  policy,
+  sessionId,
+  submitPrompt: async (_input, hooks) => {
+    events.push("turn-created");
+    await hooks.beforeEnqueue?.({ turnId: "turn-2", userMessageId: "message-2", content: [], meta: {} });
+    throw new Error("persistence failed");
+  },
+  createPod: async () => {
+    events.push("pod-created");
+    return { ...handle, turnId: "turn-2" };
+  },
+  revokePod: async (created) => { events.push(`revoked:${created.turnId}`); return {} as never; },
+  prompt: {
+    spaceId: disposableSpaceId,
+    sessionId,
+    userId: "user-1",
+    clientMessageId: "client-2",
+    content: [{ type: "text", text: "work" }],
+    source: "internal",
+    accessMode: "isolated_worker",
+  },
+}), /persistence failed/);
+assert.deepEqual(events, ["turn-created", "pod-created", "revoked:turn-2"]);
+
+console.log("isolated worker prompt integration checks passed");

--- a/apps/api/src/isolated-worker-prompt.ts
+++ b/apps/api/src/isolated-worker-prompt.ts
@@ -1,0 +1,117 @@
+import type {
+  SubmitSessionPromptHooks,
+  SubmitSessionPromptInput,
+  SubmitSessionPromptResult,
+} from "@cohub/core/sessions";
+import type {
+  IsolatedWorkerPodHandle,
+  IsolatedWorkerPolicy,
+  IsolatedWorkerRevocationReceipt,
+} from "./isolated-worker-pods.js";
+
+const POLICY_FIELDS = new Set([
+  "authoritySpaceId",
+  "disposableSpaceId",
+  "writableRoot",
+  "workspaceReadOnly",
+  "executionTokenIssued",
+  "policySha256",
+]);
+
+export type IsolatedWorkerPolicyInput = Omit<IsolatedWorkerPolicy, "podUid">;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+export function parseIsolatedWorkerPolicyInput(value: unknown, disposableSpaceId: string): IsolatedWorkerPolicyInput {
+  if (!isRecord(value)) throw new Error("isolatedWorkerPolicy is required");
+  const unknownField = Object.keys(value).find((key) => !POLICY_FIELDS.has(key));
+  if (unknownField) throw new Error(`isolatedWorkerPolicy contains unknown field: ${unknownField}`);
+  for (const field of POLICY_FIELDS) {
+    if (!(field in value)) throw new Error(`isolatedWorkerPolicy.${field} is required`);
+  }
+  if (typeof value.authoritySpaceId !== "string" || !value.authoritySpaceId.trim()) {
+    throw new Error("isolatedWorkerPolicy.authoritySpaceId is required");
+  }
+  if (value.disposableSpaceId !== disposableSpaceId) throw new Error("isolatedWorkerPolicy disposable space binding mismatch");
+  if (value.authoritySpaceId === disposableSpaceId) {
+    throw new Error("isolatedWorkerPolicy.disposableSpaceId must differ from authoritySpaceId");
+  }
+  if (value.writableRoot !== "/workspace/work") throw new Error("isolatedWorkerPolicy.writableRoot must be /workspace/work");
+  if (value.workspaceReadOnly !== true) throw new Error("isolatedWorkerPolicy.workspaceReadOnly must be true");
+  if (value.executionTokenIssued !== false) throw new Error("isolatedWorkerPolicy.executionTokenIssued must be false");
+  if (typeof value.policySha256 !== "string" || !/^[a-f0-9]{64}$/.test(value.policySha256)) {
+    throw new Error("isolatedWorkerPolicy.policySha256 must be a lowercase SHA-256 digest");
+  }
+  return {
+    authoritySpaceId: value.authoritySpaceId,
+    disposableSpaceId,
+    writableRoot: "/workspace/work",
+    workspaceReadOnly: true,
+    executionTokenIssued: false,
+    policySha256: value.policySha256,
+  };
+}
+
+export async function submitIsolatedWorkerPrompt(input: {
+  policy: IsolatedWorkerPolicyInput;
+  sessionId: string;
+  turnMeta?: Record<string, unknown>;
+  prompt: SubmitSessionPromptInput & { accessMode: "isolated_worker" };
+  submitPrompt: (prompt: SubmitSessionPromptInput, hooks: SubmitSessionPromptHooks) => Promise<SubmitSessionPromptResult>;
+  createPod: (input: IsolatedWorkerPolicyInput & { sessionId: string; turnId: string }) => Promise<IsolatedWorkerPodHandle>;
+  onPodCreatedBeforeEnqueue?: (input: {
+    handle: IsolatedWorkerPodHandle;
+    turnId: string;
+    userMessageId: string;
+  }) => Promise<{ podCreatedAt: string } | undefined>;
+  revokePod: (handle: IsolatedWorkerPodHandle) => Promise<IsolatedWorkerRevocationReceipt>;
+}) {
+  if (input.prompt.spaceId !== input.policy.disposableSpaceId || input.prompt.sessionId !== input.sessionId) {
+    throw new Error("isolated worker prompt binding mismatch");
+  }
+  let handle: IsolatedWorkerPodHandle | null = null;
+  let failureRevoked = false;
+  let podCreatedAt: string | null = null;
+  try {
+    const result = await input.submitPrompt(input.prompt, {
+      beforeEnqueue: async ({ turnId }) => {
+        handle = await input.createPod({ ...input.policy, sessionId: input.sessionId, turnId });
+        return {
+          ...(input.turnMeta ?? {}),
+          isolatedWorker: handle,
+          isolatedWorkerPolicy: handle.isolatedWorkerPolicy,
+        };
+      },
+      afterMetaPersistedBeforeEnqueue: async ({ turnId, userMessageId }) => {
+        const createdHandle = handle as IsolatedWorkerPodHandle | null;
+        if (!createdHandle) throw new Error("isolated worker pod is missing after meta persistence");
+        const completed = await input.onPodCreatedBeforeEnqueue?.({ handle: createdHandle, turnId, userMessageId });
+        if (completed) podCreatedAt = completed.podCreatedAt;
+      },
+      beforeFailureTerminalized: async () => {
+        const createdHandle = handle as IsolatedWorkerPodHandle | null;
+        if (!createdHandle) return;
+        await input.revokePod(createdHandle);
+        failureRevoked = true;
+      },
+    });
+    const completedHandle = handle as IsolatedWorkerPodHandle | null;
+    if (!completedHandle) throw new Error("isolated worker pod was not created before enqueue");
+    if (!podCreatedAt) throw new Error("isolated worker pod creation timestamp was not persisted before enqueue");
+    return {
+      ...result,
+      podUid: completedHandle.isolatedWorkerPolicy.podUid,
+      policySha256: completedHandle.isolatedWorkerPolicy.policySha256,
+      podCreatedAt,
+    };
+  } catch (error) {
+    if (!handle || failureRevoked) throw error;
+    try {
+      await input.revokePod(handle);
+    } catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], "isolated worker prompt failed and pod revocation did not complete");
+    }
+    throw error;
+  }
+}

--- a/apps/api/src/isolated-worker-prompt.ts
+++ b/apps/api/src/isolated-worker-prompt.ts
@@ -18,10 +18,33 @@ const POLICY_FIELDS = new Set([
   "policySha256",
 ]);
 
+const ISOLATED_PROMPT_BODY_FIELDS = new Set([
+  "content",
+  "userId",
+  "clientMessageId",
+  "source",
+  "model",
+  "provider",
+  "accessMode",
+  "isolatedWorkerPolicy",
+  "inputsMaterializedAt",
+  "dispatchTaskRunId",
+  "context",
+]);
+
 export type IsolatedWorkerPolicyInput = Omit<IsolatedWorkerPolicy, "podUid">;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+export function assertExactIsolatedWorkerPromptBody(value: unknown): asserts value is Record<string, unknown> {
+  if (!isRecord(value)) throw new Error("isolated worker prompt body is required");
+  const unknownField = Object.keys(value).find((key) => !ISOLATED_PROMPT_BODY_FIELDS.has(key));
+  if (unknownField) throw new Error(`isolated worker prompt contains unknown field: ${unknownField}`);
+  for (const field of ISOLATED_PROMPT_BODY_FIELDS) {
+    if (!(field in value)) throw new Error(`isolated worker prompt is missing field: ${field}`);
+  }
+}
 
 export function parseIsolatedWorkerPolicyInput(value: unknown, disposableSpaceId: string): IsolatedWorkerPolicyInput {
   if (!isRecord(value)) throw new Error("isolatedWorkerPolicy is required");

--- a/apps/api/src/isolated-worker-termination.ts
+++ b/apps/api/src/isolated-worker-termination.ts
@@ -1,0 +1,196 @@
+import { createHash } from "node:crypto";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { sessionTurns, taskRuns } from "@cohub/db";
+import {
+  ISOLATED_WORKER_RECEIPT_SCAN_TASK_TYPE,
+  ISOLATED_WORKER_REVOKE_TASK_TYPE,
+  type IsolatedWorkerRevokeTaskData,
+  type IsolatedWorkerTerminalStatus,
+} from "@cohub/protocol/isolated-worker";
+import type { TaskPayload } from "@cohub/protocol/task";
+import { db } from "./db/index.js";
+import { enqueueTask } from "./tasks.js";
+import type { IsolatedWorkerPodHandle } from "./isolated-worker-pods.js";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function deterministicUuid(seed: string) {
+  const value = createHash("sha256").update(seed).digest("hex").slice(0, 32).split("");
+  value[12] = "4";
+  value[16] = ["8", "9", "a", "b"][Number.parseInt(value[16] ?? "0", 16) % 4] ?? "8";
+  const hex = value.join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function parseHandle(meta: unknown, input: { spaceId: string; sessionId: string; turnId: string }) {
+  const record = isRecord(meta) ? meta : null;
+  const handle = record && isRecord(record.isolatedWorker)
+    ? record.isolatedWorker as unknown as IsolatedWorkerPodHandle
+    : null;
+  if (
+    !handle
+    || handle.sessionId !== input.sessionId
+    || handle.turnId !== input.turnId
+    || handle.isolatedWorkerPolicy?.disposableSpaceId !== input.spaceId
+    || !handle.isolatedWorkerPolicy.authoritySpaceId
+    || !handle.isolatedWorkerPolicy.podUid
+  ) {
+    throw new Error("isolated worker termination binding mismatch");
+  }
+  return { meta: record ?? {}, handle };
+}
+
+export async function scheduleIsolatedWorkerTermination(input: {
+  spaceId: string;
+  sessionId: string;
+  turnId: string;
+  terminalStatus: IsolatedWorkerTerminalStatus;
+}) {
+  const [turn] = await db.select().from(sessionTurns).where(and(
+    eq(sessionTurns.id, input.turnId),
+    eq(sessionTurns.sessionId, input.sessionId),
+  )).limit(1);
+  if (!turn) throw new Error("isolated worker Turn not found");
+  if (["completed", "failed", "interrupted", "cancelled"].includes(turn.status)) {
+    const { meta, handle } = parseHandle(turn.meta, input);
+    const receipt = isRecord(meta.isolatedWorkerTermination) ? meta.isolatedWorkerTermination : null;
+    if (receipt?.podUid === handle.isolatedWorkerPolicy.podUid) {
+      return {
+        revokeTaskRunId: String(receipt.revokeTaskRunId),
+        receipt,
+        alreadyTerminated: true as const,
+      };
+    }
+    throw new Error("isolated worker Turn became terminal without a termination receipt");
+  }
+  const { meta, handle } = parseHandle(turn.meta, input);
+  const existingRevocation = isRecord(meta.isolatedWorkerRevocation) ? meta.isolatedWorkerRevocation : null;
+  const existingTaskRunId = typeof existingRevocation?.taskRunId === "string" ? existingRevocation.taskRunId : null;
+  const [existingTask] = existingTaskRunId
+    ? await db.select().from(taskRuns).where(eq(taskRuns.id, existingTaskRunId)).limit(1)
+    : [];
+  if (existingTask && existingTask.status === "completed") {
+    return { revokeTaskRunId: existingTask.id, alreadyTerminated: false as const };
+  }
+  if (existingTask && ["pending", "running"].includes(existingTask.status)) {
+    return { revokeTaskRunId: existingTask.id, alreadyTerminated: false as const };
+  }
+  const previousAttempt = isRecord(meta.isolatedWorkerTerminationState)
+    && typeof meta.isolatedWorkerTerminationState.attempt === "number"
+    ? meta.isolatedWorkerTerminationState.attempt
+    : 0;
+  const attempt = previousAttempt + 1;
+  const revokeTaskRunId = deterministicUuid(`isolated-worker-revoke:${input.turnId}:${handle.isolatedWorkerPolicy.podUid}:${attempt}`);
+  const revocationMeta = {
+    taskRunId: revokeTaskRunId,
+    taskType: ISOLATED_WORKER_REVOKE_TASK_TYPE,
+    trigger: "turn_terminal_event",
+    terminalStatus: input.terminalStatus,
+    automatic: true,
+    manualEndpointInvoked: false,
+    podUid: handle.isolatedWorkerPolicy.podUid,
+  } as const;
+  const terminationState = {
+    state: "stopping",
+    attempt,
+    requestedTerminalStatus: input.terminalStatus,
+    requestedAt: new Date().toISOString(),
+    revokeTaskRunId,
+  } as const;
+  const [claimed] = await db.update(sessionTurns).set({
+    meta: sql`coalesce(${sessionTurns.meta}, '{}'::jsonb) || ${JSON.stringify({
+      isolatedWorkerRevocation: revocationMeta,
+      isolatedWorkerTerminationState: terminationState,
+    })}::jsonb`,
+    updatedAt: new Date(),
+  }).where(and(
+    eq(sessionTurns.id, input.turnId),
+    eq(sessionTurns.sessionId, input.sessionId),
+    inArray(sessionTurns.status, ["queued", "running", "abort_requested"]),
+  )).returning({ id: sessionTurns.id });
+  if (!claimed) throw new Error("isolated worker Turn changed before termination scheduling");
+  const data: IsolatedWorkerRevokeTaskData = {
+    trigger: "turn_terminal_event",
+    terminalStatus: input.terminalStatus,
+    authoritySpaceId: handle.isolatedWorkerPolicy.authoritySpaceId,
+    disposableSpaceId: input.spaceId,
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    podUid: handle.isolatedWorkerPolicy.podUid,
+  };
+  const payload: TaskPayload = {
+    type: ISOLATED_WORKER_REVOKE_TASK_TYPE,
+    spaceId: input.spaceId,
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    userId: turn.userUuid ?? undefined,
+    data,
+  };
+  await enqueueTask(payload, {
+    taskRunId: revokeTaskRunId,
+    attempts: 8,
+    backoff: { type: "exponential", delay: 1_000 },
+  });
+  return { revokeTaskRunId, alreadyTerminated: false as const };
+}
+
+export async function readIsolatedWorkerTermination(input: {
+  spaceId: string;
+  sessionId: string;
+  turnId: string;
+  revokeTaskRunId: string;
+}) {
+  const [revokeTask] = await db.select().from(taskRuns).where(and(
+    eq(taskRuns.id, input.revokeTaskRunId),
+    eq(taskRuns.taskType, ISOLATED_WORKER_REVOKE_TASK_TYPE),
+    eq(taskRuns.spaceId, input.spaceId),
+    eq(taskRuns.sessionId, input.sessionId),
+    eq(taskRuns.turnId, input.turnId),
+  )).limit(1);
+  if (!revokeTask) return { state: "pending" as const };
+  if (revokeTask.status === "failed") throw new Error(`isolated worker revoke failed: ${revokeTask.errorMessage ?? "unknown error"}`);
+  if (revokeTask.status !== "completed" || !revokeTask.finishedAt) return { state: "pending" as const };
+  const revokeResult = isRecord(revokeTask.result) ? revokeTask.result : null;
+  const receipt = revokeResult && isRecord(revokeResult.receipt) ? revokeResult.receipt : null;
+  if (!receipt || receipt.revokeTaskRunId !== input.revokeTaskRunId) {
+    throw new Error("isolated worker revoke receipt is missing or mismatched");
+  }
+  const [scanTask] = await db.select().from(taskRuns).where(and(
+    eq(taskRuns.taskType, ISOLATED_WORKER_RECEIPT_SCAN_TASK_TYPE),
+    eq(taskRuns.spaceId, String((revokeTask.payload.data as Record<string, unknown>).authoritySpaceId)),
+    sql`${taskRuns.payload}->'data'->>'revokeTaskRunId' = ${input.revokeTaskRunId}`,
+  )).orderBy(desc(taskRuns.createdAt)).limit(1);
+  if (!scanTask || scanTask.status === "pending" || scanTask.status === "running") return { state: "pending" as const };
+  if (scanTask.status === "failed") throw new Error(`isolated worker receipt scan failed: ${scanTask.errorMessage ?? "unknown error"}`);
+  const scanResult = isRecord(scanTask.result) ? scanTask.result : null;
+  if (
+    scanTask.status !== "completed"
+    || !scanTask.startedAt
+    || scanTask.startedAt.getTime() <= revokeTask.finishedAt.getTime()
+    || scanResult?.revokeTaskRunId !== input.revokeTaskRunId
+    || scanResult.scanStartedAfterRevoke !== true
+    || scanResult.receiptEligible !== true
+  ) {
+    throw new Error("isolated worker receipt scan proof is invalid");
+  }
+  return { state: "terminated" as const, receipt, scanTaskRunId: scanTask.id };
+}
+
+export async function waitForIsolatedWorkerTermination(input: {
+  spaceId: string;
+  sessionId: string;
+  turnId: string;
+  revokeTaskRunId: string;
+  timeoutMs?: number;
+}) {
+  const deadline = Date.now() + (input.timeoutMs ?? 20 * 60_000);
+  while (Date.now() < deadline) {
+    const state = await readIsolatedWorkerTermination(input);
+    if (state.state === "terminated") return state;
+    await sleep(500);
+  }
+  throw new Error("timed out waiting for isolated worker termination receipt scan");
+}

--- a/apps/api/src/routes/cron-jobs.route.ts
+++ b/apps/api/src/routes/cron-jobs.route.ts
@@ -9,6 +9,7 @@ import { hasPermission } from "../permissions.js";
 import { disableCronJob, enableCronJob, removeCronJob, updateCronJob } from "../tasks.js";
 import { fallbackPublicUserProfile, getProfilesByUuids } from "../user-profiles.js";
 import { sanitizeTaskRunPricingForViewer } from "../task-run-privacy.js";
+import { rejectIsolatedWorkerDisposableRouteMutation } from "../isolated-worker-disposable-guard.js";
 
 const router = new Hono();
 const { CronExpressionParser } = cronParser;
@@ -210,6 +211,13 @@ router.delete("/:id", async (c) => {
     .limit(1);
   if (!job) return c.json({ message: "not found" }, 404);
   if (!(await authorizeCronJobManage(user, job))) return authzDenied(c);
+  if (job.spaceId) {
+    const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, {
+      spaceId: job.spaceId,
+      operation: "cron_schedule",
+    });
+    if (rejected) return rejected;
+  }
 
   await removeCronJob(cronJobId, job.bullJobKey);
   return c.json({ ok: true });
@@ -229,6 +237,13 @@ router.patch("/:id", async (c) => {
     .limit(1);
   if (!job) return c.json({ message: "not found" }, 404);
   if (!(await authorizeCronJobManage(user, job))) return authzDenied(c);
+  if (job.spaceId) {
+    const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, {
+      spaceId: job.spaceId,
+      operation: "cron_schedule",
+    });
+    if (rejected) return rejected;
+  }
 
   const body = await c.req.json<Record<string, unknown>>().catch(() => null);
   if (!body || typeof body !== "object" || Array.isArray(body)) return c.json({ message: "invalid json body" }, 400);

--- a/apps/api/src/routes/generations.route.ts
+++ b/apps/api/src/routes/generations.route.ts
@@ -25,6 +25,7 @@ import { getSessionTurnById } from "../session-turns.js";
 import { enqueueTask } from "../tasks.js";
 import { defaultJobRetention } from "@cohub/infra/bullmq";
 import { createLogger } from "@cohub/infra/logging";
+import { rejectIsolatedWorkerDisposableRouteMutation } from "../isolated-worker-disposable-guard.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -59,6 +60,11 @@ router.post("/", async (c) => {
 
   const request = parsed.data;
   if (!(await hasPermission(user, "generation.create", { spaceId: request.spaceId }))) return authzDenied(c);
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, {
+    spaceId: request.spaceId,
+    operation: "generic_task_dispatch",
+  });
+  if (rejected) return rejected;
 
   const sessionId = request.sessionId?.trim() || null;
   const turnId = request.turnId?.trim() || null;

--- a/apps/api/src/routes/internal/canvas.route.ts
+++ b/apps/api/src/routes/internal/canvas.route.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { applyCanvasTransaction, type CanvasSemanticOp } from "../../canvas-service.js";
 import { ensureInternalRequest, requireValidId, type AuthUser } from "../../lib/middleware.js";
 import { hasPermission } from "../../permissions.js";
+import { rejectIsolatedWorkerDisposableRouteMutation } from "../../isolated-worker-disposable-guard.js";
 
 const router = new Hono();
 
@@ -23,6 +24,8 @@ router.post("/:spaceId/:documentId/tx", async (c) => {
   try {
     const actor = { uuid: body.actorId } as AuthUser;
     if (!(await hasPermission(actor, "file.edit", { spaceId }))) return c.json({ message: "forbidden" }, 403);
+    const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, { spaceId, operation: "generic_mutation" });
+    if (rejected) return rejected;
     const result = await applyCanvasTransaction({
       spaceId,
       documentId,

--- a/apps/api/src/routes/internal/gateway.route.ts
+++ b/apps/api/src/routes/internal/gateway.route.ts
@@ -35,7 +35,10 @@ import {
   type SpaceUploadManifestEntry,
 } from "../../space-upload-storage.js";
 import { enqueueSandboxUploadFilesJob } from "../../sandbox-bash-queue.js";
-import { config } from "../../config.js";
+import { spaceChannels } from "@cohub/db";
+import { eq } from "drizzle-orm";
+import { db } from "../../db/index.js";
+import { rejectIsolatedWorkerDisposableRouteMutation } from "../../isolated-worker-disposable-guard.js";
 
 const logger = createLogger({ serviceName: "cohub-api" });
 const tracer = getTracer("cohub-api");
@@ -199,6 +202,8 @@ router.post("/local-sandbox/status", async (c) => {
   }>().catch(() => null);
   const spaceId = typeof body?.spaceId === "string" ? body.spaceId.trim() : "";
   if (!spaceId || !requireValidId(spaceId)) return c.json({ ok: false, message: "spaceId is required" }, 400);
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, { spaceId, operation: "sandbox_lifecycle" });
+  if (rejected) return rejected;
   const status = body?.status === "ready" ? "ready" : "stopped";
 
   const sandbox = await getSpaceSandboxBySpaceId(spaceId);
@@ -254,6 +259,16 @@ router.post("/attachments/plan", async (c) => {
   }>().catch(() => null);
   const parsed = gatewayInboundEventSchema.safeParse(body?.event);
   if (!parsed.success) return c.json({ message: "invalid gateway attachment event", issues: parsed.error.issues }, 400);
+
+  const [channel] = await db.select({ spaceId: spaceChannels.spaceId }).from(spaceChannels)
+    .where(eq(spaceChannels.id, parsed.data.channelId)).limit(1);
+  if (channel) {
+    const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, {
+      spaceId: channel.spaceId,
+      operation: "generic_mutation",
+    });
+    if (rejected) return rejected;
+  }
 
   const resolved = await resolveChannelInboundForEventWithLock(parsed.data);
   if (!resolved) return c.json({ message: "gateway inbound already processed" }, 409);
@@ -398,6 +413,8 @@ router.post("/attachments/materialize", async (c) => {
   const userId = body?.userId?.trim() || null;
   const files = Array.isArray(body?.files) ? body.files : [];
   if (!spaceId || !requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, { spaceId, operation: "generic_mutation" });
+  if (rejected) return rejected;
   if (files.length === 0) return c.json({ message: "files are required" }, 400);
   if (files.length > MAX_GATEWAY_ATTACHMENT_FILES + MAX_GATEWAY_ATTACHMENT_IMAGES) {
     return c.json({ message: "too many files" }, 413);
@@ -494,6 +511,9 @@ router.post("/attachments/complete", async (c) => {
   const uploadId = body?.uploadId?.trim();
   const entryIds = Array.isArray(body?.entryIds) ? body.entryIds.filter((id): id is string => typeof id === "string" && id.trim().length > 0) : [];
   if (!spaceId || !uploadId || entryIds.length === 0) return c.json({ message: "spaceId, uploadId and entryIds are required" }, 400);
+  if (!requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, { spaceId, operation: "generic_mutation" });
+  if (rejected) return rejected;
 
   const completeState = await beginSpaceUploadComplete(spaceId, uploadId);
   if (!completeState.acquired) return c.json({ message: "upload is already being completed" }, 409);
@@ -556,6 +576,15 @@ router.post("/inbound", async (c) => {
   if (!parsed.success) return c.json({ message: "invalid gateway inbound event", issues: parsed.error.issues }, 400);
 
   const event = parsed.data;
+  const [channel] = await db.select({ spaceId: spaceChannels.spaceId }).from(spaceChannels)
+    .where(eq(spaceChannels.id, event.channelId)).limit(1);
+  if (channel) {
+    const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, {
+      spaceId: channel.spaceId,
+      operation: "generic_mutation",
+    });
+    if (rejected) return rejected;
+  }
   const parentCtx = extractTrace(event as unknown as Record<string, unknown>);
   const span = tracer.startSpan("api.gateway_inbound.handle", {
     attributes: {

--- a/apps/api/src/routes/internal/spaces.route.ts
+++ b/apps/api/src/routes/internal/spaces.route.ts
@@ -41,6 +41,7 @@ import {
   type IsolatedWorkerPodHandle,
 } from "../../isolated-worker-pods.js";
 import {
+  assertExactIsolatedWorkerPromptBody,
   parseIsolatedWorkerPolicyInput,
   submitIsolatedWorkerPrompt,
   type IsolatedWorkerPolicyInput,
@@ -461,6 +462,7 @@ router.post("/:spaceId/sessions/:sessionId/prompt", async (c) => {
   let isolatedWorkerInputManifestSha256: string | null = null;
   if (accessMode === "isolated_worker") {
     try {
+      assertExactIsolatedWorkerPromptBody(body);
       isolatedWorkerPolicy = parseIsolatedWorkerPolicyInput(body.isolatedWorkerPolicy, spaceId);
     } catch (error) {
       return c.json({ message: error instanceof Error ? error.message : String(error) }, 400);

--- a/apps/api/src/routes/internal/spaces.route.ts
+++ b/apps/api/src/routes/internal/spaces.route.ts
@@ -16,11 +16,12 @@ import {
   SandboxNotReadyError,
 } from "../../space-sessions.js";
 import { abortSessionTurn, failSessionTurn, interruptSessionTurn } from "../../session-turns.js";
+import { getSessionTurnById } from "../../session-turns.js";
 import { hasPermission } from "../../permissions.js";
 import { dispatchTurnFinalized } from "../../session-output.js";
-import { submitSessionPrompt, type PromptAccessMode, type SubmitSessionPromptContext } from "../../session-prompts.js";
+import { submitSessionPrompt, type AgentPromptAccessMode, type SubmitSessionPromptContext } from "../../session-prompts.js";
 import { parsePromptEnv, PromptEnvValidationError } from "@cohub/core/sessions";
-import { verifyWorkSessionToken } from "../../work-sessions.js";
+import { createWorkSessionToken, verifyWorkSessionToken } from "../../work-sessions.js";
 import { mergePromptContextAuth, promptAuthContextFromWorkSession } from "../../prompt-auth-context.js";
 import { getSpaceSandboxBySpaceId, updateSpaceSandbox, recoverSpaceSandbox } from "../../space-sandboxes.js";
 import { isSandboxReportTokenValid } from "../../crypto.js";
@@ -31,6 +32,32 @@ import {
   isPrivateNetworkAddress,
   requireValidId,
 } from "../../lib/middleware.js";
+import { config } from "../../config.js";
+import { db } from "../../db/index.js";
+import { sessionTurns, taskRuns } from "@cohub/db";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import {
+  isolatedWorkerPodLifecycle,
+  type IsolatedWorkerPodHandle,
+} from "../../isolated-worker-pods.js";
+import {
+  parseIsolatedWorkerPolicyInput,
+  submitIsolatedWorkerPrompt,
+  type IsolatedWorkerPolicyInput,
+} from "../../isolated-worker-prompt.js";
+import {
+  computeIsolatedWorkerInputManifestSha256,
+  computeIsolatedWorkerPolicySha256,
+  canonicalIsolatedWorkerJson,
+} from "../../isolated-worker-dispatch.js";
+import type { IsolatedWorkerInputBundle } from "@cohub/protocol/isolated-worker";
+import type { IsolatedWorkerTerminalStatus } from "@cohub/protocol/isolated-worker";
+import {
+  readIsolatedWorkerTermination,
+  scheduleIsolatedWorkerTermination,
+  waitForIsolatedWorkerTermination,
+} from "../../isolated-worker-termination.js";
+import { rejectIsolatedWorkerDisposableRouteMutation } from "../../isolated-worker-disposable-guard.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -100,6 +127,8 @@ router.post("/:id/status", async (c) => {
   if (!requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
   const space = await getSpaceById(spaceId);
   if (!space) return c.json({ message: "space not found" }, 404);
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, { spaceId, operation: "sandbox_lifecycle" });
+  if (rejected) return rejected;
 
   const body = await c.req.json<{ status?: string; meta?: Record<string, unknown> | null }>().catch(() => null);
   if (!body?.status) return c.json({ message: "status is required" }, 400);
@@ -155,6 +184,8 @@ router.post("/:id/sandbox-report", async (c) => {
   if (!sandbox || !expectedTokenHash || !isSandboxReportTokenValid(sandboxReportToken, expectedTokenHash)) {
     return c.json({ message: "forbidden" }, 403);
   }
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, { spaceId, operation: "sandbox_lifecycle" });
+  if (rejected) return rejected;
 
   const safeMeta = sanitizeSandboxMeta({
     ...(body.meta ?? {}),
@@ -201,6 +232,8 @@ router.post("/:id/sandbox/recover", async (c) => {
   if (!requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
   const space = await getSpaceById(spaceId);
   if (!space) return c.json({ message: "space not found" }, 404);
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, { spaceId, operation: "sandbox_lifecycle" });
+  if (rejected) return rejected;
 
   const body = (await c.req.json<{ reason?: string; source?: string }>().catch(() => ({}))) as { reason?: string; source?: string };
   try {
@@ -245,6 +278,8 @@ router.post("/:spaceId/sessions/:sessionId/info", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session || session.spaceId !== spaceId) return c.json({ message: "session not found" }, 404);
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, { spaceId, operation: "isolated_worker_runtime" });
+  if (rejected) return rejected;
 
   const body = await c.req.json<UpdateSessionInfoInput>().catch(() => null);
   if (!body) return c.json({ message: "invalid body" }, 400);
@@ -271,6 +306,8 @@ router.post("/:spaceId/sessions/:sessionId/messages", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session || session.spaceId !== spaceId) return c.json({ message: "session not found" }, 404);
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, { spaceId, operation: "isolated_worker_runtime" });
+  if (rejected) return rejected;
 
   const body = await c
     .req.json<{
@@ -313,6 +350,8 @@ router.post("/:spaceId/sessions/:sessionId/turns/:turnId/interrupt", async (c) =
 
   const session = await getSpaceSessionById(sessionId);
   if (!session || session.spaceId !== spaceId) return c.json({ message: "session not found" }, 404);
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, { spaceId, operation: "isolated_worker_revoke" });
+  if (rejected) return rejected;
 
   const body = await c.req.json<{ continuedByTurnId?: string | null; interruptedByTurnId?: string | null }>().catch(() => null);
   const continuedByTurnId = body?.continuedByTurnId?.trim() || body?.interruptedByTurnId?.trim();
@@ -335,6 +374,8 @@ router.post("/:spaceId/sessions/:sessionId/turns/:turnId/abort", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session || session.spaceId !== spaceId) return c.json({ message: "session not found" }, 404);
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, { spaceId, operation: "isolated_worker_revoke" });
+  if (rejected) return rejected;
 
   const body = await c.req.json<{ actorUserId?: string | null }>().catch(() => null);
   const turn = await abortSessionTurn({
@@ -359,10 +400,12 @@ router.post("/:spaceId/sessions/:sessionId/turns/:turnId/fail", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session || session.spaceId !== spaceId) return c.json({ message: "session not found" }, 404);
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, { spaceId, operation: "isolated_worker_revoke" });
+  if (rejected) return rejected;
 
   const body = await c.req.json<{ errorMessage?: string | null }>().catch(() => null);
   const errorMessage = body?.errorMessage?.trim() || "Agent turn failed.";
-  const turn = await failSessionTurn({ sessionId, turnId, errorMessage });
+  const turn = await failSessionTurn({ spaceId, sessionId, turnId, errorMessage });
   if (turn) await dispatchTurnFinalized({ spaceId, sessionId, turn }).catch((error) => logger.warn("[SessionTurn] failed to dispatch failed turn", error));
   return c.json({ ok: true, turn });
 });
@@ -388,7 +431,10 @@ router.post("/:spaceId/sessions/:sessionId/prompt", async (c) => {
       source?: string | null;
       model?: string | null;
       provider?: string | null;
-      accessMode?: PromptAccessMode | null;
+      accessMode?: AgentPromptAccessMode | null;
+      isolatedWorkerPolicy?: unknown;
+      dispatchTaskRunId?: string | null;
+      inputsMaterializedAt?: string | null;
       env?: unknown;
       context?: SubmitSessionPromptContext | null;
     }>()
@@ -399,11 +445,163 @@ router.post("/:spaceId/sessions/:sessionId/prompt", async (c) => {
   const userId = body.userId?.trim();
   if (!userId) return c.json({ message: "userId is required" }, 400);
   const accessMode = body.accessMode ?? "full_access";
-  if (accessMode !== "read_only" && accessMode !== "full_access") {
-    return c.json({ message: "accessMode must be one of: read_only, full_access" }, 400);
+  if (accessMode !== "read_only" && accessMode !== "full_access" && accessMode !== "isolated_worker") {
+    return c.json({ message: "accessMode must be one of: read_only, full_access, isolated_worker" }, 400);
   }
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, {
+    spaceId,
+    operation: accessMode === "isolated_worker" ? "isolated_worker_dispatch" : "generic_prompt",
+  });
+  if (rejected) return rejected;
   const promptPermission = accessMode === "read_only" ? "session.prompt.readonly" : "session.prompt.fullaccess";
-  const workSession = body.authToken ? verifyWorkSessionToken(body.authToken) : null;
+  let workSession = body.authToken ? verifyWorkSessionToken(body.authToken) : null;
+  let isolatedWorkerPolicy: IsolatedWorkerPolicyInput | null = null;
+  let isolatedWorkerDispatch: Record<string, unknown> | null = null;
+  let isolatedWorkerDispatchTaskRunId: string | null = null;
+  let isolatedWorkerInputManifestSha256: string | null = null;
+  if (accessMode === "isolated_worker") {
+    try {
+      isolatedWorkerPolicy = parseIsolatedWorkerPolicyInput(body.isolatedWorkerPolicy, spaceId);
+    } catch (error) {
+      return c.json({ message: error instanceof Error ? error.message : String(error) }, 400);
+    }
+    const authoritySpace = await getSpaceById(isolatedWorkerPolicy.authoritySpaceId);
+    if (!authoritySpace || authoritySpace.userUuid !== userId) {
+      return c.json({ message: "isolated worker authority space not found" }, 404);
+    }
+    const dispatchTaskRunId = body.dispatchTaskRunId?.trim();
+    if (!dispatchTaskRunId || !requireValidId(dispatchTaskRunId)) {
+      return c.json({ message: "dispatchTaskRunId is required for isolated_worker" }, 400);
+    }
+    const [dispatchTask] = await db.select().from(taskRuns).where(eq(taskRuns.id, dispatchTaskRunId)).limit(1);
+    const dispatchData = dispatchTask?.payload?.data;
+    const dispatchInputBundle = dispatchData?.inputBundle && typeof dispatchData.inputBundle === "object" && !Array.isArray(dispatchData.inputBundle)
+      ? dispatchData.inputBundle as Record<string, unknown>
+      : null;
+    let verifiedInputManifestSha256 = "";
+    let verifiedPolicySha256 = "";
+    try {
+      verifiedInputManifestSha256 = computeIsolatedWorkerInputManifestSha256(dispatchData?.inputBundle as IsolatedWorkerInputBundle);
+      verifiedPolicySha256 = computeIsolatedWorkerPolicySha256({
+        taskRunId: dispatchTaskRunId,
+        authoritySpaceId: isolatedWorkerPolicy.authoritySpaceId,
+        disposableSpaceId: spaceId,
+        sessionId,
+        clientMessageId: body.clientMessageId ?? "",
+        content: body.content,
+        source: body.source ?? "",
+        model: body.model ?? null,
+        provider: body.provider ?? null,
+        ...(typeof dispatchData?.repairOfDisposableSpaceId === "string"
+          ? { repairOfDisposableSpaceId: dispatchData.repairOfDisposableSpaceId }
+          : {}),
+        inputManifestSha256: verifiedInputManifestSha256,
+      });
+    } catch {
+      return c.json({ message: "isolated worker dispatch input manifest is invalid" }, 409);
+    }
+    const inputsMaterializedAt = body.inputsMaterializedAt?.trim() ?? "";
+    if (!inputsMaterializedAt || !Number.isFinite(Date.parse(inputsMaterializedAt))) {
+      return c.json({ message: "inputsMaterializedAt is required for isolated_worker" }, 400);
+    }
+    if (
+      dispatchTask?.taskType !== "isolated_worker_dispatch"
+      || dispatchTask.status !== "running"
+      || dispatchTask.spaceId !== isolatedWorkerPolicy.authoritySpaceId
+      || dispatchTask.sessionId !== sessionId
+      || dispatchTask.userUuid !== userId
+      || dispatchData?.authoritySpaceId !== isolatedWorkerPolicy.authoritySpaceId
+      || dispatchData?.disposableSpaceId !== spaceId
+      || dispatchData?.sessionId !== sessionId
+      || dispatchData?.clientMessageId !== body.clientMessageId
+      || JSON.stringify(dispatchData?.content) !== JSON.stringify(body.content)
+      || dispatchData?.source !== body.source
+      || (dispatchData?.model ?? null) !== (body.model ?? null)
+      || (dispatchData?.provider ?? null) !== (body.provider ?? null)
+      || dispatchData?.policySha256 !== isolatedWorkerPolicy.policySha256
+      || dispatchData?.inputManifestSha256 !== verifiedInputManifestSha256
+      || dispatchInputBundle?.inputManifestSha256 !== verifiedInputManifestSha256
+      || dispatchInputBundle.runtimeAuthorityReadAllowed !== false
+      || isolatedWorkerPolicy.policySha256 !== verifiedPolicySha256
+      || dispatchData?.creationPath !== "dedicated_disposable_space_without_standard_sandbox"
+      || dispatchData?.ordinarySandboxProvisioned !== false
+      || dispatchData?.terminatedSpaceReused !== false
+      || dispatchData?.credentialMode !== "engine_scoped_dispatch_authority"
+      || dispatchData?.engineInternalSecretIssued !== false
+      || dispatchData?.publicPromptUsed !== false
+      || dispatchData?.checkpointAdapter !== "trusted_production"
+    ) {
+      return c.json({ message: "isolated worker dispatch binding mismatch" }, 409);
+    }
+    workSession = verifyWorkSessionToken(createWorkSessionToken({
+      userUuid: userId,
+      workId: dispatchTaskRunId,
+      spaceId,
+      workScopes: ["session.prompt.fullaccess"],
+    }));
+    if (!workSession) throw new Error("failed to mint isolated worker prompt authority");
+    isolatedWorkerDispatch = {
+      taskRunId: dispatchTaskRunId,
+      taskType: "isolated_worker_dispatch",
+      authoritySpaceId: isolatedWorkerPolicy.authoritySpaceId,
+      disposableSpaceId: spaceId,
+      creationPath: "dedicated_disposable_space_without_standard_sandbox",
+      ordinarySandboxProvisioned: false,
+      terminatedSpaceReused: false,
+      credentialMode: "engine_scoped_dispatch_authority",
+      engineInternalSecretIssued: false,
+      publicPromptUsed: false,
+      checkpointAdapter: "trusted_production",
+      authorityCheckpointId: dispatchInputBundle.authorityCheckpointId,
+      authorityCheckpointCommit: dispatchInputBundle.authorityCheckpointCommit,
+      authorityTreeSha256: dispatchInputBundle.authorityTreeSha256,
+      inputManifestSha256: verifiedInputManifestSha256,
+      inputBundle: dispatchData?.inputBundle,
+      inputsMaterializedAt,
+      authorityExecutionTokenIssued: false,
+      runtimeAuthorityReadAllowed: false,
+    };
+    isolatedWorkerDispatchTaskRunId = dispatchTaskRunId;
+    isolatedWorkerInputManifestSha256 = verifiedInputManifestSha256;
+    const sandbox = await getSpaceSandboxBySpaceId(spaceId);
+    const sandboxMeta = sandbox?.meta && typeof sandbox.meta === "object" && !Array.isArray(sandbox.meta)
+      ? sandbox.meta as Record<string, unknown>
+      : null;
+    const allocation = sandboxMeta?.isolatedWorker && typeof sandboxMeta.isolatedWorker === "object" && !Array.isArray(sandboxMeta.isolatedWorker)
+      ? sandboxMeta.isolatedWorker as Record<string, unknown>
+      : null;
+    if (
+      sandbox?.status !== "allocated"
+      || sandbox.podName !== null
+      || allocation?.state !== "allocated"
+      || allocation.authoritySpaceId !== isolatedWorkerPolicy.authoritySpaceId
+      || allocation.disposableSpaceId !== spaceId
+      || allocation.dispatchTaskRunId !== dispatchTaskRunId
+      || allocation.policySha256 !== isolatedWorkerPolicy.policySha256
+      || allocation.creationPath !== "dedicated_disposable_space_without_standard_sandbox"
+      || allocation.ordinarySandboxProvisioned !== false
+      || allocation.terminatedSpaceReused !== false
+      || allocation.credentialMode !== "engine_scoped_dispatch_authority"
+      || allocation.engineInternalSecretIssued !== false
+      || allocation.publicPromptUsed !== false
+      || allocation.authorityExecutionTokenIssued !== false
+      || allocation.runtimeAuthorityReadAllowed !== false
+      || allocation.authorityCheckpointId !== dispatchInputBundle?.authorityCheckpointId
+      || allocation.authorityCheckpointCommit !== dispatchInputBundle?.authorityCheckpointCommit
+      || allocation.authorityTreeSha256 !== dispatchInputBundle?.authorityTreeSha256
+      || allocation.inputManifestSha256 !== verifiedInputManifestSha256
+      || allocation.inputCount !== (Array.isArray(dispatchInputBundle?.items) ? dispatchInputBundle.items.length : -1)
+      || typeof allocation.preparedWorkspace !== "string"
+      || !allocation.preparedWorkspace.endsWith(`/.isolated-worker-staging/${dispatchTaskRunId}`)
+      || allocation.inputsMaterializedAt !== inputsMaterializedAt
+      || canonicalIsolatedWorkerJson(allocation.inputBundle) !== canonicalIsolatedWorkerJson(dispatchData?.inputBundle)
+      || allocation.resumable !== false
+    ) {
+      return c.json({ message: "disposable worker space is not allocated or has already been used" }, 409);
+    }
+  } else if (body.isolatedWorkerPolicy !== undefined || body.dispatchTaskRunId !== undefined) {
+    return c.json({ message: "isolated worker fields are only allowed for isolated_worker" }, 400);
+  }
   const permissionSubject = workSession && workSession.userUuid === userId
     ? ({ uuid: userId, workSession } as { uuid: string; workSession: typeof workSession })
     : { uuid: userId };
@@ -423,7 +621,7 @@ router.post("/:spaceId/sessions/:sessionId/prompt", async (c) => {
   }
 
   try {
-    const result = await submitSessionPrompt({
+    const promptInput = {
       spaceId,
       sessionId,
       userId,
@@ -435,13 +633,241 @@ router.post("/:spaceId/sessions/:sessionId/prompt", async (c) => {
       accessMode,
       env: promptEnv,
       context: mergePromptContextAuth(body.context ?? null, promptAuth),
-    });
+    };
+    const result = isolatedWorkerPolicy
+      ? await submitIsolatedWorkerPrompt({
+          policy: isolatedWorkerPolicy,
+          sessionId,
+          turnMeta: {
+            isolatedWorkerDispatch,
+            isolatedWorkerInputBundle: isolatedWorkerDispatch?.inputBundle,
+          },
+          prompt: { ...promptInput, accessMode: "isolated_worker" },
+          submitPrompt: submitSessionPrompt,
+          createPod: ({ sessionId: workerSessionId, turnId, ...policy }) => isolatedWorkerPodLifecycle.create({
+            authoritySpaceId: policy.authoritySpaceId,
+            disposableSpaceId: policy.disposableSpaceId,
+            sessionId: workerSessionId,
+            turnId,
+            writableRoot: policy.writableRoot,
+            policySha256: policy.policySha256,
+            image: config.sandboxImage,
+            spaceStoragePvc: config.spaceStoragePvc,
+            spaceStorageSubpath: config.spaceStorageSubpath,
+          }),
+          onPodCreatedBeforeEnqueue: async ({ handle, turnId }) => {
+            if (!isolatedWorkerDispatchTaskRunId) throw new Error("isolated worker dispatch task binding is missing");
+            if (!isolatedWorkerInputManifestSha256) throw new Error("isolated worker input manifest binding is missing");
+            if (!isolatedWorkerDispatch) throw new Error("isolated worker dispatch metadata is missing");
+            const inputsMaterializedAt = isolatedWorkerDispatch.inputsMaterializedAt;
+            if (typeof inputsMaterializedAt !== "string" || !Number.isFinite(Date.parse(inputsMaterializedAt))) {
+              throw new Error("isolated worker input materialization timestamp binding is missing");
+            }
+            const podCreatedAt = new Date(handle.podCreatedAt);
+            if (!Number.isFinite(podCreatedAt.getTime())) throw new Error("isolated worker Pod creation timestamp is invalid");
+            if (podCreatedAt.getTime() <= Date.parse(inputsMaterializedAt)) {
+              throw new Error("isolated worker pod must be created after inputs are materialized");
+            }
+            const completedDispatchMeta = {
+              ...isolatedWorkerDispatch,
+              podCreatedAt: podCreatedAt.toISOString(),
+            };
+            const [boundTurn] = await db.update(sessionTurns).set({
+              meta: sql`coalesce(${sessionTurns.meta}, '{}'::jsonb) || ${JSON.stringify({
+                isolatedWorkerDispatch: completedDispatchMeta,
+                isolatedWorkerInputBundle: isolatedWorkerDispatch.inputBundle,
+              })}::jsonb`,
+              updatedAt: podCreatedAt,
+            }).where(and(eq(sessionTurns.id, turnId), eq(sessionTurns.sessionId, sessionId), eq(sessionTurns.status, "queued"))).returning({ id: sessionTurns.id });
+            if (!boundTurn) throw new Error("isolated worker dispatch Turn binding CAS failed");
+            return { podCreatedAt: podCreatedAt.toISOString() };
+          },
+          revokePod: async (handle) => {
+            const scheduled = await scheduleIsolatedWorkerTermination({
+              spaceId: handle.isolatedWorkerPolicy.disposableSpaceId,
+              sessionId: handle.sessionId,
+              turnId: handle.turnId,
+              terminalStatus: "failed",
+            });
+            if (scheduled.alreadyTerminated) return scheduled.receipt as never;
+            const terminated = await waitForIsolatedWorkerTermination({
+              spaceId: handle.isolatedWorkerPolicy.disposableSpaceId,
+              sessionId: handle.sessionId,
+              turnId: handle.turnId,
+              revokeTaskRunId: scheduled.revokeTaskRunId,
+            });
+            return terminated.receipt as never;
+          },
+        })
+      : await submitSessionPrompt(promptInput);
     return c.json({ ok: true, ...result });
   } catch (error) {
     if (error instanceof SandboxNotReadyError) return c.json({ message: "sandbox is not ready" }, 503);
     if (error instanceof BillingAccessBlockedError) return c.json(serializeBillingBlocked(error), 402);
     throw error as Error;
   }
+});
+
+// POST /internal/spaces/:spaceId/sessions/:sessionId/turns/:turnId/isolated-worker/termination
+router.post("/:spaceId/sessions/:sessionId/turns/:turnId/isolated-worker/termination", async (c) => {
+  const forbidden = ensureInternalRequest(c);
+  if (forbidden) return forbidden;
+  const spaceId = c.req.param("spaceId");
+  const sessionId = c.req.param("sessionId");
+  const turnId = c.req.param("turnId");
+  if (!requireValidId(spaceId) || !requireValidId(sessionId) || !requireValidId(turnId)) {
+    return c.json({ message: "isolated worker not found" }, 404);
+  }
+  const body = await c.req.json<{ terminalStatus?: IsolatedWorkerTerminalStatus }>().catch(() => null);
+  if (!body || !["completed", "failed", "interrupted", "cancelled"].includes(body.terminalStatus ?? "")) {
+    return c.json({ message: "terminalStatus is invalid" }, 400);
+  }
+  try {
+    const scheduled = await scheduleIsolatedWorkerTermination({
+      spaceId,
+      sessionId,
+      turnId,
+      terminalStatus: body.terminalStatus as IsolatedWorkerTerminalStatus,
+    });
+    return c.json({ ok: true, ...scheduled }, scheduled.alreadyTerminated ? 200 : 202);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("not found")) return c.json({ message }, 404);
+    if (message.includes("binding mismatch") || message.includes("became terminal")) return c.json({ message }, 409);
+    throw error;
+  }
+});
+
+router.get("/:spaceId/sessions/:sessionId/turns/:turnId/isolated-worker/termination", async (c) => {
+  const forbidden = ensureInternalRequest(c);
+  if (forbidden) return forbidden;
+  const spaceId = c.req.param("spaceId");
+  const sessionId = c.req.param("sessionId");
+  const turnId = c.req.param("turnId");
+  const revokeTaskRunId = c.req.query("revokeTaskRunId") ?? "";
+  if (!requireValidId(spaceId) || !requireValidId(sessionId) || !requireValidId(turnId) || !requireValidId(revokeTaskRunId)) {
+    return c.json({ message: "isolated worker termination not found" }, 404);
+  }
+  const state = await readIsolatedWorkerTermination({ spaceId, sessionId, turnId, revokeTaskRunId });
+  return c.json({ ok: true, ...state }, state.state === "terminated" ? 200 : 202);
+});
+
+// Worker-only execution endpoint for an already-running automatic revoke TaskRun.
+router.post("/:spaceId/sessions/:sessionId/turns/:turnId/isolated-worker/revoke", async (c) => {
+  const forbidden = ensureInternalRequest(c);
+  if (forbidden) return forbidden;
+
+  const spaceId = c.req.param("spaceId");
+  const sessionId = c.req.param("sessionId");
+  const turnId = c.req.param("turnId");
+  if (!requireValidId(spaceId) || !requireValidId(sessionId) || !requireValidId(turnId)) {
+    return c.json({ message: "isolated worker not found" }, 404);
+  }
+  const session = await getSpaceSessionById(sessionId);
+  if (!session || session.spaceId !== spaceId) return c.json({ message: "session not found" }, 404);
+  const turn = await getSessionTurnById(sessionId, turnId);
+  if (!turn) return c.json({ message: "turn not found" }, 404);
+  const body = await c.req.json<{
+    authoritySpaceId?: string;
+    disposableSpaceId?: string;
+    podUid?: string;
+    revokeTaskRunId?: string;
+    terminalStatus?: IsolatedWorkerTerminalStatus;
+    automaticTrigger?: string;
+    manualEndpointInvoked?: boolean;
+  }>().catch(() => null);
+  if (!body?.authoritySpaceId?.trim() || !body.disposableSpaceId?.trim() || !body.podUid?.trim()) {
+    return c.json({ message: "authoritySpaceId, disposableSpaceId, and podUid are required" }, 400);
+  }
+  const meta = turn.meta && typeof turn.meta === "object" && !Array.isArray(turn.meta)
+    ? turn.meta as Record<string, unknown>
+    : null;
+  const handle = meta?.isolatedWorker as IsolatedWorkerPodHandle | undefined;
+  const dispatch = meta?.isolatedWorkerDispatch && typeof meta.isolatedWorkerDispatch === "object" && !Array.isArray(meta.isolatedWorkerDispatch)
+    ? meta.isolatedWorkerDispatch as Record<string, unknown>
+    : null;
+  const dispatchTaskRunId = typeof dispatch?.taskRunId === "string" ? dispatch.taskRunId : null;
+  const terminationState = meta?.isolatedWorkerTerminationState && typeof meta.isolatedWorkerTerminationState === "object" && !Array.isArray(meta.isolatedWorkerTerminationState)
+    ? meta.isolatedWorkerTerminationState as Record<string, unknown>
+    : null;
+  const existingReceipt = meta?.isolatedWorkerTermination && typeof meta.isolatedWorkerTermination === "object" && !Array.isArray(meta.isolatedWorkerTermination)
+    ? meta.isolatedWorkerTermination as Record<string, unknown>
+    : null;
+  if (
+    handle
+    && terminationState?.state === "terminated"
+    && terminationState.revokeTaskRunId === body.revokeTaskRunId
+    && handle.isolatedWorkerPolicy?.podUid === body.podUid
+    && existingReceipt
+    && existingReceipt?.revokeTaskRunId === body.revokeTaskRunId
+    && existingReceipt.podUid === body.podUid
+    && existingReceipt.automaticTrigger === "turn_terminal_event"
+    && existingReceipt.manualEndpointInvoked === false
+  ) {
+    return c.json({ ok: true, receipt: existingReceipt });
+  }
+  const [revokeTask] = body.revokeTaskRunId
+    ? await db.select().from(taskRuns).where(eq(taskRuns.id, body.revokeTaskRunId)).limit(1)
+    : [];
+  const revokeData = revokeTask?.payload?.data && typeof revokeTask.payload.data === "object" && !Array.isArray(revokeTask.payload.data)
+    ? revokeTask.payload.data as Record<string, unknown>
+    : null;
+  if (
+    !handle
+    || !dispatchTaskRunId
+    || !revokeTask
+    || revokeTask.taskType !== "isolated_worker_revoke"
+    || revokeTask.status !== "running"
+    || revokeTask.spaceId !== spaceId
+    || revokeTask.sessionId !== sessionId
+    || revokeTask.turnId !== turnId
+    || terminationState?.state !== "stopping"
+    || terminationState.revokeTaskRunId !== body.revokeTaskRunId
+    || terminationState.requestedTerminalStatus !== body.terminalStatus
+    || revokeData?.trigger !== "turn_terminal_event"
+    || revokeData.terminalStatus !== body.terminalStatus
+    || revokeData.authoritySpaceId !== body.authoritySpaceId
+    || revokeData.disposableSpaceId !== body.disposableSpaceId
+    || revokeData.sessionId !== sessionId
+    || revokeData.turnId !== turnId
+    || revokeData.podUid !== body.podUid
+    || body.automaticTrigger !== "turn_terminal_event"
+    || body.manualEndpointInvoked !== false
+    || handle.sessionId !== sessionId
+    || handle.turnId !== turnId
+    || handle.isolatedWorkerPolicy?.disposableSpaceId !== spaceId
+    || handle.isolatedWorkerPolicy.authoritySpaceId !== body.authoritySpaceId
+    || handle.isolatedWorkerPolicy.disposableSpaceId !== body.disposableSpaceId
+    || handle.isolatedWorkerPolicy.podUid !== body.podUid
+  ) {
+    return c.json({ message: "isolated worker binding mismatch" }, 409);
+  }
+  const receipt = await isolatedWorkerPodLifecycle.revoke(handle, {
+    revokeTaskRunId: body.revokeTaskRunId as string,
+    automaticTrigger: "turn_terminal_event",
+    manualEndpointInvoked: false,
+  });
+  const terminatedHandle = { ...handle, status: "terminated", termination: receipt };
+  await db.transaction(async (tx) => {
+    const [updatedTurn] = await tx.update(sessionTurns).set({
+      meta: sql`coalesce(${sessionTurns.meta}, '{}'::jsonb) || ${JSON.stringify({
+      isolatedWorker: terminatedHandle,
+      isolatedWorkerTermination: receipt,
+      isolatedWorkerTerminationState: {
+        ...terminationState,
+        state: "terminated",
+        terminatedAt: receipt.terminatedAt,
+      },
+      })}::jsonb`,
+      updatedAt: new Date(),
+    }).where(and(
+      eq(sessionTurns.id, turnId),
+      eq(sessionTurns.sessionId, sessionId),
+      inArray(sessionTurns.status, ["queued", "running", "abort_requested"]),
+    )).returning({ id: sessionTurns.id });
+    if (!updatedTurn) throw new Error("failed to persist isolated worker termination receipt");
+  });
+  return c.json({ ok: true, receipt });
 });
 
 export default router;

--- a/apps/api/src/routes/session-access.route.ts
+++ b/apps/api/src/routes/session-access.route.ts
@@ -5,6 +5,7 @@ import { accessPolicies, spaceSessions } from "@cohub/db";
 import { requireValidId, useAuth, authzDenied } from "../lib/middleware.js";
 import { hasPermission } from "../permissions.js";
 import type { AccessPolicyRole } from "@cohub/db";
+import { rejectIsolatedWorkerDisposableRouteMutation } from "../isolated-worker-disposable-guard.js";
 
 const router = new Hono();
 const SIGNED_IN_VALID_ROLES = new Set<AccessPolicyRole>(["builder", "guest", null]);
@@ -41,6 +42,11 @@ router.patch("/:id/access", async (c) => {
   const [session] = await db.select({ spaceId: spaceSessions.spaceId }).from(spaceSessions).where(eq(spaceSessions.id, sessionId)).limit(1);
   if (!session) return c.json({ message: "session not found" }, 404);
   if (!(await hasPermission(user, "member.manage", { spaceId: session.spaceId, sessionId }))) return authzDenied(c);
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, {
+    spaceId: session.spaceId,
+    operation: "generic_mutation",
+  });
+  if (rejected) return rejected;
 
   const body = await c.req.json<{ signed_in_user?: AccessPolicyRole; anonymous_user?: AccessPolicyRole }>().catch(() => null);
   if (!body || (body.signed_in_user === undefined && body.anonymous_user === undefined)) {
@@ -91,6 +97,11 @@ router.delete("/:id/access", async (c) => {
   const [session] = await db.select({ spaceId: spaceSessions.spaceId }).from(spaceSessions).where(eq(spaceSessions.id, sessionId)).limit(1);
   if (!session) return c.json({ message: "session not found" }, 404);
   if (!(await hasPermission(user, "member.manage", { spaceId: session.spaceId, sessionId }))) return authzDenied(c);
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, {
+    spaceId: session.spaceId,
+    operation: "generic_mutation",
+  });
+  if (rejected) return rejected;
 
   await db.delete(accessPolicies).where(and(eq(accessPolicies.resourceType, "session"), eq(accessPolicies.resourceId, sessionId)));
   return c.json({ ok: true });

--- a/apps/api/src/routes/sessions.route.ts
+++ b/apps/api/src/routes/sessions.route.ts
@@ -19,10 +19,31 @@ import { clearSessionStreamSnapshot, getSessionStreamSnapshot } from "../session
 import { createSessionFork, listSessionForksForSessions } from "../session-forks.js";
 import { dispatchLabelAssignmentsUpdated } from "../realtime-events.js";
 import { buildSessionTurnResponse } from "../session-turn-response.js";
+import { rejectIsolatedWorkerDisposableRouteMutation } from "../isolated-worker-disposable-guard.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
 const router = new Hono();
+
+router.use("*", async (c, next) => {
+  if (["GET", "HEAD", "OPTIONS"].includes(c.req.method)) return next();
+  const match = c.req.path.match(/\/api\/sessions\/([^/]+)(\/.*)?$/);
+  const sessionId = match?.[1] ?? "";
+  if (!requireValidId(sessionId)) return next();
+  const suffix = match?.[2] ?? "";
+  if (/^\/turns\/[^/]+\/signed-urls$/.test(suffix)) return next();
+
+  const user = getOptionalAuth(c);
+  if (!user) return next();
+  const session = await getSpaceSessionById(sessionId);
+  if (!session || !(await hasPermission(user, "session.view", { spaceId: session.spaceId, sessionId }))) {
+    return next();
+  }
+  const operation = suffix === "/abort" ? "isolated_worker_revoke" as const : "generic_mutation" as const;
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, { spaceId: session.spaceId, operation });
+  if (rejected) return rejected;
+  return next();
+});
 
 router.post("/:id/turns/:turnId/fork", async (c) => {
   const user = useAuth(c);

--- a/apps/api/src/routes/spaces/index.ts
+++ b/apps/api/src/routes/spaces/index.ts
@@ -12,14 +12,46 @@ import presenceRouter from "./presence.route.js";
 import previewSessionRouter from "./preview-session.route.js";
 import commerceRouter from "./commerce.route.js";
 import completionsRouter from "./completions.route.js";
+import isolatedWorkersRouter from "./isolated-workers.route.js";
+import { getOptionalAuth, requireValidId } from "../../lib/middleware.js";
+import { hasPermission } from "../../permissions.js";
+import {
+  rejectIsolatedWorkerDisposableRouteMutation,
+  type IsolatedWorkerDisposableOperation,
+} from "../../isolated-worker-disposable-guard.js";
 
 const router = new Hono();
+
+const READ_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+router.use("*", async (c, next) => {
+  if (READ_METHODS.has(c.req.method)) return next();
+  const match = c.req.path.match(/\/api\/spaces\/([^/]+)(\/.*)?$/);
+  const spaceId = match?.[1] ?? "";
+  if (!requireValidId(spaceId)) return next();
+
+  // Preserve each route's own authentication and authorization response. The
+  // disposable classification must not become a space-existence oracle.
+  const user = getOptionalAuth(c);
+  if (!user || !(await hasPermission(user, "space.view", { spaceId }))) return next();
+
+  const suffix = match?.[2] ?? "";
+  let operation: IsolatedWorkerDisposableOperation = "generic_mutation";
+  if (suffix === "/isolated-workers/dispatch") operation = "isolated_worker_dispatch";
+  else if (suffix === "/isolated-workers/reuse-probe") operation = "isolated_worker_reuse_probe";
+  else if (/\/sessions\/[^/]+\/turns\/[^/]+\/cancel$/.test(suffix)) operation = "isolated_worker_revoke";
+
+  const rejected = await rejectIsolatedWorkerDisposableRouteMutation(c, { spaceId, operation });
+  if (rejected) return rejected;
+  return next();
+});
 
 router.route("/", spacesRouter);
 // In production, /:id/fs/* is routed to fs-api by the gateway.
 // This remains a local/non-split fallback.
 router.route("/:id/fs", fsRouter);
 router.route("/:id/completions", completionsRouter);
+router.route("/:id/isolated-workers", isolatedWorkersRouter);
 router.route("/:id/members", membersRouter);
 router.route("/:id/access", accessRouter);
 router.route("/:id/usage", usageRouter);

--- a/apps/api/src/routes/spaces/isolated-workers.route.ts
+++ b/apps/api/src/routes/spaces/isolated-workers.route.ts
@@ -1,0 +1,163 @@
+import { Hono } from "hono";
+import { and, eq } from "drizzle-orm";
+import {
+  checkpoints,
+  spaceSandboxes,
+  spaceSessions,
+  spaces,
+  taskRuns,
+} from "@cohub/db";
+import type {
+  IsolatedWorkerDispatchInput,
+  IsolatedWorkerReuseProbeInput,
+} from "@cohub/protocol/isolated-worker";
+import { db } from "../../db/index.js";
+import { authzDenied, requireValidId, useAuth } from "../../lib/middleware.js";
+import { hasPermission } from "../../permissions.js";
+import { taskQueue } from "../../tasks.js";
+import {
+  createIsolatedWorkerDispatch,
+  createIsolatedWorkerReuseProbe,
+  parseIsolatedWorkerDispatchInput,
+  type IsolatedWorkerDispatchStore,
+} from "../../isolated-worker-dispatch.js";
+
+const router = new Hono();
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+const store: IsolatedWorkerDispatchStore = {
+  async validateInputManifest(input) {
+    const [checkpoint] = await db.select().from(checkpoints).where(and(
+      eq(checkpoints.id, input.inputBundle.authorityCheckpointId),
+      eq(checkpoints.spaceId, input.authoritySpaceId),
+    )).limit(1);
+    if (!checkpoint || checkpoint.commitHash !== input.inputBundle.authorityCheckpointCommit) {
+      throw new Error("input manifest authority checkpoint binding mismatch");
+    }
+    const meta = isRecord(checkpoint.meta) ? checkpoint.meta : null;
+    const gitTree = meta && isRecord(meta.gitTree) ? meta.gitTree : null;
+    if (
+      gitTree?.sha256 !== input.inputBundle.authorityTreeSha256
+    ) {
+      throw new Error("input manifest authority checkpoint tree binding mismatch");
+    }
+  },
+  async reserveTask(input) {
+    await db.insert(taskRuns).values({
+      id: input.taskRunId,
+      jobId: input.taskRunId,
+      taskType: input.payload.type,
+      spaceId: input.payload.spaceId ?? null,
+      sessionId: input.payload.sessionId ?? null,
+      userUuid: input.payload.userId ?? null,
+      status: "pending",
+      payload: input.payload,
+    });
+  },
+
+  async enqueue(input) {
+    await taskQueue.add(input.payload.type, input.payload, { jobId: input.taskRunId, attempts: 1 });
+  },
+
+  async markEnqueueFailed(input) {
+    const message = input.error instanceof Error ? input.error.message : String(input.error);
+    await db.update(taskRuns).set({
+        status: "failed",
+        result: { disposableSpaceId: input.disposableSpaceId, rejected: true, reason: "dispatch_enqueue_failed", podCreated: false, disposableSpaceCreated: false, authorityExecutionTokenIssued: false },
+        errorMessage: message,
+        finishedAt: new Date(),
+        updatedAt: new Date(),
+      }).where(eq(taskRuns.id, input.taskRunId));
+  },
+
+  async assertReusableProbeTarget(input) {
+    const [row] = await db
+      .select({ space: spaces, sandbox: spaceSandboxes })
+      .from(spaces)
+      .leftJoin(spaceSandboxes, eq(spaceSandboxes.spaceId, spaces.id))
+      .where(and(eq(spaces.id, input.disposableSpaceId), eq(spaces.userUuid, input.userId)))
+      .limit(1);
+    const disposable = isRecord(row?.space.meta) && isRecord(row.space.meta.isolatedWorkerDisposable)
+      ? row.space.meta.isolatedWorkerDisposable
+      : null;
+    if (!row?.sandbox || !disposable || disposable.authoritySpaceId !== input.authoritySpaceId) {
+      throw new Error("disposable worker space not found for authority");
+    }
+    return { status: row.sandbox.status, authoritySpaceId: String(disposable.authoritySpaceId) };
+  },
+
+  async reserveReuseProbe(input) {
+    await db.insert(taskRuns).values({
+      id: input.taskRunId,
+      jobId: input.taskRunId,
+      taskType: input.payload.type,
+      spaceId: input.payload.spaceId ?? null,
+      sessionId: input.payload.sessionId ?? null,
+      userUuid: input.payload.userId ?? null,
+      status: "pending",
+      payload: input.payload,
+    });
+  },
+};
+
+router.post("/dispatch", async (c) => {
+  const user = useAuth(c);
+  if (user instanceof Response) return user;
+  const authoritySpaceId = c.req.param("id") ?? "";
+  if (!requireValidId(authoritySpaceId)) return c.json({ message: "space not found" }, 404);
+  if (!(await hasPermission(user, "session.prompt.fullaccess", { spaceId: authoritySpaceId }))) return authzDenied(c);
+  const [authority] = await db.select({ id: spaces.id }).from(spaces)
+    .where(and(eq(spaces.id, authoritySpaceId), eq(spaces.userUuid, user.uuid))).limit(1);
+  if (!authority) return c.json({ message: "space not found" }, 404);
+  const rawBody = await c.req.json<unknown>().catch(() => null);
+  let body: IsolatedWorkerDispatchInput;
+  try {
+    body = parseIsolatedWorkerDispatchInput(rawBody);
+  } catch (error) {
+    return c.json({ message: error instanceof Error ? error.message : String(error) }, 400);
+  }
+  if (body.repairOfDisposableSpaceId && !requireValidId(body.repairOfDisposableSpaceId)) {
+    return c.json({ message: "invalid repairOfDisposableSpaceId" }, 400);
+  }
+  try {
+    const result = await createIsolatedWorkerDispatch({ authoritySpaceId, userId: user.uuid, input: body, store });
+    return c.json(result, 202);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("repair target") || message.includes("disposable worker space not found")) {
+      return c.json({ message }, 409);
+    }
+    throw error;
+  }
+});
+
+router.post("/reuse-probe", async (c) => {
+  const user = useAuth(c);
+  if (user instanceof Response) return user;
+  const authoritySpaceId = c.req.param("id") ?? "";
+  if (!requireValidId(authoritySpaceId)) return c.json({ message: "space not found" }, 404);
+  if (!(await hasPermission(user, "session.prompt.fullaccess", { spaceId: authoritySpaceId }))) return authzDenied(c);
+  const body = await c.req.json<IsolatedWorkerReuseProbeInput>().catch(() => null);
+  if (!body || !requireValidId(body.disposableSpaceId) || !requireValidId(body.sessionId)) {
+    return c.json({ message: "valid disposableSpaceId and sessionId are required" }, 400);
+  }
+  const [session] = await db.select({ id: spaceSessions.id }).from(spaceSessions)
+    .where(and(eq(spaceSessions.id, body.sessionId), eq(spaceSessions.spaceId, authoritySpaceId))).limit(1);
+  if (!session) return c.json({ message: "session not found" }, 404);
+  try {
+    const result = await createIsolatedWorkerReuseProbe({
+      authoritySpaceId,
+      disposableSpaceId: body.disposableSpaceId,
+      sessionId: body.sessionId,
+      userId: user.uuid,
+      store,
+    });
+    return c.json(result, 202);
+  } catch (error) {
+    return c.json({ message: error instanceof Error ? error.message : String(error) }, 409);
+  }
+});
+
+export default router;

--- a/apps/api/src/routes/spaces/spaces.route.ts
+++ b/apps/api/src/routes/spaces/spaces.route.ts
@@ -70,6 +70,10 @@ import { parseChannelConfigPatch, mergeChannelConfig, validateChannelModelConfig
 import { redisCommandClient } from "../../redis.js";
 import { featureGateResponse } from "../../lib/feature-gate.js";
 import { billingBlockedResponse } from "../../lib/billing-blocked.js";
+import {
+  scheduleIsolatedWorkerTermination,
+  waitForIsolatedWorkerTermination,
+} from "../../isolated-worker-termination.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -225,6 +229,27 @@ async function cancelQueuedTurn(input: {
   turnId: string;
   actorUserId: string;
 }): Promise<NonNullable<Awaited<ReturnType<typeof getSessionTurnById>>>> {
+  const [candidate] = await db.select({ status: sessionTurns.status, meta: sessionTurns.meta })
+    .from(sessionTurns)
+    .where(and(eq(sessionTurns.id, input.turnId), eq(sessionTurns.sessionId, input.sessionId)))
+    .limit(1);
+  const candidateMeta = readMetaRecord(candidate?.meta as Record<string, unknown> | null);
+  if (candidate?.status === "queued" && candidateMeta.isolatedWorker) {
+    const scheduled = await scheduleIsolatedWorkerTermination({
+      spaceId: input.spaceId,
+      sessionId: input.sessionId,
+      turnId: input.turnId,
+      terminalStatus: "cancelled",
+    });
+    if (!scheduled.alreadyTerminated) {
+      await waitForIsolatedWorkerTermination({
+        spaceId: input.spaceId,
+        sessionId: input.sessionId,
+        turnId: input.turnId,
+        revokeTaskRunId: scheduled.revokeTaskRunId,
+      });
+    }
+  }
   const now = new Date();
   const [updated] = await db.transaction(async (tx) => {
     const [session] = await tx.select({ id: spaceSessions.id, spaceId: spaceSessions.spaceId }).from(spaceSessions).where(eq(spaceSessions.id, input.sessionId)).for("update").limit(1);
@@ -1380,7 +1405,16 @@ router.get("/:id/checkpoints/:checkpointId", async (c) => {
 
   if (!checkpoint) return c.json({ message: "checkpoint not found" }, 404);
 
-  return c.json({ checkpoint });
+  const checkpointMeta = checkpoint.meta && typeof checkpoint.meta === "object" && !Array.isArray(checkpoint.meta)
+    ? checkpoint.meta as Record<string, unknown>
+    : null;
+  const gitTree = checkpointMeta?.gitTree && typeof checkpointMeta.gitTree === "object" && !Array.isArray(checkpointMeta.gitTree)
+    ? checkpointMeta.gitTree as Record<string, unknown>
+    : null;
+  const treeSha256 = typeof gitTree?.sha256 === "string" && /^[a-f0-9]{64}$/.test(gitTree.sha256)
+    ? gitTree.sha256
+    : null;
+  return c.json({ checkpoint: { ...checkpoint, treeSha256 }, treeSha256 });
 });
 
 // In production, these checkpoints/fs routes are routed to fs-api by the gateway.

--- a/apps/api/src/session-prompts.ts
+++ b/apps/api/src/session-prompts.ts
@@ -1,5 +1,6 @@
 import type {
   ChannelPromptContext,
+  AgentPromptAccessMode,
   PromptAccessMode,
   PromptSource,
   PromptTemplateUsageMeta,
@@ -15,9 +16,11 @@ import type {
 } from "@cohub/core/sessions";
 import type { ContentBlock } from "@cohub/protocol/core";
 import { getSessionDomainServices } from "./session-services.js";
+import { assertIsolatedWorkerDisposableOperationAllowed } from "./isolated-worker-disposable-guard.js";
 
 export type {
   ChannelPromptContext,
+  AgentPromptAccessMode,
   PromptAccessMode,
   PromptSource,
   PromptTemplateUsageMeta,
@@ -41,7 +44,13 @@ export const expandPromptContent = async (input: {
 export const submitSessionPrompt = async (
   input: SubmitSessionPromptInput,
   hooks: SubmitSessionPromptHooks = {},
-): Promise<SubmitSessionPromptResult> => getSessionDomainServices().submitPrompt(input, {
-  ...hooks,
-  beforeEnqueue: hooks.beforeEnqueue,
-});
+): Promise<SubmitSessionPromptResult> => {
+  await assertIsolatedWorkerDisposableOperationAllowed(
+    input.spaceId,
+    input.accessMode === "isolated_worker" ? "isolated_worker_dispatch" : "generic_prompt",
+  );
+  return getSessionDomainServices().submitPrompt(input, {
+    ...hooks,
+    beforeEnqueue: hooks.beforeEnqueue,
+  });
+};

--- a/apps/api/src/session-turns.ts
+++ b/apps/api/src/session-turns.ts
@@ -19,6 +19,11 @@ import { ensureSessionTurnSegments, findSegmentForTurn } from "./session-forks.j
 import { fallbackPublicUserProfile, getProfilesByUuids } from "./user-profiles.js";
 import { buildTurnObjectPrefix, assertTurnObjectKeyForTurn, createTurnObjectCdnUrl, writeTurnObjectJson } from "./turn-object-storage.js";
 import { deriveMessagePreviewText } from "./session-content.js";
+import {
+  scheduleIsolatedWorkerTermination,
+  waitForIsolatedWorkerTermination,
+} from "./isolated-worker-termination.js";
+import type { IsolatedWorkerTerminalStatus } from "@cohub/protocol/isolated-worker";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -29,6 +34,24 @@ const toIso = (value: Date | string | null | undefined) => {
 
 const normalizeRecord = (value: unknown): Record<string, unknown> | null =>
   value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+
+const terminateIsolatedWorkerBeforeFinalStatus = async (input: {
+  spaceId: string;
+  sessionId: string;
+  turnId: string;
+  terminalStatus: IsolatedWorkerTerminalStatus;
+  meta: unknown;
+}) => {
+  if (!normalizeRecord(input.meta)?.isolatedWorker) return;
+  const scheduled = await scheduleIsolatedWorkerTermination(input);
+  if (scheduled.alreadyTerminated) return;
+  await waitForIsolatedWorkerTermination({
+    spaceId: input.spaceId,
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    revokeTaskRunId: scheduled.revokeTaskRunId,
+  });
+};
 
 const addUsage = (a: Usage | null | undefined, b: Usage | null | undefined): Usage | null => {
   if (!a && !b) return null;
@@ -521,7 +544,13 @@ export const buildIntermediateObjectsForTurn = async (input: { spaceId: string; 
   };
 };
 
-export const failSessionTurn = async (input: { sessionId: string; turnId: string; errorMessage: string }) => {
+export const failSessionTurn = async (input: { spaceId: string; sessionId: string; turnId: string; errorMessage: string }) => {
+  const [pending] = await db.select().from(sessionTurns).where(and(
+    eq(sessionTurns.id, input.turnId),
+    eq(sessionTurns.sessionId, input.sessionId),
+    inArray(sessionTurns.status, ["queued", "running", "abort_requested"]),
+  )).limit(1);
+  if (pending) await terminateIsolatedWorkerBeforeFinalStatus({ ...input, terminalStatus: "failed", meta: pending.meta });
   const completedAt = new Date();
   const completedAtIso = completedAt.toISOString();
   const [row] = await db.update(sessionTurns).set({
@@ -553,6 +582,21 @@ export const finalizeSessionTurnFromMessage = async (input: {
     logger.warn("[SessionTurn] failed to build intermediate objects", error);
     return null;
   });
+  const [pending] = await db.select().from(sessionTurns).where(and(
+    eq(sessionTurns.id, input.turnId),
+    eq(sessionTurns.sessionId, input.sessionId),
+    inArray(sessionTurns.status, ["running", "abort_requested"]),
+  )).limit(1);
+  if (pending) {
+    const terminalStatus: IsolatedWorkerTerminalStatus = input.status === "failed"
+      ? "failed"
+      : input.status === "cancelled"
+        ? "cancelled"
+        : input.status === "interrupted"
+          ? "interrupted"
+          : "completed";
+    await terminateIsolatedWorkerBeforeFinalStatus({ ...input, terminalStatus, meta: pending.meta });
+  }
   const completedAt = new Date();
   const completedAtIso = completedAt.toISOString();
   const [row] = await db.update(sessionTurns).set({
@@ -608,6 +652,7 @@ const finalizeInterruptedTurn = async (input: {
     logger.warn("[SessionTurn] failed to build interrupted intermediate objects", error);
     return null;
   });
+  await terminateIsolatedWorkerBeforeFinalStatus({ ...input, terminalStatus: "interrupted", meta: existing.meta });
   const completedAt = new Date();
   const completedAtIso = completedAt.toISOString();
   const [row] = await db.update(sessionTurns).set({

--- a/apps/api/src/space-sandboxes.ts
+++ b/apps/api/src/space-sandboxes.ts
@@ -1,12 +1,15 @@
-import { asc, eq, isNull, ne, or, sql } from "drizzle-orm";
+import { and, asc, eq, isNull, ne, or, sql } from "drizzle-orm";
 import { billingOperations, COHUB_BILLING_FEATURES } from "@cohub/billing";
 import {
   DEFAULT_SANDBOX_SPEC_ID,
   SANDBOX_SPECS,
+  assertSandboxCanAutoRecover,
+  assertSandboxCanResumeOrRecreate,
   buildInvalidatedSandboxEndpointMeta,
   getSandboxSpecRank,
   isSandboxAwaitingEndpointReport,
   isSandboxDialable,
+  isTerminatedIsolatedWorkerSandbox,
   normalizeSandboxSpecId,
   resolveSpaceSandboxAutoDestroyPolicy,
   type SandboxSpecId,
@@ -26,6 +29,7 @@ import type { SpaceSandboxRuntimeStatus, SpaceSandboxStatus, SpaceSandboxStopRea
 import { smokeVerifySandboxPod } from "./lib/sandbox/recovery.js";
 import type { V1Pod } from "@kubernetes/client-node";
 import { createLogger } from "@cohub/infra/logging";
+import { assertIsolatedWorkerDisposableOperationAllowed } from "./isolated-worker-disposable-guard.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -140,6 +144,7 @@ export const markSandboxSpecPendingRestart = async (input: { spaceId: string; sp
 };
 
 export const resizeSpaceSandboxToSpec = async (input: { spaceId: string; specId: SandboxSpecId }) => {
+  await assertIsolatedWorkerDisposableOperationAllowed(input.spaceId, "sandbox_lifecycle");
   const sandbox = await getSpaceSandboxBySpaceId(input.spaceId);
   if (!sandbox || sandbox.provider === "local") return { resized: false, pendingRestart: false, skipped: true };
   if (sandbox.status !== "running" && sandbox.status !== "ready") {
@@ -234,6 +239,9 @@ export const ensureSpaceSandbox = async (input: {
   stopReason?: SpaceSandboxStopReason | null;
   meta?: Record<string, unknown> | null;
 }) => {
+  await assertIsolatedWorkerDisposableOperationAllowed(input.spaceId, "sandbox_lifecycle");
+  const existing = await getSpaceSandboxBySpaceId(input.spaceId);
+  assertSandboxCanResumeOrRecreate(existing);
   const [sandbox] = await db
     .insert(spaceSandboxes)
     .values({
@@ -252,6 +260,10 @@ export const ensureSpaceSandbox = async (input: {
     })
     .onConflictDoUpdate({
       target: spaceSandboxes.spaceId,
+      setWhere: sql`not (
+        coalesce(jsonb_typeof(${spaceSandboxes.meta}->'isolatedWorkerPolicy') = 'object', false)
+        or coalesce(jsonb_typeof(${spaceSandboxes.meta}->'isolatedWorker') = 'object', false)
+      )`,
       set: {
         ...(input.provider !== undefined ? { provider: input.provider } : {}),
         status: input.status ?? "pending",
@@ -269,7 +281,11 @@ export const ensureSpaceSandbox = async (input: {
     })
     .returning();
 
-  if (!sandbox) throw new Error("Failed to ensure space sandbox");
+  if (!sandbox) {
+    const latest = await getSpaceSandboxBySpaceId(input.spaceId);
+    assertSandboxCanResumeOrRecreate(latest);
+    throw new Error("Failed to ensure space sandbox");
+  }
   return sandbox;
 };
 
@@ -298,6 +314,10 @@ export const updateSpaceSandbox = async (input: {
   stopReason?: SpaceSandboxStopReason | null;
   meta?: Record<string, unknown> | null;
 }) => {
+  const existing = await getSpaceSandboxBySpaceId(input.spaceId);
+  if (isTerminatedIsolatedWorkerSandbox(existing) && input.status !== "stopping" && input.status !== "terminated") {
+    throw new Error("terminated isolated worker sandbox state cannot be updated");
+  }
   const [sandbox] = await db
     .update(spaceSandboxes)
     .set({
@@ -314,7 +334,19 @@ export const updateSpaceSandbox = async (input: {
       ...(input.meta !== undefined ? { meta: input.meta } : {}),
       updatedAt: new Date(),
     })
-    .where(eq(spaceSandboxes.spaceId, input.spaceId))
+    .where(and(
+      eq(spaceSandboxes.spaceId, input.spaceId),
+      input.status === "stopping" || input.status === "terminated"
+        ? sql`true`
+        : sql`not (
+          coalesce(jsonb_typeof(${spaceSandboxes.meta}->'isolatedWorkerPolicy') = 'object', false)
+          and (
+            ${spaceSandboxes.status} in ('stopping', 'terminated')
+            or coalesce(${spaceSandboxes.meta}->'termination'->>'sandboxTerminated', 'false') = 'true'
+            or coalesce(${spaceSandboxes.meta}->>'terminationClaimId', '') <> ''
+          )
+        )`,
+    ))
     .returning();
 
   return sandbox ?? null;
@@ -336,6 +368,449 @@ export const mergeSpaceSandboxMeta = async (spaceId: string, metaPatch: Record<s
     .returning();
 
   return sandbox ?? null;
+};
+
+export const claimIsolatedWorkerSandboxAllocation = async (input: {
+  authoritySpaceId: string;
+  disposableSpaceId: string;
+  sessionId: string;
+  turnId: string;
+  policySha256: string;
+  podName: string;
+}) => {
+  const isolatedWorker = {
+    state: "starting",
+    authoritySpaceId: input.authoritySpaceId,
+    disposableSpaceId: input.disposableSpaceId,
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    policySha256: input.policySha256,
+    resumable: false,
+  };
+  const [sandbox] = await db.update(spaceSandboxes).set({
+    status: "provisioning",
+    runtimeStatus: "starting",
+    podName: input.podName,
+    meta: sql`(
+      CASE
+        WHEN jsonb_typeof(${spaceSandboxes.meta}) = 'object' THEN ${spaceSandboxes.meta}
+        ELSE '{}'::jsonb
+      END
+    ) || ${JSON.stringify({ isolatedWorker, resumable: false })}::jsonb`,
+    updatedAt: new Date(),
+  }).where(and(
+    eq(spaceSandboxes.spaceId, input.disposableSpaceId),
+    sql`${spaceSandboxes.status} = 'allocated'`,
+    isNull(spaceSandboxes.podName),
+    sql`${spaceSandboxes.meta}->'isolatedWorker'->>'state' = 'allocated'`,
+    sql`${spaceSandboxes.meta}->'isolatedWorker'->>'authoritySpaceId' = ${input.authoritySpaceId}`,
+    sql`${spaceSandboxes.meta}->'isolatedWorker'->>'disposableSpaceId' = ${input.disposableSpaceId}`,
+    sql`coalesce(${spaceSandboxes.meta}->'isolatedWorker'->>'resumable', 'true') = 'false'`,
+    sql`coalesce(${spaceSandboxes.meta}->>'terminationClaimId', '') = ''`,
+    sql`coalesce(${spaceSandboxes.meta}->'termination'->>'sandboxTerminated', 'false') <> 'true'`,
+  )).returning({ spaceId: spaceSandboxes.spaceId });
+  return Boolean(sandbox);
+};
+
+export const completeIsolatedWorkerSandboxAllocation = async (input: {
+  registration: {
+    spaceId: string;
+    status: "ready";
+    runtimeStatus: "healthy";
+    podName: string;
+    meta: Record<string, unknown>;
+  };
+  authoritySpaceId: string;
+  sessionId: string;
+  turnId: string;
+  policySha256: string;
+  podUid: string;
+}) => {
+  const isolatedWorker = {
+    state: "ready",
+    authoritySpaceId: input.authoritySpaceId,
+    disposableSpaceId: input.registration.spaceId,
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    policySha256: input.policySha256,
+    podUid: input.podUid,
+    resumable: false,
+  };
+  const [sandbox] = await db.update(spaceSandboxes).set({
+    status: input.registration.status,
+    runtimeStatus: input.registration.runtimeStatus,
+    podName: input.registration.podName,
+    meta: sql`(
+      CASE
+        WHEN jsonb_typeof(${spaceSandboxes.meta}) = 'object' THEN ${spaceSandboxes.meta}
+        ELSE '{}'::jsonb
+      END
+    ) || ${JSON.stringify({ ...input.registration.meta, isolatedWorker, resumable: false })}::jsonb`,
+    updatedAt: new Date(),
+  }).where(and(
+    eq(spaceSandboxes.spaceId, input.registration.spaceId),
+    eq(spaceSandboxes.status, "provisioning"),
+    eq(spaceSandboxes.podName, input.registration.podName),
+    sql`${spaceSandboxes.meta}->'isolatedWorker'->>'state' = 'starting'`,
+    sql`${spaceSandboxes.meta}->'isolatedWorker'->>'authoritySpaceId' = ${input.authoritySpaceId}`,
+    sql`${spaceSandboxes.meta}->'isolatedWorker'->>'sessionId' = ${input.sessionId}`,
+    sql`${spaceSandboxes.meta}->'isolatedWorker'->>'turnId' = ${input.turnId}`,
+    sql`${spaceSandboxes.meta}->'isolatedWorker'->>'policySha256' = ${input.policySha256}`,
+    sql`coalesce(${spaceSandboxes.meta}->>'terminationClaimId', '') = ''`,
+  )).returning({ spaceId: spaceSandboxes.spaceId });
+  return Boolean(sandbox);
+};
+
+export const markIsolatedWorkerSandboxCreateFailed = async (input: {
+  authoritySpaceId: string;
+  disposableSpaceId: string;
+  sessionId: string;
+  turnId: string;
+  policySha256: string;
+  podName: string;
+  reason: string;
+}) => {
+  const isolatedWorker = {
+    state: "create_failed",
+    authoritySpaceId: input.authoritySpaceId,
+    disposableSpaceId: input.disposableSpaceId,
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    policySha256: input.policySha256,
+    resumable: false,
+    createFailedAt: new Date().toISOString(),
+    createFailure: input.reason,
+  };
+  const [sandbox] = await db.update(spaceSandboxes).set({
+    status: "error",
+    runtimeStatus: "unhealthy",
+    podName: null,
+    meta: sql`coalesce(${spaceSandboxes.meta}, '{}'::jsonb) || ${JSON.stringify({
+      isolatedWorker,
+      podIp: null,
+      wsEndpoint: null,
+      resumable: false,
+    })}::jsonb`,
+    updatedAt: new Date(),
+  }).where(and(
+    eq(spaceSandboxes.spaceId, input.disposableSpaceId),
+    eq(spaceSandboxes.status, "provisioning"),
+    eq(spaceSandboxes.podName, input.podName),
+    sql`${spaceSandboxes.meta}->'isolatedWorker'->>'state' = 'starting'`,
+    sql`${spaceSandboxes.meta}->'isolatedWorker'->>'authoritySpaceId' = ${input.authoritySpaceId}`,
+    sql`${spaceSandboxes.meta}->'isolatedWorker'->>'sessionId' = ${input.sessionId}`,
+    sql`${spaceSandboxes.meta}->'isolatedWorker'->>'turnId' = ${input.turnId}`,
+    sql`${spaceSandboxes.meta}->'isolatedWorker'->>'policySha256' = ${input.policySha256}`,
+    sql`coalesce(${spaceSandboxes.meta}->>'terminationClaimId', '') = ''`,
+  )).returning({ spaceId: spaceSandboxes.spaceId });
+  return Boolean(sandbox);
+};
+
+export const claimIsolatedWorkerTermination = async (input: {
+  spaceId: string;
+  podUid: string;
+  claimId: string;
+  startedAt: string;
+}) => {
+  const [sandbox] = await db
+    .update(spaceSandboxes)
+    .set({
+      status: "stopping",
+      runtimeStatus: "unknown",
+      meta: sql`jsonb_set((
+        CASE
+          WHEN jsonb_typeof(${spaceSandboxes.meta}) = 'object' THEN ${spaceSandboxes.meta}
+          ELSE '{}'::jsonb
+        END
+      ) || ${JSON.stringify({
+        terminationStartedAt: input.startedAt,
+        terminationClaimId: input.claimId,
+        terminationStage: "deleting",
+        terminationRequired: true,
+        resumable: false,
+      })}::jsonb, '{isolatedWorker,state}', '"stopping"'::jsonb, true)`,
+      updatedAt: new Date(),
+    })
+    .where(and(
+      eq(spaceSandboxes.spaceId, input.spaceId),
+      sql`${spaceSandboxes.status} <> 'terminated'`,
+      sql`${spaceSandboxes.meta}->'isolatedWorkerPolicy'->>'podUid' = ${input.podUid}`,
+      sql`${spaceSandboxes.meta}->>'terminationClaimId' is null`,
+      sql`coalesce(${spaceSandboxes.meta}->'termination'->>'sandboxTerminated', 'false') <> 'true'`,
+    ))
+    .returning({ spaceId: spaceSandboxes.spaceId });
+  if (sandbox) return true;
+  const latest = await getSpaceSandboxBySpaceId(input.spaceId);
+  const meta = asMetaObject(latest?.meta);
+  const policy = asMetaObject(meta.isolatedWorkerPolicy);
+  return latest?.status === "stopping"
+    && policy.podUid === input.podUid
+    && meta.terminationClaimId === input.claimId;
+};
+
+export const markIsolatedWorkerPodDeleted = async (input: {
+  spaceId: string;
+  podUid: string;
+  claimId: string;
+  podDeletedAt: string;
+}) => {
+  const [sandbox] = await db.update(spaceSandboxes).set({
+    meta: sql`coalesce(${spaceSandboxes.meta}, '{}'::jsonb) || ${JSON.stringify({
+      terminationStage: "pod_deleted",
+      podDeletedAt: input.podDeletedAt,
+    })}::jsonb`,
+    updatedAt: new Date(),
+  }).where(and(
+    eq(spaceSandboxes.spaceId, input.spaceId),
+    eq(spaceSandboxes.status, "stopping"),
+    sql`${spaceSandboxes.meta}->'isolatedWorkerPolicy'->>'podUid' = ${input.podUid}`,
+    sql`${spaceSandboxes.meta}->>'terminationClaimId' = ${input.claimId}`,
+    sql`${spaceSandboxes.meta}->>'terminationStage' = 'deleting'`,
+  )).returning({ spaceId: spaceSandboxes.spaceId });
+  if (sandbox) return input.podDeletedAt;
+  const latest = await getSpaceSandboxBySpaceId(input.spaceId);
+  const meta = asMetaObject(latest?.meta);
+  const persistedPodDeletedAt = typeof meta.podDeletedAt === "string" ? meta.podDeletedAt : null;
+  return latest?.status === "stopping"
+    && meta.terminationClaimId === input.claimId
+    && (meta.terminationStage === "pod_deleted" || meta.terminationStage === "checkpointing")
+    && persistedPodDeletedAt
+    ? persistedPodDeletedAt
+    : null;
+};
+
+export const claimIsolatedWorkerCheckpoint = async (input: {
+  spaceId: string;
+  podUid: string;
+  claimId: string;
+  checkpointAttemptId: string;
+  checkpointTaskRunId: string;
+}) => {
+  const [sandbox] = await db.update(spaceSandboxes).set({
+    meta: sql`coalesce(${spaceSandboxes.meta}, '{}'::jsonb) || ${JSON.stringify({
+      terminationStage: "checkpointing",
+      checkpointAttemptId: input.checkpointAttemptId,
+      checkpointTaskRunId: input.checkpointTaskRunId,
+    })}::jsonb`,
+    updatedAt: new Date(),
+  }).where(and(
+    eq(spaceSandboxes.spaceId, input.spaceId),
+    eq(spaceSandboxes.status, "stopping"),
+    sql`${spaceSandboxes.meta}->'isolatedWorkerPolicy'->>'podUid' = ${input.podUid}`,
+    sql`${spaceSandboxes.meta}->>'terminationClaimId' = ${input.claimId}`,
+    sql`${spaceSandboxes.meta}->>'terminationStage' = 'pod_deleted'`,
+    sql`${spaceSandboxes.meta}->>'podDeletedAt' is not null`,
+  )).returning({ spaceId: spaceSandboxes.spaceId });
+  if (sandbox) return {
+    checkpointAttemptId: input.checkpointAttemptId,
+    checkpointTaskRunId: input.checkpointTaskRunId,
+  };
+  const latest = await getSpaceSandboxBySpaceId(input.spaceId);
+  const meta = asMetaObject(latest?.meta);
+  const policy = asMetaObject(meta.isolatedWorkerPolicy);
+  return latest?.status === "stopping"
+    && policy.podUid === input.podUid
+    && meta.terminationClaimId === input.claimId
+    && (meta.terminationStage === "checkpointing" || meta.terminationStage === "checkpointed")
+    && typeof meta.checkpointAttemptId === "string"
+    && typeof meta.checkpointTaskRunId === "string"
+    ? {
+        checkpointAttemptId: meta.checkpointAttemptId,
+        checkpointTaskRunId: meta.checkpointTaskRunId,
+      }
+    : null;
+};
+
+export const rotateIsolatedWorkerCheckpointAttempt = async (input: {
+  spaceId: string;
+  podUid: string;
+  claimId: string;
+  checkpointAttemptId: string;
+  checkpointTaskRunId: string;
+  nextCheckpointAttemptId: string;
+  nextCheckpointTaskRunId: string;
+}) => {
+  const [sandbox] = await db.update(spaceSandboxes).set({
+    meta: sql`coalesce(${spaceSandboxes.meta}, '{}'::jsonb) || ${JSON.stringify({
+      checkpointAttemptId: input.nextCheckpointAttemptId,
+      checkpointTaskRunId: input.nextCheckpointTaskRunId,
+    })}::jsonb`,
+    updatedAt: new Date(),
+  }).where(and(
+    eq(spaceSandboxes.spaceId, input.spaceId),
+    eq(spaceSandboxes.status, "stopping"),
+    sql`${spaceSandboxes.meta}->'isolatedWorkerPolicy'->>'podUid' = ${input.podUid}`,
+    sql`${spaceSandboxes.meta}->>'terminationClaimId' = ${input.claimId}`,
+    sql`${spaceSandboxes.meta}->>'terminationStage' = 'checkpointing'`,
+    sql`${spaceSandboxes.meta}->>'checkpointAttemptId' = ${input.checkpointAttemptId}`,
+    sql`${spaceSandboxes.meta}->>'checkpointTaskRunId' = ${input.checkpointTaskRunId}`,
+    sql`${spaceSandboxes.meta}->'terminationCheckpoint' is null`,
+  )).returning({ spaceId: spaceSandboxes.spaceId });
+  if (sandbox) return {
+    checkpointAttemptId: input.nextCheckpointAttemptId,
+    checkpointTaskRunId: input.nextCheckpointTaskRunId,
+  };
+  const latest = await getSpaceSandboxBySpaceId(input.spaceId);
+  const meta = asMetaObject(latest?.meta);
+  const policy = asMetaObject(meta.isolatedWorkerPolicy);
+  return latest?.status === "stopping"
+    && policy.podUid === input.podUid
+    && meta.terminationClaimId === input.claimId
+    && (meta.terminationStage === "checkpointing" || meta.terminationStage === "checkpointed")
+    && typeof meta.checkpointAttemptId === "string"
+    && typeof meta.checkpointTaskRunId === "string"
+    ? {
+        checkpointAttemptId: meta.checkpointAttemptId,
+        checkpointTaskRunId: meta.checkpointTaskRunId,
+      }
+    : null;
+};
+
+export const readIsolatedWorkerTerminationCheckpoint = async (input: {
+  spaceId: string;
+  podUid: string;
+  claimId: string;
+  checkpointAttemptId: string;
+}) => {
+  const sandbox = await getSpaceSandboxBySpaceId(input.spaceId);
+  const meta = asMetaObject(sandbox?.meta);
+  const policy = asMetaObject(meta.isolatedWorkerPolicy);
+  if (
+    sandbox?.status !== "stopping"
+    || policy.podUid !== input.podUid
+    || meta.terminationClaimId !== input.claimId
+    || meta.checkpointAttemptId !== input.checkpointAttemptId
+    || meta.terminationStage !== "checkpointed"
+  ) return null;
+  const checkpoint = meta.terminationCheckpoint;
+  return checkpoint && typeof checkpoint === "object" && !Array.isArray(checkpoint)
+    ? checkpoint as Record<string, unknown>
+    : null;
+};
+
+export const persistIsolatedWorkerTerminationCheckpoint = async (input: {
+  spaceId: string;
+  podUid: string;
+  claimId: string;
+  checkpointAttemptId: string;
+  checkpoint: {
+    disposableSpaceId: string;
+    checkpointId: string;
+    commit: string;
+    tree: string;
+    treeSha256: string;
+    currentHead: string;
+    checkpointCreatedAt: string;
+  };
+}) => {
+  const [sandbox] = await db.update(spaceSandboxes).set({
+    meta: sql`coalesce(${spaceSandboxes.meta}, '{}'::jsonb) || ${JSON.stringify({
+      terminationStage: "checkpointed",
+      terminationCheckpoint: input.checkpoint,
+    })}::jsonb`,
+    updatedAt: new Date(),
+  }).where(and(
+    eq(spaceSandboxes.spaceId, input.spaceId),
+    eq(spaceSandboxes.status, "stopping"),
+    sql`${spaceSandboxes.meta}->'isolatedWorkerPolicy'->>'podUid' = ${input.podUid}`,
+    sql`${spaceSandboxes.meta}->>'terminationClaimId' = ${input.claimId}`,
+    sql`${spaceSandboxes.meta}->>'terminationStage' = 'checkpointing'`,
+    sql`${spaceSandboxes.meta}->>'checkpointAttemptId' = ${input.checkpointAttemptId}`,
+  )).returning({ spaceId: spaceSandboxes.spaceId });
+  if (sandbox) return true;
+  return Boolean(await readIsolatedWorkerTerminationCheckpoint(input));
+};
+
+export const completeIsolatedWorkerTermination = async (input: {
+  spaceId: string;
+  podUid: string;
+  claimId: string;
+  checkpointAttemptId: string;
+  receipt: {
+    revokeTaskRunId: string;
+    automaticTrigger: "turn_terminal_event";
+    manualEndpointInvoked: false;
+    podUid: string;
+    podDeleted: true;
+    podDeletedAt: string;
+    credentialRevoked: true;
+    sandboxTerminated: true;
+    checkpointCreatedAfterPodDeletion: true;
+    checkpointAdapter: "trusted_production";
+    terminatedAt: string;
+    checkpointId: string;
+    checkpointCommit: string;
+    checkpointTreeSha256: string;
+  };
+}) => {
+  if (input.receipt.podUid !== input.podUid) throw new Error("isolated worker termination receipt pod UID mismatch");
+  if (
+    input.receipt.automaticTrigger !== "turn_terminal_event"
+    || input.receipt.manualEndpointInvoked !== false
+    || !input.receipt.revokeTaskRunId
+  ) throw new Error("isolated worker termination receipt automatic TaskRun binding mismatch");
+  return db.transaction(async (tx) => {
+    const [sandbox] = await tx
+      .update(spaceSandboxes)
+    .set({
+      status: "terminated",
+      runtimeStatus: "unknown",
+      podName: null,
+      stoppedAt: new Date(input.receipt.terminatedAt),
+      meta: sql`jsonb_set((
+        CASE
+          WHEN jsonb_typeof(${spaceSandboxes.meta}) = 'object' THEN ${spaceSandboxes.meta}
+          ELSE '{}'::jsonb
+        END
+      ) || ${JSON.stringify({
+        termination: input.receipt,
+        isolatedWorkerDisposable: {
+          frozenHead: {
+            checkpointId: input.receipt.checkpointId,
+            commitHash: input.receipt.checkpointCommit,
+            treeSha256: input.receipt.checkpointTreeSha256,
+          },
+        },
+        terminationClaimId: null,
+        terminationStage: "terminated",
+        checkpointAttemptId: null,
+        wsEndpoint: null,
+        podIp: null,
+        resumable: false,
+      })}::jsonb, '{isolatedWorker,state}', '"terminated"'::jsonb, true)`,
+      updatedAt: new Date(),
+    })
+    .where(and(
+      eq(spaceSandboxes.spaceId, input.spaceId),
+      sql`${spaceSandboxes.meta}->'isolatedWorkerPolicy'->>'podUid' = ${input.podUid}`,
+      sql`${spaceSandboxes.meta}->>'terminationClaimId' = ${input.claimId}`,
+      sql`${spaceSandboxes.meta}->>'terminationStage' = 'checkpointed'`,
+      sql`${spaceSandboxes.meta}->>'checkpointAttemptId' = ${input.checkpointAttemptId}`,
+      sql`${spaceSandboxes.meta}->'terminationCheckpoint'->>'disposableSpaceId' = ${input.spaceId}`,
+      sql`${spaceSandboxes.meta}->'terminationCheckpoint'->>'checkpointId' = ${input.receipt.checkpointId}`,
+      sql`${spaceSandboxes.meta}->'terminationCheckpoint'->>'commit' = ${input.receipt.checkpointCommit}`,
+      sql`${spaceSandboxes.meta}->'terminationCheckpoint'->>'currentHead' = ${input.receipt.checkpointCommit}`,
+      sql`${spaceSandboxes.meta}->'terminationCheckpoint'->>'treeSha256' = ${input.receipt.checkpointTreeSha256}`,
+      sql`coalesce(${spaceSandboxes.meta}->'termination'->>'sandboxTerminated', 'false') <> 'true'`,
+    ))
+      .returning({ spaceId: spaceSandboxes.spaceId });
+    if (!sandbox) return false;
+    const frozenHead = {
+      checkpointId: input.receipt.checkpointId,
+      commitHash: input.receipt.checkpointCommit,
+      treeSha256: input.receipt.checkpointTreeSha256,
+    };
+    const [updatedSpace] = await tx.update(spaces).set({
+      meta: sql`coalesce(${spaces.meta}, '{}'::jsonb) || jsonb_build_object(
+        'isolatedWorkerDisposable',
+        coalesce(${spaces.meta}->'isolatedWorkerDisposable', '{}'::jsonb)
+          || ${JSON.stringify({ frozenHead })}::jsonb
+      )`,
+      updatedAt: new Date(),
+    }).where(eq(spaces.id, input.spaceId)).returning({ id: spaces.id });
+    if (!updatedSpace) throw new Error("isolated worker disposable space is missing during termination");
+    return true;
+  });
 };
 
 export const listSandboxRolloutTargets = async (input?: {
@@ -428,8 +903,10 @@ export const reconcileSpaceSandbox = async (input: {
   mode: "ensure" | "replace";
   reason: "space_created" | "manual_recreate" | "auto_recover" | "auto_resume" | "space_mods_changed";
 }) => {
+  await assertIsolatedWorkerDisposableOperationAllowed(input.spaceId, "sandbox_lifecycle");
   const podName = `sandbox-${input.spaceId}`;
   const existingSandbox = await getSpaceSandboxBySpaceId(input.spaceId);
+  assertSandboxCanResumeOrRecreate(existingSandbox);
   const existingMeta = asMetaObject(existingSandbox?.meta);
 
   if (input.mode === "replace") {
@@ -639,7 +1116,10 @@ export const recoverSpaceSandbox = async (input: {
   source?: string;
   verify?: boolean;
 }) => {
+  await assertIsolatedWorkerDisposableOperationAllowed(input.spaceId, "sandbox_lifecycle");
   const existing = await getSpaceSandboxBySpaceId(input.spaceId);
+  if (input.source === "manual") assertSandboxCanResumeOrRecreate(existing);
+  else assertSandboxCanAutoRecover(existing);
   if (existing?.provider === "local") {
     // Local sandboxes live on the user's machine; there is nothing to recover
     // server-side. Report current status without attempting a cloud recreate.
@@ -777,4 +1257,3 @@ export const recoverSpaceSandbox = async (input: {
     await redisCommandClient.del(lockKey).catch(() => undefined);
   }
 };
-

--- a/apps/api/src/tasks.ts
+++ b/apps/api/src/tasks.ts
@@ -9,10 +9,14 @@ import type { TaskPayload, TaskScheduleConfig } from "@cohub/protocol/task";
 import { GENERATION_TASK_TYPE } from "@cohub/protocol/generation";
 import { dispatchTaskCreated } from "./realtime-events.js";
 import { createLogger } from "@cohub/infra/logging";
+import {
+  assertIsolatedWorkerDisposableOperationAllowed,
+  type IsolatedWorkerDisposableOperation,
+} from "./isolated-worker-disposable-guard.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
-type TaskEnqueueOptions = Omit<JobsOptions, "scheduledAt"> & { scheduledAt?: Date | null };
+type TaskEnqueueOptions = Omit<JobsOptions, "scheduledAt"> & { scheduledAt?: Date | null; taskRunId?: string };
 
 const QUEUE_NAME = COHUB_TASKS_QUEUE;
 
@@ -21,20 +25,32 @@ export const taskQueue = createBullmqQueue(QUEUE_NAME, {
   telemetryServiceName: "cohub-api",
 });
 
-export const SUPPORTED_TASK_TYPES = new Set<string>(["send_message", "save_checkpoint", "create_space", "run_command", GENERATION_TASK_TYPE]);
+export const SUPPORTED_TASK_TYPES = new Set<string>(["send_message", "save_checkpoint", "create_space", "run_command", "isolated_worker_dispatch", "isolated_worker_revoke", "isolated_worker_receipt_scan", GENERATION_TASK_TYPE]);
 
 export const enqueueTask = async (
   payload: TaskPayload,
   opts?: TaskEnqueueOptions,
-) => enqueueTaskRun({
-  db,
-  payload,
-  options: opts,
-  enqueue: (name, taskPayload, options) => taskQueue.add(name, taskPayload, options),
-  onTaskCreated: (taskRun) => dispatchTaskCreated(taskRun).catch((error) => {
-    logger.warn("[Realtime] failed to dispatch task.created", error);
-  }),
-});
+) => {
+  if (payload.spaceId) {
+    let operation: IsolatedWorkerDisposableOperation = "generic_task_dispatch";
+    if (payload.type === "isolated_worker_dispatch") operation = "isolated_worker_dispatch";
+    else if (payload.type === "isolated_worker_revoke") operation = "isolated_worker_revoke";
+    else if (payload.type === "isolated_worker_receipt_scan") operation = "isolated_worker_receipt_scan";
+    else if (payload.type === "save_checkpoint" && payload.data?.reason === "isolated_worker_revocation") {
+      operation = "isolated_worker_checkpoint";
+    }
+    await assertIsolatedWorkerDisposableOperationAllowed(payload.spaceId, operation);
+  }
+  return enqueueTaskRun({
+    db,
+    payload,
+    options: opts,
+    enqueue: (name, taskPayload, options) => taskQueue.add(name, taskPayload, options),
+    onTaskCreated: (taskRun) => dispatchTaskCreated(taskRun).catch((error) => {
+      logger.warn("[Realtime] failed to dispatch task.created", error);
+    }),
+  });
+};
 
 export const createCronJob = async (params: {
   userId: string;
@@ -45,6 +61,9 @@ export const createCronJob = async (params: {
   spaceId?: string | null;
   sessionId?: string | null;
 }) => {
+  if (params.spaceId) {
+    await assertIsolatedWorkerDisposableOperationAllowed(params.spaceId, "cron_schedule");
+  }
   const taskPayload: TaskPayload = {
     type: params.taskType,
     spaceId: params.spaceId ?? undefined,
@@ -188,6 +207,9 @@ const cronJobScheduleData = (job: CronJobRow): CronJobScheduleData => ({
 });
 
 export const enableCronJob = async (cronJobId: string, bullJobKey: string, jobData: CronJobScheduleData) => {
+  if (jobData.spaceId) {
+    await assertIsolatedWorkerDisposableOperationAllowed(jobData.spaceId, "cron_schedule");
+  }
   const repeatJobKey = await scheduleCronJobRepeat(cronJobId, bullJobKey, jobData);
 
   try {
@@ -226,6 +248,9 @@ export const updateCronJob = async (
   current: CronJobRow,
   patch: CronJobUpdatePatch,
 ) => {
+  if (current.spaceId) {
+    await assertIsolatedWorkerDisposableOperationAllowed(current.spaceId, "cron_schedule");
+  }
   const next = {
     ...current,
     ...patch,

--- a/apps/worker/src/checkpoint/git.ts
+++ b/apps/worker/src/checkpoint/git.ts
@@ -63,6 +63,24 @@ const spawnGitWithOutput = async (args: string[], cwd: string) => {
   });
 };
 
+const spawnGitWithBuffer = async (args: string[], cwd: string) => {
+  return new Promise<{ stdout: Buffer; stderr: string }>((resolve, reject) => {
+    const child = spawn("git", ["-c", `safe.directory=${cwd}`, ...args], {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const chunks: Buffer[] = [];
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString("utf8"); });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) return resolve({ stdout: Buffer.concat(chunks), stderr });
+      reject(new Error(redactBasicAuthUrls(stderr.trim() || `git ${args[0]} exited with non-zero status ${code}`)));
+    });
+  });
+};
+
 export const runGitWithOutput = async (args: string[], cwd: string) => {
   await cleanStaleGitLock(cwd);
   try {
@@ -75,6 +93,20 @@ export const runGitWithOutput = async (args: string[], cwd: string) => {
     const removed = await cleanStaleGitLock(cwd);
     if (!removed) throw error;
     return spawnGitWithOutput(args, cwd);
+  }
+};
+
+export const runGitWithBuffer = async (args: string[], cwd: string) => {
+  await cleanStaleGitLock(cwd);
+  try {
+    return await spawnGitWithBuffer(args, cwd);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!isGitIndexLockError(message)) throw error;
+    await waitForStaleGitLock(cwd);
+    const removed = await cleanStaleGitLock(cwd);
+    if (!removed) throw error;
+    return spawnGitWithBuffer(args, cwd);
   }
 };
 

--- a/apps/worker/src/checkpoint/save.ts
+++ b/apps/worker/src/checkpoint/save.ts
@@ -14,6 +14,8 @@ export type SaveCheckpointInput = {
 export type SaveCheckpointResult = {
   checkpointId: string;
   commitHash: string;
+  treeHash: string;
+  checkpointTreeSha256: string;
   branch: string;
   commitMessage: string;
   changedFiles: number;

--- a/apps/worker/src/config.ts
+++ b/apps/worker/src/config.ts
@@ -7,6 +7,7 @@ export interface WorkerConfig {
   giteaOrg: string;
   workerSecret: string;
   appEncryptionKey: string;
+  internalApiBaseUrl: string;
   spaceStorageRoot: string;
   spaceSystemRoot: string;
   checkpointCacheRoot: string;
@@ -61,6 +62,7 @@ export const config: WorkerConfig = {
   giteaOrg: process.env.GITEA_ORG ?? "cohub-spaces",
   workerSecret: process.env.WORKER_SECRET ?? "",
   appEncryptionKey: process.env.APP_ENCRYPTION_KEY ?? "",
+  internalApiBaseUrl: process.env.INTERNAL_API_BASE_URL ?? (env === "prod" ? "http://cohub-api:8787" : "http://cohub-api-dev:8787"),
   spaceStorageRoot: process.env.SPACE_STORAGE_ROOT ?? "",
   spaceSystemRoot: process.env.SPACE_SYSTEM_ROOT ?? process.env.SPACE_STORAGE_ROOT ?? "",
   checkpointCacheRoot: process.env.CHECKPOINT_CACHE_ROOT ?? process.env.SPACE_STORAGE_ROOT ?? "",

--- a/apps/worker/src/isolated-worker-inputs.test.ts
+++ b/apps/worker/src/isolated-worker-inputs.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { materializeFrozenInputManifest } from "./isolated-worker-inputs.js";
+
+const root = await mkdtemp(join(tmpdir(), "cohub-isolated-inputs-"));
+const source = join(root, "source");
+const target = join(root, "target");
+await mkdir(join(source, "modules"), { recursive: true });
+await writeFile(join(source, "modules", "method.md"), "frozen method\n");
+await writeFile(join(source, "modules", "undeclared.md"), "must not copy\n");
+const content = Buffer.from("frozen method\n");
+const inputBundle = {
+  authorityCheckpointId: "99999999-9999-4999-8999-999999999999",
+  authorityCheckpointCommit: "a".repeat(40),
+  authorityTreeSha256: "c".repeat(64),
+  inputManifestSha256: "d".repeat(64),
+  runtimeAuthorityReadAllowed: false as const,
+  items: [{
+    sourcePath: "modules/method.md",
+    destinationPath: "inputs/method.md",
+    contentSha256: createHash("sha256").update(content).digest("hex"),
+    sourceType: "regular_file" as const,
+  }],
+};
+const firstItem = inputBundle.items[0];
+assert.ok(firstItem);
+
+const receipt = await materializeFrozenInputManifest({ sourceRoot: source, targetRoot: target, inputBundle });
+assert.equal(await readFile(join(target, "inputs", "method.md"), "utf8"), "frozen method\n");
+await assert.rejects(readFile(join(target, "inputs", "undeclared.md")), /ENOENT/);
+assert.deepEqual(receipt.files, inputBundle.items);
+
+const symlinkTarget = join(root, "target-symlink");
+await symlink("method.md", join(source, "modules", "link.md"));
+await assert.rejects(
+  materializeFrozenInputManifest({
+    sourceRoot: source,
+    targetRoot: symlinkTarget,
+    inputBundle: { ...inputBundle, items: [{ ...firstItem, sourcePath: "modules/link.md" }] },
+  }),
+  /regular file/,
+);
+
+const badHashTarget = join(root, "target-bad-hash");
+await assert.rejects(
+  materializeFrozenInputManifest({
+    sourceRoot: source,
+    targetRoot: badHashTarget,
+    inputBundle: { ...inputBundle, items: [{ ...firstItem, contentSha256: "0".repeat(64) }] },
+  }),
+  /hash mismatch/,
+);
+
+const outside = join(root, "outside");
+await mkdir(outside);
+await writeFile(join(outside, "secret.md"), "outside secret\n");
+await symlink(outside, join(source, "modules-link"));
+await assert.rejects(
+  materializeFrozenInputManifest({
+    sourceRoot: source,
+    targetRoot: join(root, "target-intermediate-symlink"),
+    inputBundle: { ...inputBundle, items: [{ ...firstItem, sourcePath: "modules-link/secret.md" }] },
+  }),
+  /symlink/,
+);
+
+await assert.rejects(
+  materializeFrozenInputManifest({
+    sourceRoot: source,
+    targetRoot: join(root, "target-path-escape"),
+    inputBundle: { ...inputBundle, items: [{ ...firstItem, sourcePath: "../secret" }] },
+  }),
+  /unsafe manifest path/,
+);
+
+await assert.rejects(
+  materializeFrozenInputManifest({
+    sourceRoot: source,
+    targetRoot: join(root, "target-undeclared"),
+    inputBundle: { ...inputBundle, items: [{ ...firstItem, sourcePath: "modules/not-declared.md" }] },
+  }),
+  /ENOENT/,
+);
+
+console.log("isolated worker frozen input materialization checks passed");

--- a/apps/worker/src/isolated-worker-inputs.ts
+++ b/apps/worker/src/isolated-worker-inputs.ts
@@ -1,0 +1,139 @@
+import { constants } from "node:fs";
+import { createHash } from "node:crypto";
+import { chmod, lstat, mkdir, open, readdir, realpath, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import type { IsolatedWorkerInputBundle } from "@cohub/protocol/isolated-worker";
+
+function safePath(root: string, value: string) {
+  if (!value || value.includes("\0") || value.includes("\\") || isAbsolute(value)) throw new Error(`unsafe manifest path: ${value}`);
+  const parts = value.split("/");
+  if (parts.some((part) => !part || part === "." || part === "..")) throw new Error(`unsafe manifest path: ${value}`);
+  if (parts[0] === ".git" || parts[0] === ".cohub" || parts[0] === "work") throw new Error(`reserved manifest path: ${value}`);
+  const target = resolve(root, value);
+  const rel = relative(resolve(root), target);
+  if (!rel || rel.startsWith("..") || isAbsolute(rel)) throw new Error(`manifest path escapes root: ${value}`);
+  return target;
+}
+
+type PathIdentity = { path: string; dev: number; ino: number };
+
+async function captureDirectoryChain(root: string, relativePath: string): Promise<PathIdentity[]> {
+  const identities: PathIdentity[] = [];
+  const parts = relativePath.split("/").slice(0, -1);
+  let current = resolve(root);
+  for (const part of ["", ...parts]) {
+    if (part) current = resolve(current, part);
+    const entry = await lstat(current);
+    if (entry.isSymbolicLink() || !entry.isDirectory()) throw new Error(`manifest source directory is a symlink or not a directory: ${current}`);
+    identities.push({ path: current, dev: entry.dev, ino: entry.ino });
+  }
+  return identities;
+}
+
+async function assertDirectoryChainUnchanged(identities: PathIdentity[]) {
+  for (const identity of identities) {
+    const entry = await lstat(identity.path);
+    if (entry.isSymbolicLink() || !entry.isDirectory() || entry.dev !== identity.dev || entry.ino !== identity.ino) {
+      throw new Error(`manifest source directory changed during read: ${identity.path}`);
+    }
+  }
+}
+
+async function readRegularFileNoFollow(root: string, relativePath: string) {
+  const path = safePath(root, relativePath);
+  const rootRealPath = await realpath(root);
+  const chain = await captureDirectoryChain(root, relativePath);
+  const before = await lstat(path);
+  if (!before.isFile() || before.isSymbolicLink()) throw new Error(`manifest source is not a regular file: ${path}`);
+  const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const opened = await handle.stat();
+    if (!opened.isFile() || opened.dev !== before.dev || opened.ino !== before.ino) {
+      throw new Error(`manifest source changed before read: ${path}`);
+    }
+    const content = await handle.readFile();
+    const after = await handle.stat();
+    if (after.dev !== opened.dev || after.ino !== opened.ino || after.size !== opened.size || after.mtimeMs !== opened.mtimeMs) {
+      throw new Error(`manifest source changed during read: ${path}`);
+    }
+    const resolvedSource = await realpath(path);
+    const sourceRelative = relative(rootRealPath, resolvedSource);
+    if (!sourceRelative || sourceRelative.startsWith("..") || isAbsolute(sourceRelative)) {
+      throw new Error(`manifest source escapes root through symlink: ${relativePath}`);
+    }
+    await assertDirectoryChainUnchanged(chain);
+    return content;
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function materializeFrozenInputManifest(input: {
+  sourceRoot: string;
+  targetRoot: string;
+  inputBundle: IsolatedWorkerInputBundle;
+}) {
+  await mkdir(input.targetRoot, { recursive: true, mode: 0o755 });
+  const initial = await readdir(input.targetRoot);
+  if (initial.length !== 0) throw new Error("disposable workspace must be empty before frozen input materialization");
+  const copied: IsolatedWorkerInputBundle["items"] = [];
+  const createdDirs = new Set<string>();
+  for (const file of input.inputBundle.items) {
+    if (file.sourceType !== "regular_file") throw new Error(`unsupported input source type: ${file.sourceType}`);
+    if (!file.destinationPath.startsWith("inputs/")) throw new Error(`input destination must be under inputs/: ${file.destinationPath}`);
+    const target = safePath(input.targetRoot, file.destinationPath);
+    const content = await readRegularFileNoFollow(input.sourceRoot, file.sourcePath);
+    const digest = createHash("sha256").update(content).digest("hex");
+    if (digest !== file.contentSha256) throw new Error(`input hash mismatch: ${file.sourcePath}`);
+    const parent = dirname(target);
+    await mkdir(parent, { recursive: true, mode: 0o755 });
+    createdDirs.add(parent);
+    await writeFile(target, content, { flag: "wx", mode: 0o444 });
+    copied.push({ ...file });
+  }
+  await mkdir(resolve(input.targetRoot, "work"), { mode: 0o700 });
+  for (const dir of [...createdDirs].sort((a, b) => b.length - a.length)) await chmod(dir, 0o555);
+  await chmod(input.targetRoot, 0o555);
+  return { files: copied, workRoot: "work/" as const };
+}
+
+async function listInputFiles(root: string, relativeDir: string): Promise<string[]> {
+  const dirPath = resolve(root, relativeDir);
+  const dir = await lstat(dirPath);
+  if (dir.isSymbolicLink() || !dir.isDirectory()) throw new Error(`materialized input directory is unsafe: ${relativeDir}`);
+  const files: string[] = [];
+  for (const entry of await readdir(dirPath, { withFileTypes: true })) {
+    const relativePath = `${relativeDir}/${entry.name}`;
+    if (entry.isSymbolicLink()) throw new Error(`materialized input contains symlink: ${relativePath}`);
+    if (entry.isDirectory()) files.push(...await listInputFiles(root, relativePath));
+    else if (entry.isFile()) files.push(relativePath);
+    else throw new Error(`materialized input contains special file: ${relativePath}`);
+  }
+  return files;
+}
+
+export async function verifyFrozenInputMaterialization(input: {
+  targetRoot: string;
+  inputBundle: IsolatedWorkerInputBundle;
+}) {
+  const topLevel = (await readdir(input.targetRoot)).sort();
+  if (topLevel.length !== 2 || topLevel[0] !== "inputs" || topLevel[1] !== "work") {
+    throw new Error(`materialized workspace has undeclared top-level entries: ${topLevel.join(",")}`);
+  }
+  const work = await lstat(resolve(input.targetRoot, "work"));
+  if (work.isSymbolicLink() || !work.isDirectory()) throw new Error("materialized work root is unsafe");
+  const actualFiles = (await listInputFiles(input.targetRoot, "inputs")).sort();
+  const expectedFiles = input.inputBundle.items.map((item) => item.destinationPath).sort();
+  if (canonicalPaths(actualFiles) !== canonicalPaths(expectedFiles)) {
+    throw new Error("materialized input file set does not match frozen manifest");
+  }
+  for (const file of input.inputBundle.items) {
+    const content = await readRegularFileNoFollow(input.targetRoot, file.destinationPath);
+    const digest = createHash("sha256").update(content).digest("hex");
+    if (digest !== file.contentSha256) throw new Error(`materialized input hash mismatch: ${file.destinationPath}`);
+  }
+}
+
+function canonicalPaths(paths: string[]) {
+  return JSON.stringify(paths);
+}

--- a/apps/worker/src/tasks/enqueue.ts
+++ b/apps/worker/src/tasks/enqueue.ts
@@ -1,4 +1,6 @@
 import { COHUB_TASKS_QUEUE, createBullmqQueue } from "@cohub/infra/bullmq";
+import { and, eq } from "drizzle-orm";
+import { taskRuns } from "@cohub/db";
 import { enqueueTaskRun, type TaskEnqueueOptions } from "@cohub/core/tasks";
 import type { TaskPayload } from "@cohub/protocol/task";
 import { config } from "../config.js";
@@ -15,3 +17,17 @@ export const enqueueTask = (payload: TaskPayload, options?: TaskEnqueueOptions) 
   options,
   enqueue: (name, taskPayload, jobOptions) => taskQueue.add(name, taskPayload, jobOptions),
 });
+
+export async function retryFailedTask(taskRunId: string) {
+  const job = await taskQueue.getJob(taskRunId);
+  if (!job) throw new Error(`failed TaskRun ${taskRunId} has no BullMQ job`);
+  if (await job.getState() !== "failed") throw new Error(`TaskRun ${taskRunId} BullMQ job is not failed`);
+  await job.retry("failed");
+  await db.update(taskRuns).set({
+    status: "pending",
+    errorMessage: null,
+    startedAt: null,
+    finishedAt: null,
+    updatedAt: new Date(),
+  }).where(and(eq(taskRuns.id, taskRunId), eq(taskRuns.status, "failed")));
+}

--- a/apps/worker/src/tasks/index.ts
+++ b/apps/worker/src/tasks/index.ts
@@ -6,3 +6,5 @@ import "./create-space-task.js";
 import "./run-command-task.js";
 import "./generation-task.js";
 import "./generation-billing-retry-task.js";
+import "./isolated-worker-dispatch-task.js";
+import "./isolated-worker-termination-task.js";

--- a/apps/worker/src/tasks/isolated-worker-dispatch-handler.ts
+++ b/apps/worker/src/tasks/isolated-worker-dispatch-handler.ts
@@ -1,0 +1,345 @@
+import { createHash } from "node:crypto";
+import type { TaskPayload } from "@cohub/protocol/task";
+import {
+  ISOLATED_WORKER_CREATION_PATH,
+  ISOLATED_WORKER_DISPATCH_TASK_TYPE,
+  type IsolatedWorkerDispatchTaskData,
+} from "@cohub/protocol/isolated-worker";
+
+type Reservation = {
+  authoritySpaceId: string;
+  disposableSpaceId: string;
+  sessionId: string;
+  userId: string;
+  sandboxStatus: string;
+  sandboxPodName: string | null;
+  allocation: Record<string, unknown> | null;
+};
+
+type DispatchInvocation = { taskRunId: string; payload: TaskPayload };
+
+export class IsolatedWorkerDispatchRejectedError extends Error {
+  readonly taskResult: Record<string, unknown>;
+
+  constructor(message: string, taskResult: Record<string, unknown>) {
+    super(message);
+    this.name = "IsolatedWorkerDispatchRejectedError";
+    this.taskResult = taskResult;
+  }
+}
+
+export type IsolatedWorkerDispatchHandlerDependencies = {
+  recoverReservation(input: {
+    taskRunId: string;
+    authoritySpaceId: string;
+    disposableSpaceId: string;
+    sessionId: string;
+    userId: string;
+    data: IsolatedWorkerDispatchTaskData;
+  }): Promise<
+    | { state: "none" }
+    | { state: "submitted"; result: Record<string, unknown> }
+    | { state: "staged" | "prepared" | "published"; inputsMaterializedAt: string; preparedWorkspace: string }
+  >;
+  readReservation(input: {
+    taskRunId: string;
+    authoritySpaceId: string;
+    disposableSpaceId: string;
+    sessionId: string;
+    userId: string;
+    policySha256: string;
+    dispatchData: IsolatedWorkerDispatchTaskData;
+  }): Promise<Reservation>;
+  prepareWorkspace(input: {
+    taskRunId: string;
+    authoritySpaceId: string;
+    disposableSpaceId: string;
+    inputBundle: IsolatedWorkerDispatchTaskData["inputBundle"];
+  }): Promise<{ inputsMaterializedAt: string; preparedWorkspace: string }>;
+  cleanupPreparedWorkspace(input: { preparedWorkspace: string }): Promise<void>;
+  allocateReservation(input: {
+    taskRunId: string;
+    userId: string;
+    data: IsolatedWorkerDispatchTaskData;
+    inputsMaterializedAt: string;
+    preparedWorkspace: string;
+  }): Promise<void>;
+  publishWorkspace(input: {
+    taskRunId: string;
+    disposableSpaceId: string;
+    preparedWorkspace: string;
+    inputsMaterializedAt: string;
+    data: IsolatedWorkerDispatchTaskData;
+  }): Promise<void>;
+  rollbackReservation(input: {
+    taskRunId: string;
+    disposableSpaceId: string;
+    sessionId: string;
+    preparedWorkspace: string;
+    cause: unknown;
+  }): Promise<void>;
+  submitInternal(input: {
+    dispatchTaskRunId: string;
+    authoritySpaceId: string;
+    disposableSpaceId: string;
+    sessionId: string;
+    userId: string;
+    clientMessageId: string;
+    content: IsolatedWorkerDispatchTaskData["content"];
+    source: string;
+    model: string | null;
+    provider: string | null;
+    policySha256: string;
+    inputBundle: IsolatedWorkerDispatchTaskData["inputBundle"];
+    inputsMaterializedAt: string;
+  }): Promise<{ turnId: string; podUid: string; policySha256: string; podCreatedAt: string }>;
+};
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+export function canonicalIsolatedWorkerJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalIsolatedWorkerJson).join(",")}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonicalIsolatedWorkerJson(record[key])}`).join(",")}}`;
+}
+
+function parseDispatchData(payload: TaskPayload): IsolatedWorkerDispatchTaskData {
+  const data = payload.data;
+  if (!isRecord(data)) throw new Error("isolated worker dispatch data is required");
+  const exact = {
+    creationPath: ISOLATED_WORKER_CREATION_PATH,
+    ordinarySandboxProvisioned: false,
+    terminatedSpaceReused: false,
+    credentialMode: "engine_scoped_dispatch_authority",
+    engineInternalSecretIssued: false,
+    publicPromptUsed: false,
+    checkpointAdapter: "trusted_production",
+  } as const;
+  for (const [field, expected] of Object.entries(exact)) {
+    if (data[field] !== expected) throw new Error(`isolated worker dispatch ${field} mismatch`);
+  }
+  for (const field of ["authoritySpaceId", "disposableSpaceId", "sessionId", "clientMessageId", "source"] as const) {
+    if (typeof data[field] !== "string" || !data[field].trim()) throw new Error(`isolated worker dispatch ${field} is required`);
+  }
+  if (!Array.isArray(data.content) || data.content.length === 0) throw new Error("isolated worker dispatch content is required");
+  if (typeof data.policySha256 !== "string" || !/^[a-f0-9]{64}$/.test(data.policySha256)) {
+    throw new Error("isolated worker dispatch policySha256 is malformed");
+  }
+  if (!isRecord(data.inputBundle) || typeof data.inputManifestSha256 !== "string" || data.inputBundle.inputManifestSha256 !== data.inputManifestSha256) {
+    throw new Error("isolated worker dispatch input bundle is invalid");
+  }
+  if (!Array.isArray(data.inputBundle.items) || data.inputBundle.items.length < 1 || data.inputBundle.items.length > 32) {
+    throw new Error("isolated worker dispatch input bundle items are invalid");
+  }
+  const manifestCanonical = canonicalIsolatedWorkerJson({
+    authorityCheckpointId: data.inputBundle.authorityCheckpointId,
+    authorityCheckpointCommit: data.inputBundle.authorityCheckpointCommit,
+    authorityTreeSha256: data.inputBundle.authorityTreeSha256,
+    items: data.inputBundle.items,
+  });
+  const manifestHash = createHash("sha256").update(manifestCanonical).digest("hex");
+  if (manifestHash !== data.inputManifestSha256 || data.inputBundle.runtimeAuthorityReadAllowed !== false) {
+    throw new Error("isolated worker dispatch input manifest hash mismatch");
+  }
+  if (data.model !== null && typeof data.model !== "string") throw new Error("isolated worker dispatch model is invalid");
+  if (data.provider !== null && typeof data.provider !== "string") throw new Error("isolated worker dispatch provider is invalid");
+  return data as unknown as IsolatedWorkerDispatchTaskData;
+}
+
+function classifyMaterializationFailure(message: string) {
+  if (message.includes("symlink") || message.includes("regular file")) return "input_symlink_forbidden";
+  if (message.includes("hash mismatch")) return "input_hash_mismatch";
+  if (message.includes("ENOENT") || message.includes("not found") || message.includes("undeclared")) return "input_undeclared";
+  if (message.includes("path") || message.includes("inputs/")) return "input_path_forbidden";
+  return "input_materialization_failed";
+}
+
+export function createIsolatedWorkerDispatchHandler(deps: IsolatedWorkerDispatchHandlerDependencies) {
+  const inFlight = new Map<string, Promise<void>>();
+  return async (input: DispatchInvocation) => {
+    const previous = inFlight.get(input.taskRunId) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => { release = resolve; });
+    const queued = previous.then(() => current);
+    inFlight.set(input.taskRunId, queued);
+    await previous;
+    try {
+    if (input.payload.type !== ISOLATED_WORKER_DISPATCH_TASK_TYPE) throw new Error("isolated worker dispatch task type mismatch");
+    if (!/^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/.test(input.taskRunId)) {
+      throw new Error("isolated worker dispatch TaskRun id is malformed");
+    }
+    const raw = input.payload.data;
+    if (isRecord(raw) && raw.reuseRejected === true) {
+      if (
+        typeof raw.disposableSpaceId !== "string"
+        || raw.reason !== "terminated_space_reuse_forbidden"
+        || raw.authoritySpaceId !== input.payload.spaceId
+      ) {
+        throw new Error("isolated worker reuse rejection binding mismatch");
+      }
+      throw new IsolatedWorkerDispatchRejectedError("terminated space reuse forbidden", {
+        disposableSpaceId: raw.disposableSpaceId,
+        rejected: true,
+        reason: "terminated_space_reuse_forbidden",
+      });
+    }
+    const data = parseDispatchData(input.payload);
+    if (
+      data.authoritySpaceId !== input.payload.spaceId
+      || data.sessionId !== input.payload.sessionId
+      || !input.payload.userId
+    ) {
+      throw new Error("isolated worker TaskRun binding mismatch");
+    }
+    const recovered = await deps.recoverReservation({
+      taskRunId: input.taskRunId,
+      authoritySpaceId: data.authoritySpaceId,
+      disposableSpaceId: data.disposableSpaceId,
+      sessionId: data.sessionId,
+      userId: input.payload.userId,
+      data,
+    });
+    if (recovered.state === "submitted") return recovered.result;
+    let materialized: { inputsMaterializedAt: string; preparedWorkspace: string };
+    if (recovered.state === "none") {
+      try {
+        materialized = await deps.prepareWorkspace({
+          taskRunId: input.taskRunId,
+          authoritySpaceId: data.authoritySpaceId,
+          disposableSpaceId: data.disposableSpaceId,
+          inputBundle: data.inputBundle,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new IsolatedWorkerDispatchRejectedError(message, {
+          disposableSpaceId: data.disposableSpaceId,
+          rejected: true,
+          reason: classifyMaterializationFailure(message),
+          podCreated: false,
+          disposableSpaceCreated: false,
+          authorityExecutionTokenIssued: false,
+        });
+      }
+    } else {
+      materialized = recovered;
+    }
+    if (recovered.state === "none" || recovered.state === "staged") {
+      try {
+        await deps.allocateReservation({
+          taskRunId: input.taskRunId,
+          userId: input.payload.userId,
+          data,
+          inputsMaterializedAt: materialized.inputsMaterializedAt,
+          preparedWorkspace: materialized.preparedWorkspace,
+        });
+      } catch (error) {
+        try {
+          await deps.cleanupPreparedWorkspace({ preparedWorkspace: materialized.preparedWorkspace });
+        } catch (cleanupError) {
+          throw new AggregateError([error, cleanupError], "isolated worker reservation and staging cleanup both failed");
+        }
+        throw error;
+      }
+    }
+    if (recovered.state !== "published") {
+      try {
+        await deps.publishWorkspace({
+          taskRunId: input.taskRunId,
+          disposableSpaceId: data.disposableSpaceId,
+          preparedWorkspace: materialized.preparedWorkspace,
+          inputsMaterializedAt: materialized.inputsMaterializedAt,
+          data,
+        });
+      } catch (error) {
+        try {
+          await deps.rollbackReservation({
+            taskRunId: input.taskRunId,
+            disposableSpaceId: data.disposableSpaceId,
+            sessionId: data.sessionId,
+            preparedWorkspace: materialized.preparedWorkspace,
+            cause: error,
+          });
+        } catch (rollbackError) {
+          throw new AggregateError([error, rollbackError], "isolated worker publish and reservation rollback both failed");
+        }
+        throw error;
+      }
+    }
+    const reservation = await deps.readReservation({
+      taskRunId: input.taskRunId,
+      authoritySpaceId: data.authoritySpaceId,
+      disposableSpaceId: data.disposableSpaceId,
+      sessionId: data.sessionId,
+      userId: input.payload.userId,
+      policySha256: data.policySha256,
+      dispatchData: data,
+    });
+    const allocation = reservation.allocation;
+    if (
+      reservation.authoritySpaceId !== data.authoritySpaceId
+      || reservation.disposableSpaceId !== data.disposableSpaceId
+      || reservation.sessionId !== data.sessionId
+      || reservation.userId !== input.payload.userId
+      || reservation.sandboxStatus !== "allocated"
+      || reservation.sandboxPodName !== null
+      || allocation?.state !== "allocated"
+      || allocation.authoritySpaceId !== data.authoritySpaceId
+      || allocation.disposableSpaceId !== data.disposableSpaceId
+      || allocation.resumable !== false
+      || canonicalIsolatedWorkerJson(allocation.inputBundle) !== canonicalIsolatedWorkerJson(data.inputBundle)
+    ) {
+      throw new Error("disposable worker reservation is not an unused allocated space");
+    }
+    const submitted = await deps.submitInternal({
+      dispatchTaskRunId: input.taskRunId,
+      authoritySpaceId: data.authoritySpaceId,
+      disposableSpaceId: data.disposableSpaceId,
+      sessionId: data.sessionId,
+      userId: input.payload.userId,
+      clientMessageId: data.clientMessageId,
+      content: data.content,
+      source: data.source,
+      model: data.model,
+      provider: data.provider,
+      policySha256: data.policySha256,
+      inputBundle: data.inputBundle,
+      inputsMaterializedAt: materialized.inputsMaterializedAt,
+    });
+    if (!submitted.turnId || !submitted.podUid || submitted.policySha256 !== data.policySha256) {
+      throw new Error("isolated worker internal prompt response binding mismatch");
+    }
+    const materializedAt = Date.parse(materialized.inputsMaterializedAt);
+    const podCreatedAt = Date.parse(submitted.podCreatedAt);
+    if (!Number.isFinite(materializedAt) || !Number.isFinite(podCreatedAt) || materializedAt >= podCreatedAt) {
+      throw new Error("isolated worker input materialization did not precede Pod creation");
+    }
+    return {
+      authoritySpaceId: data.authoritySpaceId,
+      disposableSpaceId: data.disposableSpaceId,
+      sessionId: data.sessionId,
+      turnId: submitted.turnId,
+      podUid: submitted.podUid,
+      policySha256: data.policySha256,
+      authorityCheckpointId: data.inputBundle.authorityCheckpointId,
+      authorityCheckpointCommit: data.inputBundle.authorityCheckpointCommit,
+      authorityTreeSha256: data.inputBundle.authorityTreeSha256,
+      inputManifestSha256: data.inputManifestSha256,
+      inputCount: data.inputBundle.items.length,
+      inputsMaterializedAt: materialized.inputsMaterializedAt,
+      podCreatedAt: submitted.podCreatedAt,
+      ordinarySandboxProvisioned: false,
+      terminatedSpaceReused: false,
+      executionTokenIssued: false,
+      authorityExecutionTokenIssued: false,
+      engineInternalSecretIssued: false,
+      publicPromptUsed: false,
+      checkpointAdapterReady: true,
+    };
+    } finally {
+      release();
+      if (inFlight.get(input.taskRunId) === queued) inFlight.delete(input.taskRunId);
+    }
+  };
+}

--- a/apps/worker/src/tasks/isolated-worker-dispatch-handler.ts
+++ b/apps/worker/src/tasks/isolated-worker-dispatch-handler.ts
@@ -105,9 +105,53 @@ export function canonicalIsolatedWorkerJson(value: unknown): string {
   return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonicalIsolatedWorkerJson(record[key])}`).join(",")}}`;
 }
 
+const DISPATCH_DATA_FIELDS = new Set([
+  "authoritySpaceId",
+  "disposableSpaceId",
+  "sessionId",
+  "clientMessageId",
+  "content",
+  "source",
+  "model",
+  "provider",
+  "policySha256",
+  "inputBundle",
+  "inputManifestSha256",
+  "creationPath",
+  "ordinarySandboxProvisioned",
+  "terminatedSpaceReused",
+  "credentialMode",
+  "engineInternalSecretIssued",
+  "publicPromptUsed",
+  "checkpointAdapter",
+  "repairOfDisposableSpaceId",
+]);
+
+const INPUT_BUNDLE_FIELDS = new Set([
+  "authorityCheckpointId",
+  "authorityCheckpointCommit",
+  "authorityTreeSha256",
+  "inputManifestSha256",
+  "runtimeAuthorityReadAllowed",
+  "items",
+]);
+
+const INPUT_ITEM_FIELDS = new Set([
+  "sourcePath",
+  "destinationPath",
+  "contentSha256",
+  "sourceType",
+]);
+
+function assertExactKeys(value: Record<string, unknown>, allowed: Set<string>, label: string) {
+  const unknownField = Object.keys(value).find((key) => !allowed.has(key));
+  if (unknownField) throw new Error(`${label} contains unknown field: ${unknownField}`);
+}
+
 function parseDispatchData(payload: TaskPayload): IsolatedWorkerDispatchTaskData {
   const data = payload.data;
   if (!isRecord(data)) throw new Error("isolated worker dispatch data is required");
+  assertExactKeys(data, DISPATCH_DATA_FIELDS, "isolated worker dispatch");
   const exact = {
     creationPath: ISOLATED_WORKER_CREATION_PATH,
     ordinarySandboxProvisioned: false,
@@ -127,11 +171,26 @@ function parseDispatchData(payload: TaskPayload): IsolatedWorkerDispatchTaskData
   if (typeof data.policySha256 !== "string" || !/^[a-f0-9]{64}$/.test(data.policySha256)) {
     throw new Error("isolated worker dispatch policySha256 is malformed");
   }
-  if (!isRecord(data.inputBundle) || typeof data.inputManifestSha256 !== "string" || data.inputBundle.inputManifestSha256 !== data.inputManifestSha256) {
+  if (!isRecord(data.inputBundle)) throw new Error("isolated worker dispatch input bundle is invalid");
+  assertExactKeys(data.inputBundle, INPUT_BUNDLE_FIELDS, "isolated worker input bundle");
+  if (typeof data.inputManifestSha256 !== "string" || data.inputBundle.inputManifestSha256 !== data.inputManifestSha256) {
     throw new Error("isolated worker dispatch input bundle is invalid");
   }
   if (!Array.isArray(data.inputBundle.items) || data.inputBundle.items.length < 1 || data.inputBundle.items.length > 32) {
     throw new Error("isolated worker dispatch input bundle items are invalid");
+  }
+  for (const item of data.inputBundle.items) {
+    if (!isRecord(item)) throw new Error("isolated worker input item is invalid");
+    assertExactKeys(item, INPUT_ITEM_FIELDS, "isolated worker input item");
+    if (
+      typeof item.sourcePath !== "string"
+      || typeof item.destinationPath !== "string"
+      || typeof item.contentSha256 !== "string"
+      || !/^[a-f0-9]{64}$/.test(item.contentSha256)
+      || item.sourceType !== "regular_file"
+    ) {
+      throw new Error("isolated worker input item is invalid");
+    }
   }
   const manifestCanonical = canonicalIsolatedWorkerJson({
     authorityCheckpointId: data.inputBundle.authorityCheckpointId,
@@ -172,6 +231,7 @@ export function createIsolatedWorkerDispatchHandler(deps: IsolatedWorkerDispatch
     }
     const raw = input.payload.data;
     if (isRecord(raw) && raw.reuseRejected === true) {
+      assertExactKeys(raw, new Set(["authoritySpaceId", "disposableSpaceId", "reuseRejected", "reason"]), "isolated worker reuse rejection");
       if (
         typeof raw.disposableSpaceId !== "string"
         || raw.reason !== "terminated_space_reuse_forbidden"

--- a/apps/worker/src/tasks/isolated-worker-dispatch-task.test.ts
+++ b/apps/worker/src/tasks/isolated-worker-dispatch-task.test.ts
@@ -146,6 +146,37 @@ assert.deepEqual(await recoveredHandler({
 }), result);
 assert.deepEqual(recoveredCalls, ["recover-submitted"]);
 
+await assert.rejects(
+  handler({
+    taskRunId: "77777777-7777-4777-8777-777777777777",
+    payload: {
+      type: "isolated_worker_dispatch",
+      spaceId: authoritySpaceId,
+      sessionId,
+      userId: "user-1",
+      data: { ...dispatchData, callerForgedReceipt: "accepted" },
+    },
+  }),
+  /isolated worker dispatch contains unknown field: callerForgedReceipt/,
+);
+
+await assert.rejects(
+  handler({
+    taskRunId: "88888888-8888-4888-8888-888888888888",
+    payload: {
+      type: "isolated_worker_dispatch",
+      spaceId: authoritySpaceId,
+      sessionId,
+      userId: "user-1",
+      data: {
+        ...dispatchData,
+        inputBundle: { ...inputBundle, callerForgedAuthority: true },
+      },
+    },
+  }),
+  /isolated worker input bundle contains unknown field: callerForgedAuthority/,
+);
+
 const reject = createIsolatedWorkerDispatchHandler({
   async recoverReservation() {
     throw new Error("must not recover a terminated workspace");

--- a/apps/worker/src/tasks/isolated-worker-dispatch-task.test.ts
+++ b/apps/worker/src/tasks/isolated-worker-dispatch-task.test.ts
@@ -1,0 +1,465 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  createIsolatedWorkerDispatchHandler,
+  IsolatedWorkerDispatchRejectedError,
+} from "./isolated-worker-dispatch-handler.js";
+
+const taskRunId = "33333333-3333-4333-8333-333333333333";
+const authoritySpaceId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const disposableSpaceId = "11111111-1111-4111-8111-111111111111";
+const sessionId = "22222222-2222-4222-8222-222222222222";
+const policySha256 = "a".repeat(64);
+const inputBundleManifest = {
+  authorityCheckpointId: "99999999-9999-4999-8999-999999999999",
+  authorityCheckpointCommit: "c".repeat(40),
+  authorityTreeSha256: "e".repeat(64),
+  items: [{ sourcePath: "modules/task.md", destinationPath: "inputs/task.md", contentSha256: "f".repeat(64), sourceType: "regular_file" as const }],
+};
+const canonical = (value: unknown): string => value === null || typeof value !== "object"
+  ? JSON.stringify(value)
+  : Array.isArray(value)
+    ? `[${value.map(canonical).join(",")}]`
+    : `{${Object.keys(value as Record<string, unknown>).sort().map((key) => `${JSON.stringify(key)}:${canonical((value as Record<string, unknown>)[key])}`).join(",")}}`;
+const inputManifestSha256 = createHash("sha256").update(canonical(inputBundleManifest)).digest("hex");
+const inputBundle = { ...inputBundleManifest, inputManifestSha256, runtimeAuthorityReadAllowed: false as const };
+const dispatchData = {
+  authoritySpaceId,
+  disposableSpaceId,
+  sessionId,
+  clientMessageId: "client-1",
+  content: [{ type: "text" as const, text: "hello" }],
+  source: "isolated_worker_dispatch",
+  model: null,
+  provider: null,
+  policySha256,
+  inputBundle,
+  inputManifestSha256,
+  creationPath: "dedicated_disposable_space_without_standard_sandbox" as const,
+  ordinarySandboxProvisioned: false as const,
+  terminatedSpaceReused: false as const,
+  credentialMode: "engine_scoped_dispatch_authority" as const,
+  engineInternalSecretIssued: false as const,
+  publicPromptUsed: false as const,
+  checkpointAdapter: "trusted_production" as const,
+};
+const calls: string[] = [];
+
+const handler = createIsolatedWorkerDispatchHandler({
+  async recoverReservation() {
+    calls.push("recover");
+    return { state: "none" };
+  },
+  async readReservation() {
+    calls.push("read");
+    return {
+      authoritySpaceId,
+      disposableSpaceId,
+      sessionId,
+      userId: "user-1",
+      sandboxStatus: "allocated",
+      sandboxPodName: null,
+      allocation: { state: "allocated", authoritySpaceId, disposableSpaceId, inputBundle, resumable: false },
+    };
+  },
+  async prepareWorkspace(input) {
+    calls.push(`prepare:${input.disposableSpaceId}`);
+    return { inputsMaterializedAt: "2026-07-15T00:00:00.000Z", preparedWorkspace: "/stage" };
+  },
+  async cleanupPreparedWorkspace() {
+    calls.push("unexpected-cleanup");
+  },
+  async allocateReservation(input) {
+    calls.push(`allocate:${input.data.disposableSpaceId}`);
+  },
+  async publishWorkspace() {
+    calls.push("publish");
+  },
+  async rollbackReservation() {
+    calls.push("unexpected-rollback");
+  },
+  async submitInternal(input) {
+    calls.push(`submit:${input.dispatchTaskRunId}`);
+    assert.equal("authToken" in input, false);
+    assert.equal("workerSecret" in input, false);
+    return { turnId: "44444444-4444-4444-8444-444444444444", podUid: "pod-uid-1", policySha256, podCreatedAt: "2026-07-15T00:00:01.000Z" };
+  },
+});
+
+const result = await handler({
+  taskRunId,
+  payload: {
+    type: "isolated_worker_dispatch",
+    spaceId: authoritySpaceId,
+    sessionId,
+    userId: "user-1",
+    data: dispatchData,
+  },
+});
+assert.deepEqual(calls, ["recover", `prepare:${disposableSpaceId}`, `allocate:${disposableSpaceId}`, "publish", "read", `submit:${taskRunId}`]);
+assert.deepEqual(result, {
+  authoritySpaceId,
+  disposableSpaceId,
+  sessionId,
+  turnId: "44444444-4444-4444-8444-444444444444",
+  podUid: "pod-uid-1",
+  policySha256,
+  authorityCheckpointId: inputBundle.authorityCheckpointId,
+  authorityCheckpointCommit: inputBundle.authorityCheckpointCommit,
+  authorityTreeSha256: inputBundle.authorityTreeSha256,
+  inputManifestSha256,
+  inputCount: 1,
+  inputsMaterializedAt: "2026-07-15T00:00:00.000Z",
+  podCreatedAt: "2026-07-15T00:00:01.000Z",
+  ordinarySandboxProvisioned: false,
+  terminatedSpaceReused: false,
+  executionTokenIssued: false,
+  authorityExecutionTokenIssued: false,
+  engineInternalSecretIssued: false,
+  publicPromptUsed: false,
+  checkpointAdapterReady: true,
+});
+
+const recoveredCalls: string[] = [];
+const recoveredHandler = createIsolatedWorkerDispatchHandler({
+  async recoverReservation() {
+    recoveredCalls.push("recover-submitted");
+    return { state: "submitted", result };
+  },
+  async readReservation() { throw new Error("submitted retry must not read allocation"); },
+  async prepareWorkspace() { throw new Error("submitted retry must not rematerialize inputs"); },
+  async cleanupPreparedWorkspace() { throw new Error("submitted retry must not clean workspace"); },
+  async allocateReservation() { throw new Error("submitted retry must not allocate"); },
+  async publishWorkspace() { throw new Error("submitted retry must not publish"); },
+  async rollbackReservation() { throw new Error("submitted retry must not roll back"); },
+  async submitInternal() { throw new Error("submitted retry must not submit a second prompt"); },
+});
+assert.deepEqual(await recoveredHandler({
+  taskRunId,
+  payload: {
+    type: "isolated_worker_dispatch",
+    spaceId: authoritySpaceId,
+    sessionId,
+    userId: "user-1",
+    data: dispatchData,
+  },
+}), result);
+assert.deepEqual(recoveredCalls, ["recover-submitted"]);
+
+const reject = createIsolatedWorkerDispatchHandler({
+  async recoverReservation() {
+    throw new Error("must not recover a terminated workspace");
+  },
+  async readReservation() {
+    throw new Error("must not read a reusable allocation");
+  },
+  async prepareWorkspace() {
+    throw new Error("must not prepare a terminated workspace");
+  },
+  async cleanupPreparedWorkspace() {
+    throw new Error("must not clean a terminated workspace");
+  },
+  async allocateReservation() {
+    throw new Error("must not allocate a terminated workspace");
+  },
+  async publishWorkspace() {
+    throw new Error("must not publish a terminated workspace");
+  },
+  async rollbackReservation() {
+    throw new Error("must not roll back a terminated workspace");
+  },
+  async submitInternal() {
+    throw new Error("must not submit a terminated worker");
+  },
+});
+await assert.rejects(
+  reject({
+    taskRunId: "55555555-5555-4555-8555-555555555555",
+    payload: {
+      type: "isolated_worker_dispatch",
+      spaceId: authoritySpaceId,
+      sessionId,
+      userId: "user-1",
+      data: {
+        authoritySpaceId,
+        disposableSpaceId,
+        reuseRejected: true,
+        reason: "terminated_space_reuse_forbidden",
+      },
+    },
+  }),
+  (error: unknown) => {
+    assert.ok(error instanceof IsolatedWorkerDispatchRejectedError);
+    assert.deepEqual(error.taskResult, { disposableSpaceId, rejected: true, reason: "terminated_space_reuse_forbidden" });
+    return true;
+  },
+);
+
+for (const probe of [
+  { message: "manifest source is not a regular file: link", reason: "input_symlink_forbidden" },
+  { message: "input hash mismatch: modules/task.md", reason: "input_hash_mismatch" },
+  { message: "unsafe manifest path: ../secret", reason: "input_path_forbidden" },
+  { message: "ENOENT: no such file or directory", reason: "input_undeclared" },
+] as const) {
+  const failureCalls: string[] = [];
+  const rejectInput = createIsolatedWorkerDispatchHandler({
+    async recoverReservation() {
+      failureCalls.push("recover");
+      return { state: "none" };
+    },
+    async prepareWorkspace() {
+      failureCalls.push("prepare");
+      throw new Error(probe.message);
+    },
+    async cleanupPreparedWorkspace() {
+      failureCalls.push("cleanup");
+    },
+    async allocateReservation() {
+      failureCalls.push("allocate");
+    },
+    async publishWorkspace() {
+      failureCalls.push("publish");
+    },
+    async rollbackReservation() {
+      failureCalls.push("rollback");
+    },
+    async readReservation() {
+      failureCalls.push("read");
+      throw new Error("must not read after failed preflight");
+    },
+    async submitInternal() {
+      failureCalls.push("submit");
+      throw new Error("must not submit after failed preflight");
+    },
+  });
+  await assert.rejects(
+    rejectInput({
+      taskRunId,
+      payload: {
+        type: "isolated_worker_dispatch",
+        spaceId: authoritySpaceId,
+        sessionId,
+        userId: "user-1",
+        data: dispatchData,
+      },
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof IsolatedWorkerDispatchRejectedError);
+      assert.deepEqual(error.taskResult, {
+        disposableSpaceId,
+        rejected: true,
+        reason: probe.reason,
+        podCreated: false,
+        disposableSpaceCreated: false,
+        authorityExecutionTokenIssued: false,
+      });
+      return true;
+    },
+  );
+  assert.deepEqual(failureCalls, ["recover", "prepare"]);
+}
+
+const allocationFailureCalls: string[] = [];
+const allocationFailure = createIsolatedWorkerDispatchHandler({
+  async recoverReservation() {
+    allocationFailureCalls.push("recover");
+    return { state: "none" };
+  },
+  async prepareWorkspace() {
+    allocationFailureCalls.push("prepare");
+    return { inputsMaterializedAt: "2026-07-15T00:00:00.000Z", preparedWorkspace: "/stage" };
+  },
+  async cleanupPreparedWorkspace() {
+    allocationFailureCalls.push("cleanup");
+  },
+  async allocateReservation() {
+    allocationFailureCalls.push("allocate");
+    throw new Error("allocation kill point");
+  },
+  async publishWorkspace() {
+    allocationFailureCalls.push("publish");
+  },
+  async rollbackReservation() {
+    allocationFailureCalls.push("rollback");
+  },
+  async readReservation() {
+    allocationFailureCalls.push("read");
+    throw new Error("must not read after allocation failure");
+  },
+  async submitInternal() {
+    allocationFailureCalls.push("submit");
+    throw new Error("must not submit after allocation failure");
+  },
+});
+await assert.rejects(
+  allocationFailure({
+    taskRunId,
+    payload: { type: "isolated_worker_dispatch", spaceId: authoritySpaceId, sessionId, userId: "user-1", data: dispatchData },
+  }),
+  /allocation kill point/,
+);
+assert.deepEqual(allocationFailureCalls, ["recover", "prepare", "allocate", "cleanup"]);
+
+const publishFailureCalls: string[] = [];
+const publishFailure = createIsolatedWorkerDispatchHandler({
+  async recoverReservation() {
+    publishFailureCalls.push("recover");
+    return { state: "none" };
+  },
+  async prepareWorkspace() {
+    publishFailureCalls.push("prepare");
+    return { inputsMaterializedAt: "2026-07-15T00:00:00.000Z", preparedWorkspace: "/stage" };
+  },
+  async cleanupPreparedWorkspace() {
+    publishFailureCalls.push("cleanup");
+  },
+  async allocateReservation() {
+    publishFailureCalls.push("allocate");
+  },
+  async publishWorkspace() {
+    publishFailureCalls.push("publish");
+    throw new Error("publish kill point");
+  },
+  async rollbackReservation() {
+    publishFailureCalls.push("rollback");
+  },
+  async readReservation() {
+    publishFailureCalls.push("read");
+    throw new Error("must not read after publish failure");
+  },
+  async submitInternal() {
+    publishFailureCalls.push("submit");
+    throw new Error("must not submit after publish failure");
+  },
+});
+await assert.rejects(
+  publishFailure({
+    taskRunId,
+    payload: { type: "isolated_worker_dispatch", spaceId: authoritySpaceId, sessionId, userId: "user-1", data: dispatchData },
+  }),
+  /publish kill point/,
+);
+assert.deepEqual(publishFailureCalls, ["recover", "prepare", "allocate", "publish", "rollback"]);
+
+for (const recoveryState of ["staged", "prepared", "published"] as const) {
+  const recoveryCalls: string[] = [];
+  const recovery = createIsolatedWorkerDispatchHandler({
+    async recoverReservation() {
+      recoveryCalls.push("recover");
+      return {
+        state: recoveryState,
+        inputsMaterializedAt: "2026-07-15T00:00:00.000Z",
+        preparedWorkspace: "/stage",
+      };
+    },
+    async prepareWorkspace() {
+      recoveryCalls.push("prepare");
+      throw new Error("recovery must not rematerialize inputs");
+    },
+    async cleanupPreparedWorkspace() {
+      recoveryCalls.push("cleanup");
+    },
+    async allocateReservation() {
+      recoveryCalls.push("allocate");
+    },
+    async publishWorkspace() {
+      recoveryCalls.push("publish");
+    },
+    async rollbackReservation() {
+      recoveryCalls.push("rollback");
+    },
+    async readReservation() {
+      recoveryCalls.push("read");
+      return {
+        authoritySpaceId,
+        disposableSpaceId,
+        sessionId,
+        userId: "user-1",
+        sandboxStatus: "allocated",
+        sandboxPodName: null,
+        allocation: { state: "allocated", authoritySpaceId, disposableSpaceId, inputBundle, resumable: false },
+      };
+    },
+    async submitInternal() {
+      recoveryCalls.push("submit");
+      return {
+        turnId: "44444444-4444-4444-8444-444444444444",
+        podUid: "pod-uid-1",
+        policySha256,
+        podCreatedAt: "2026-07-15T00:00:01.000Z",
+      };
+    },
+  });
+  await recovery({
+    taskRunId,
+    payload: { type: "isolated_worker_dispatch", spaceId: authoritySpaceId, sessionId, userId: "user-1", data: dispatchData },
+  });
+  assert.deepEqual(
+    recoveryCalls,
+    recoveryState === "staged"
+      ? ["recover", "allocate", "publish", "read", "submit"]
+      : recoveryState === "prepared"
+        ? ["recover", "publish", "read", "submit"]
+        : ["recover", "read", "submit"],
+  );
+}
+
+let concurrentPhase: "none" | "prepared" | "published" = "none";
+let prepareCount = 0;
+let allocateCount = 0;
+let publishCount = 0;
+const concurrent = createIsolatedWorkerDispatchHandler({
+  async recoverReservation() {
+    if (concurrentPhase === "none") return { state: "none" };
+    return {
+      state: concurrentPhase,
+      inputsMaterializedAt: "2026-07-15T00:00:00.000Z",
+      preparedWorkspace: "/stage",
+    };
+  },
+  async prepareWorkspace() {
+    prepareCount += 1;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    return { inputsMaterializedAt: "2026-07-15T00:00:00.000Z", preparedWorkspace: "/stage" };
+  },
+  async cleanupPreparedWorkspace() {},
+  async allocateReservation() {
+    allocateCount += 1;
+    concurrentPhase = "prepared";
+  },
+  async publishWorkspace() {
+    publishCount += 1;
+    concurrentPhase = "published";
+  },
+  async rollbackReservation() {},
+  async readReservation() {
+    return {
+      authoritySpaceId,
+      disposableSpaceId,
+      sessionId,
+      userId: "user-1",
+      sandboxStatus: "allocated",
+      sandboxPodName: null,
+      allocation: { state: "allocated", authoritySpaceId, disposableSpaceId, inputBundle, resumable: false },
+    };
+  },
+  async submitInternal() {
+    return {
+      turnId: "44444444-4444-4444-8444-444444444444",
+      podUid: "pod-uid-1",
+      policySha256,
+      podCreatedAt: "2026-07-15T00:00:01.000Z",
+    };
+  },
+});
+const concurrentPayload = { type: "isolated_worker_dispatch" as const, spaceId: authoritySpaceId, sessionId, userId: "user-1", data: dispatchData };
+const [firstConcurrent, secondConcurrent] = await Promise.all([
+  concurrent({ taskRunId, payload: concurrentPayload }),
+  concurrent({ taskRunId, payload: concurrentPayload }),
+]);
+assert.deepEqual(firstConcurrent, secondConcurrent);
+assert.equal(prepareCount, 1);
+assert.equal(allocateCount, 1);
+assert.equal(publishCount, 1);
+
+console.log("isolated worker dispatch task checks passed");

--- a/apps/worker/src/tasks/isolated-worker-dispatch-task.ts
+++ b/apps/worker/src/tasks/isolated-worker-dispatch-task.ts
@@ -519,7 +519,6 @@ const productionDependencies: IsolatedWorkerDispatchHandlerDependencies = {
             executionTokenIssued: false,
             policySha256: input.policySha256,
           },
-          inputBundle: input.inputBundle,
           inputsMaterializedAt: input.inputsMaterializedAt,
           dispatchTaskRunId: input.dispatchTaskRunId,
           context: { kind: "scheduled_task", taskRunId: input.dispatchTaskRunId },

--- a/apps/worker/src/tasks/isolated-worker-dispatch-task.ts
+++ b/apps/worker/src/tasks/isolated-worker-dispatch-task.ts
@@ -1,0 +1,545 @@
+import { lstat, mkdir, readdir, rename, rm } from "node:fs/promises";
+import { dirname } from "node:path";
+import { and, eq } from "drizzle-orm";
+import type { TaskPayload } from "@cohub/protocol/task";
+import {
+  ISOLATED_WORKER_DISPATCH_TASK_TYPE,
+} from "@cohub/protocol/isolated-worker";
+import { spaces, spaceMembers, spaceSandboxes, spaceSessions, sessionTurnSegments, sessionTurns, taskRuns } from "@cohub/db";
+import { db } from "../db.js";
+import { config } from "../config.js";
+import { getSpaceWorkspaceDir } from "../git.js";
+import { restoreWorkspaceFromCheckpoint } from "../checkpoint/restore.js";
+import { ensureWorkerLocalTmpDir, getWorkerLocalTmpDir, removeWorkerLocalTmpDir } from "../local-tmp.js";
+import { materializeFrozenInputManifest, verifyFrozenInputMaterialization } from "../isolated-worker-inputs.js";
+import { registerTask } from "./registry.js";
+import {
+  canonicalIsolatedWorkerJson,
+  createIsolatedWorkerDispatchHandler,
+  isRecord,
+  type IsolatedWorkerDispatchHandlerDependencies,
+} from "./isolated-worker-dispatch-handler.js";
+
+export {
+  createIsolatedWorkerDispatchHandler,
+  IsolatedWorkerDispatchRejectedError,
+} from "./isolated-worker-dispatch-handler.js";
+
+const preparedWorkspacePath = (taskRunId: string) =>
+  `${config.spaceStorageRoot}/.isolated-worker-staging/${taskRunId}`;
+
+class IsolatedWorkerPublishError extends Error {
+  readonly spaceBaseCreated: boolean;
+
+  constructor(cause: unknown, spaceBaseCreated: boolean) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+    this.name = "IsolatedWorkerPublishError";
+    this.spaceBaseCreated = spaceBaseCreated;
+  }
+}
+
+async function throwWithCleanup(primary: unknown, cleanups: Array<() => Promise<void>>, message: string): Promise<never> {
+  const errors = [primary];
+  for (const cleanup of cleanups) {
+    try {
+      await cleanup();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 1) throw new AggregateError(errors, message);
+  throw primary;
+}
+
+async function pathExists(path: string) {
+  return lstat(path).then(() => true).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return false;
+    throw error;
+  });
+}
+
+const productionDependencies: IsolatedWorkerDispatchHandlerDependencies = {
+  async recoverReservation(input) {
+    const preparedWorkspace = preparedWorkspacePath(input.taskRunId);
+    const finalWorkspace = getSpaceWorkspaceDir(input.disposableSpaceId);
+    const [row] = await db.select({ space: spaces, sandbox: spaceSandboxes, session: spaceSessions })
+      .from(spaces)
+      .innerJoin(spaceSandboxes, eq(spaceSandboxes.spaceId, spaces.id))
+      .innerJoin(spaceSessions, and(eq(spaceSessions.id, input.sessionId), eq(spaceSessions.spaceId, spaces.id)))
+      .where(eq(spaces.id, input.disposableSpaceId))
+      .limit(1);
+    const preparedExists = await pathExists(preparedWorkspace);
+    const finalExists = await pathExists(finalWorkspace);
+    if (!row) {
+      if (finalExists) throw new Error("isolated worker final workspace exists without reservation");
+      if (!preparedExists) return { state: "none" as const };
+      try {
+        await verifyFrozenInputMaterialization({ targetRoot: preparedWorkspace, inputBundle: input.data.inputBundle });
+      } catch (error) {
+        await throwWithCleanup(error, [() => rm(preparedWorkspace, { recursive: true, force: true })], "isolated worker abandoned staging validation and cleanup failed");
+      }
+      return { state: "staged" as const, inputsMaterializedAt: new Date().toISOString(), preparedWorkspace };
+    }
+    const meta = isRecord(row.sandbox.meta) ? row.sandbox.meta : null;
+    const allocation = meta && isRecord(meta.isolatedWorker) ? meta.isolatedWorker : null;
+    const sessionMeta = isRecord(row.session.meta) ? row.session.meta : null;
+    if (row.sandbox.status !== "allocated") {
+      const policy = meta && isRecord(meta.isolatedWorkerPolicy) ? meta.isolatedWorkerPolicy : null;
+      const boundTurnId = typeof meta?.turnId === "string" ? meta.turnId : null;
+      const [turn] = boundTurnId
+        ? await db.select().from(sessionTurns).where(and(
+            eq(sessionTurns.id, boundTurnId),
+            eq(sessionTurns.sessionId, input.sessionId),
+          )).limit(1)
+        : [];
+      const turnMeta = isRecord(turn?.meta) ? turn.meta : null;
+      const dispatch = turnMeta && isRecord(turnMeta.isolatedWorkerDispatch) ? turnMeta.isolatedWorkerDispatch : null;
+      const handle = turnMeta && isRecord(turnMeta.isolatedWorker) ? turnMeta.isolatedWorker : null;
+      const handlePolicy = handle && isRecord(handle.isolatedWorkerPolicy) ? handle.isolatedWorkerPolicy : null;
+      if (
+        !turn
+        || sessionMeta?.dispatchTaskRunId !== input.taskRunId
+        || sessionMeta.authoritySpaceId !== input.authoritySpaceId
+        || meta?.sessionId !== input.sessionId
+        || meta.turnId !== turn.id
+        || policy?.authoritySpaceId !== input.authoritySpaceId
+        || policy.disposableSpaceId !== input.disposableSpaceId
+        || policy.policySha256 !== input.data.policySha256
+        || handle?.sessionId !== input.sessionId
+        || handle.turnId !== turn.id
+        || handlePolicy?.podUid !== policy.podUid
+        || dispatch?.taskRunId !== input.taskRunId
+        || dispatch.authoritySpaceId !== input.authoritySpaceId
+        || dispatch.disposableSpaceId !== input.disposableSpaceId
+        || dispatch.inputManifestSha256 !== input.data.inputManifestSha256
+        || canonicalIsolatedWorkerJson(dispatch.inputBundle) !== canonicalIsolatedWorkerJson(input.data.inputBundle)
+        || typeof dispatch.inputsMaterializedAt !== "string"
+        || typeof dispatch.podCreatedAt !== "string"
+        || Date.parse(dispatch.inputsMaterializedAt) >= Date.parse(dispatch.podCreatedAt)
+      ) {
+        throw new Error("isolated worker submitted recovery binding mismatch");
+      }
+      return {
+        state: "submitted" as const,
+        result: {
+          authoritySpaceId: input.data.authoritySpaceId,
+          disposableSpaceId: input.data.disposableSpaceId,
+          sessionId: input.data.sessionId,
+          turnId: turn.id,
+          podUid: String(policy.podUid),
+          policySha256: input.data.policySha256,
+          authorityCheckpointId: input.data.inputBundle.authorityCheckpointId,
+          authorityCheckpointCommit: input.data.inputBundle.authorityCheckpointCommit,
+          authorityTreeSha256: input.data.inputBundle.authorityTreeSha256,
+          inputManifestSha256: input.data.inputManifestSha256,
+          inputCount: input.data.inputBundle.items.length,
+          inputsMaterializedAt: dispatch.inputsMaterializedAt,
+          podCreatedAt: dispatch.podCreatedAt,
+          ordinarySandboxProvisioned: false,
+          terminatedSpaceReused: false,
+          executionTokenIssued: false,
+          authorityExecutionTokenIssued: false,
+          engineInternalSecretIssued: false,
+          publicPromptUsed: false,
+          checkpointAdapterReady: true,
+        },
+      };
+    }
+    if (
+      row.space.userUuid !== input.userId
+      || row.session.userUuid !== input.userId
+      || row.session.source !== "isolated_worker_dispatch"
+      || sessionMeta?.dispatchTaskRunId !== input.taskRunId
+      || sessionMeta.authoritySpaceId !== input.authoritySpaceId
+      || allocation?.authoritySpaceId !== input.authoritySpaceId
+      || allocation.disposableSpaceId !== input.disposableSpaceId
+      || allocation.dispatchTaskRunId !== input.taskRunId
+      || allocation.policySha256 !== input.data.policySha256
+      || allocation.creationPath !== input.data.creationPath
+      || allocation.ordinarySandboxProvisioned !== false
+      || allocation.terminatedSpaceReused !== false
+      || allocation.credentialMode !== input.data.credentialMode
+      || allocation.engineInternalSecretIssued !== false
+      || allocation.publicPromptUsed !== false
+      || allocation.authorityExecutionTokenIssued !== false
+      || allocation.runtimeAuthorityReadAllowed !== false
+      || allocation.authorityCheckpointId !== input.data.inputBundle.authorityCheckpointId
+      || allocation.authorityCheckpointCommit !== input.data.inputBundle.authorityCheckpointCommit
+      || allocation.authorityTreeSha256 !== input.data.inputBundle.authorityTreeSha256
+      || allocation.inputManifestSha256 !== input.data.inputManifestSha256
+      || allocation.inputCount !== input.data.inputBundle.items.length
+      || allocation.preparedWorkspace !== preparedWorkspace
+      || canonicalIsolatedWorkerJson(allocation.inputBundle) !== canonicalIsolatedWorkerJson(input.data.inputBundle)
+      || typeof allocation.inputsMaterializedAt !== "string"
+    ) {
+      throw new Error("isolated worker recovery reservation binding mismatch");
+    }
+    if (allocation.state === "prepared") {
+      if (preparedExists === finalExists) throw new Error("isolated worker prepared recovery filesystem phase mismatch");
+      await verifyFrozenInputMaterialization({
+        targetRoot: preparedExists ? preparedWorkspace : finalWorkspace,
+        inputBundle: input.data.inputBundle,
+      });
+      return { state: "prepared" as const, inputsMaterializedAt: allocation.inputsMaterializedAt, preparedWorkspace };
+    }
+    if (allocation.state === "allocated") {
+      if (preparedExists || !finalExists) throw new Error("isolated worker published recovery filesystem phase mismatch");
+      await verifyFrozenInputMaterialization({ targetRoot: finalWorkspace, inputBundle: input.data.inputBundle });
+      return { state: "published" as const, inputsMaterializedAt: allocation.inputsMaterializedAt, preparedWorkspace };
+    }
+    throw new Error("isolated worker reservation is not recoverable");
+  },
+  async readReservation(input) {
+    const [row] = await db.select({
+      space: spaces,
+      sandbox: spaceSandboxes,
+      session: spaceSessions,
+      task: taskRuns,
+    })
+      .from(spaces)
+      .innerJoin(spaceSandboxes, eq(spaceSandboxes.spaceId, spaces.id))
+      .innerJoin(spaceSessions, and(eq(spaceSessions.id, input.sessionId), eq(spaceSessions.spaceId, spaces.id)))
+      .innerJoin(taskRuns, eq(taskRuns.id, input.taskRunId))
+      .where(and(eq(spaces.id, input.disposableSpaceId), eq(spaces.userUuid, input.userId)))
+      .limit(1);
+    const meta = isRecord(row?.sandbox.meta) ? row.sandbox.meta : null;
+    const allocation = meta && isRecord(meta.isolatedWorker) ? meta.isolatedWorker : null;
+    const sessionMeta = isRecord(row?.session.meta) ? row.session.meta : null;
+    const persistedData = isRecord(row?.task.payload?.data) ? row.task.payload.data : null;
+    if (
+      !row
+      || row.session.userUuid !== input.userId
+      || row.session.source !== "isolated_worker_dispatch"
+      || sessionMeta?.authoritySpaceId !== input.authoritySpaceId
+      || sessionMeta.dispatchTaskRunId !== input.taskRunId
+      || row.task.jobId !== input.taskRunId
+      || row.task.taskType !== ISOLATED_WORKER_DISPATCH_TASK_TYPE
+      || row.task.status !== "running"
+      || row.task.spaceId !== input.authoritySpaceId
+      || row.task.sessionId !== input.sessionId
+      || row.task.userUuid !== input.userId
+      || persistedData?.authoritySpaceId !== input.authoritySpaceId
+      || persistedData.disposableSpaceId !== input.disposableSpaceId
+      || persistedData.sessionId !== input.sessionId
+      || persistedData.policySha256 !== input.policySha256
+      || canonicalIsolatedWorkerJson(persistedData) !== canonicalIsolatedWorkerJson(input.dispatchData)
+    ) {
+      throw new Error("persisted isolated worker dispatch reservation binding mismatch");
+    }
+    return {
+      authoritySpaceId: String(allocation?.authoritySpaceId ?? ""),
+      disposableSpaceId: row?.space.id ?? "",
+      sessionId: input.sessionId,
+      userId: row?.space.userUuid ?? "",
+      sandboxStatus: row?.sandbox.status ?? "missing",
+      sandboxPodName: row?.sandbox.podName ?? null,
+      allocation,
+    };
+  },
+  async prepareWorkspace(input) {
+    const evidenceRoot = getWorkerLocalTmpDir("isolated-inputs", input.disposableSpaceId, input.taskRunId);
+    const sourceWorkspace = `${evidenceRoot}/source`;
+    const archiveDir = `${evidenceRoot}/archive`;
+    const preparedWorkspace = preparedWorkspacePath(input.taskRunId);
+    await ensureWorkerLocalTmpDir(evidenceRoot);
+    try {
+      await mkdir(sourceWorkspace, { mode: 0o700 });
+      await mkdir(dirname(preparedWorkspace), { recursive: true, mode: 0o700 });
+      await mkdir(preparedWorkspace, { mode: 0o700 });
+      const restored = await restoreWorkspaceFromCheckpoint({
+        checkpointId: input.inputBundle.authorityCheckpointId,
+        targetWorkspaceDir: sourceWorkspace,
+        restoreTmpDir: archiveDir,
+      });
+      const checkpointMeta = isRecord(restored.checkpoint.meta) ? restored.checkpoint.meta : null;
+      const gitTree = checkpointMeta && isRecord(checkpointMeta.gitTree) ? checkpointMeta.gitTree : null;
+      if (
+        restored.sourceSpace.id !== input.authoritySpaceId
+        || restored.checkpoint.commitHash !== input.inputBundle.authorityCheckpointCommit
+        || gitTree?.sha256 !== input.inputBundle.authorityTreeSha256
+      ) {
+        throw new Error("frozen authority checkpoint readback mismatch");
+      }
+      await materializeFrozenInputManifest({
+        sourceRoot: sourceWorkspace,
+        targetRoot: preparedWorkspace,
+        inputBundle: input.inputBundle,
+      });
+      const inputsMaterializedAt = new Date().toISOString();
+      try {
+        await removeWorkerLocalTmpDir(evidenceRoot);
+      } catch (cleanupError) {
+        await throwWithCleanup(cleanupError, [() => rm(preparedWorkspace, { recursive: true, force: true })], "isolated worker evidence and staging cleanup failed");
+      }
+      return { inputsMaterializedAt, preparedWorkspace };
+    } catch (error) {
+      return throwWithCleanup(error, [
+        () => removeWorkerLocalTmpDir(evidenceRoot),
+        () => rm(preparedWorkspace, { recursive: true, force: true }),
+      ], "isolated worker input preparation and cleanup failed");
+    }
+  },
+  async cleanupPreparedWorkspace(input) {
+    await rm(input.preparedWorkspace, { recursive: true, force: true });
+  },
+  async allocateReservation(input) {
+    const data = input.data;
+    const now = new Date();
+    const creationProof = {
+      authoritySpaceId: data.authoritySpaceId,
+      disposableSpaceId: data.disposableSpaceId,
+      dispatchTaskRunId: input.taskRunId,
+      creationPath: data.creationPath,
+      ordinarySandboxProvisioned: false,
+      terminatedSpaceReused: false,
+      credentialMode: data.credentialMode,
+      engineInternalSecretIssued: false,
+      publicPromptUsed: false,
+      checkpointAdapter: data.checkpointAdapter,
+      authorityCheckpointId: data.inputBundle.authorityCheckpointId,
+      authorityTreeSha256: data.inputBundle.authorityTreeSha256,
+      inputManifestSha256: data.inputManifestSha256,
+      authorityExecutionTokenIssued: false,
+      runtimeAuthorityReadAllowed: false,
+    };
+    await db.transaction(async (tx) => {
+      await tx.insert(spaces).values({
+        id: data.disposableSpaceId,
+        userUuid: input.userId,
+        name: `Isolated worker ${data.disposableSpaceId.slice(0, 8)}`,
+        storageRepoName: `space-${data.disposableSpaceId}`,
+        lastActivityAt: now,
+        meta: {
+          isolatedWorkerDisposable: creationProof,
+          bootstrap: { status: "ready", source: { type: "isolated_worker_dispatch", authoritySpaceId: data.authoritySpaceId } },
+        },
+      });
+      await tx.insert(spaceMembers).values({
+        spaceId: data.disposableSpaceId,
+        userId: input.userId,
+        role: "host",
+        createdBy: input.userId,
+        updatedBy: input.userId,
+      });
+      await tx.insert(spaceSessions).values({
+        id: data.sessionId,
+        spaceId: data.disposableSpaceId,
+        userUuid: input.userId,
+        title: "Isolated worker",
+        source: "isolated_worker_dispatch",
+        status: "active",
+        lastMessageAt: now,
+        lastMessageId: null,
+        meta: {
+          createdBy: "isolated_worker_dispatch",
+          authoritySpaceId: data.authoritySpaceId,
+          dispatchTaskRunId: input.taskRunId,
+          participants: { userUuids: [input.userId] },
+        },
+      });
+      await tx.insert(sessionTurnSegments).values({
+        sessionId: data.sessionId,
+        ordinal: 1,
+        sourceSessionId: data.sessionId,
+        fromSequence: 1,
+        toSequence: null,
+      });
+      await tx.insert(spaceSandboxes).values({
+        spaceId: data.disposableSpaceId,
+        provider: "cloud",
+        status: "allocated",
+        runtimeStatus: "unknown",
+        podName: null,
+        meta: {
+          isolatedWorker: {
+            state: "prepared",
+            authoritySpaceId: data.authoritySpaceId,
+            disposableSpaceId: data.disposableSpaceId,
+            dispatchTaskRunId: input.taskRunId,
+            policySha256: data.policySha256,
+            creationPath: data.creationPath,
+            ordinarySandboxProvisioned: false,
+            terminatedSpaceReused: false,
+            credentialMode: data.credentialMode,
+            engineInternalSecretIssued: false,
+            publicPromptUsed: false,
+            authorityExecutionTokenIssued: false,
+            runtimeAuthorityReadAllowed: false,
+            authorityCheckpointId: data.inputBundle.authorityCheckpointId,
+            authorityCheckpointCommit: data.inputBundle.authorityCheckpointCommit,
+            authorityTreeSha256: data.inputBundle.authorityTreeSha256,
+            inputManifestSha256: data.inputManifestSha256,
+            inputCount: data.inputBundle.items.length,
+            inputBundle: data.inputBundle,
+            inputsMaterializedAt: input.inputsMaterializedAt,
+            preparedWorkspace: input.preparedWorkspace,
+            resumable: false,
+          },
+          resumable: false,
+        },
+      });
+    });
+  },
+  async publishWorkspace(input) {
+    const expectedPrepared = preparedWorkspacePath(input.taskRunId);
+    if (input.preparedWorkspace !== expectedPrepared) throw new Error("isolated worker staging path binding mismatch");
+    const finalWorkspace = getSpaceWorkspaceDir(input.disposableSpaceId);
+    let spaceBaseCreated = false;
+    try {
+      const preparedExists = await pathExists(input.preparedWorkspace);
+      const finalExists = await pathExists(finalWorkspace);
+      if (preparedExists && finalExists) throw new Error("isolated worker publish found both staging and final workspace");
+      if (!preparedExists && !finalExists) throw new Error("isolated worker publish found no workspace");
+      if (preparedExists) {
+        const spaceBase = dirname(finalWorkspace);
+        if (await pathExists(spaceBase)) {
+          const info = await lstat(spaceBase);
+          if (info.isSymbolicLink() || !info.isDirectory() || (await readdir(spaceBase)).length !== 0) {
+            throw new Error("isolated worker publish base directory is not empty");
+          }
+          spaceBaseCreated = true;
+        } else {
+          await mkdir(spaceBase, { mode: 0o775 });
+          spaceBaseCreated = true;
+        }
+        await rename(input.preparedWorkspace, finalWorkspace);
+      } else {
+        spaceBaseCreated = true;
+      }
+      await verifyFrozenInputMaterialization({ targetRoot: finalWorkspace, inputBundle: input.data.inputBundle });
+      const [updated] = await db.update(spaceSandboxes).set({
+        meta: {
+          isolatedWorker: {
+            state: "allocated",
+            authoritySpaceId: input.data.authoritySpaceId,
+            disposableSpaceId: input.data.disposableSpaceId,
+            dispatchTaskRunId: input.taskRunId,
+            policySha256: input.data.policySha256,
+            creationPath: input.data.creationPath,
+            ordinarySandboxProvisioned: false,
+            terminatedSpaceReused: false,
+            credentialMode: input.data.credentialMode,
+            engineInternalSecretIssued: false,
+            publicPromptUsed: false,
+            authorityExecutionTokenIssued: false,
+            runtimeAuthorityReadAllowed: false,
+            authorityCheckpointId: input.data.inputBundle.authorityCheckpointId,
+            authorityCheckpointCommit: input.data.inputBundle.authorityCheckpointCommit,
+            authorityTreeSha256: input.data.inputBundle.authorityTreeSha256,
+            inputManifestSha256: input.data.inputManifestSha256,
+            inputCount: input.data.inputBundle.items.length,
+            inputBundle: input.data.inputBundle,
+            inputsMaterializedAt: input.inputsMaterializedAt,
+            preparedWorkspace: input.preparedWorkspace,
+            resumable: false,
+          },
+          resumable: false,
+        },
+        updatedAt: new Date(),
+      }).where(and(
+        eq(spaceSandboxes.spaceId, input.disposableSpaceId),
+        eq(spaceSandboxes.status, "allocated"),
+      )).returning({ spaceId: spaceSandboxes.spaceId });
+      if (!updated) throw new Error("isolated worker published workspace reservation CAS failed");
+    } catch (error) {
+      throw new IsolatedWorkerPublishError(error, spaceBaseCreated);
+    }
+  },
+  async rollbackReservation(input) {
+    const expectedPrepared = preparedWorkspacePath(input.taskRunId);
+    if (input.preparedWorkspace !== expectedPrepared) throw new Error("isolated worker rollback staging path binding mismatch");
+    const spaceBaseDir = dirname(getSpaceWorkspaceDir(input.disposableSpaceId));
+    const filesystemErrors: unknown[] = [];
+    const cleanupPaths = [input.preparedWorkspace];
+    if (input.cause instanceof IsolatedWorkerPublishError && input.cause.spaceBaseCreated) cleanupPaths.push(spaceBaseDir);
+    for (const path of cleanupPaths) {
+      try {
+        await rm(path, { recursive: true, force: true });
+      } catch (error) {
+        filesystemErrors.push(error);
+      }
+    }
+    if (filesystemErrors.length > 0) {
+      const orphanMeta = {
+        isolatedWorker: {
+          state: "orphan_cleanup_required",
+          disposableSpaceId: input.disposableSpaceId,
+          resumable: false,
+        },
+        resumable: false,
+      };
+      try {
+        await db.update(spaceSandboxes).set({ status: "stopping", meta: orphanMeta, updatedAt: new Date() })
+          .where(eq(spaceSandboxes.spaceId, input.disposableSpaceId));
+      } catch (markError) {
+        filesystemErrors.push(markError);
+      }
+      throw new AggregateError(filesystemErrors, "isolated worker orphan workspace cleanup failed");
+    }
+    try {
+      await db.transaction(async (tx) => {
+        await tx.delete(sessionTurnSegments).where(eq(sessionTurnSegments.sessionId, input.sessionId));
+        await tx.delete(spaceSessions).where(eq(spaceSessions.id, input.sessionId));
+        await tx.delete(spaceSandboxes).where(eq(spaceSandboxes.spaceId, input.disposableSpaceId));
+        await tx.delete(spaceMembers).where(eq(spaceMembers.spaceId, input.disposableSpaceId));
+        await tx.delete(spaces).where(eq(spaces.id, input.disposableSpaceId));
+      });
+    } catch (error) {
+      try {
+        await db.update(spaceSandboxes).set({
+          status: "stopping",
+          meta: { isolatedWorker: { state: "orphan_cleanup_required", disposableSpaceId: input.disposableSpaceId, resumable: false }, resumable: false },
+          updatedAt: new Date(),
+        }).where(eq(spaceSandboxes.spaceId, input.disposableSpaceId));
+      } catch (markError) {
+        throw new AggregateError([error, markError], "isolated worker rollback database cleanup and orphan marking failed");
+      }
+      throw error;
+    }
+  },
+  async submitInternal(input) {
+    const response = await fetch(
+      `${config.internalApiBaseUrl}/internal/spaces/${input.disposableSpaceId}/sessions/${input.sessionId}/prompt`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-worker-secret": config.workerSecret },
+        body: JSON.stringify({
+          content: input.content,
+          userId: input.userId,
+          clientMessageId: input.clientMessageId,
+          source: input.source,
+          model: input.model,
+          provider: input.provider,
+          accessMode: "isolated_worker",
+          isolatedWorkerPolicy: {
+            authoritySpaceId: input.authoritySpaceId,
+            disposableSpaceId: input.disposableSpaceId,
+            writableRoot: "/workspace/work",
+            workspaceReadOnly: true,
+            executionTokenIssued: false,
+            policySha256: input.policySha256,
+          },
+          inputBundle: input.inputBundle,
+          inputsMaterializedAt: input.inputsMaterializedAt,
+          dispatchTaskRunId: input.dispatchTaskRunId,
+          context: { kind: "scheduled_task", taskRunId: input.dispatchTaskRunId },
+        }),
+      },
+    );
+    const body = await response.json().catch(() => null) as Record<string, unknown> | null;
+    if (!response.ok) throw new Error(`isolated worker internal prompt failed ${response.status}: ${JSON.stringify(body)}`);
+    return {
+      turnId: typeof body?.turnId === "string" ? body.turnId : "",
+      podUid: typeof body?.podUid === "string" ? body.podUid : "",
+      policySha256: typeof body?.policySha256 === "string" ? body.policySha256 : "",
+      podCreatedAt: typeof body?.podCreatedAt === "string" ? body.podCreatedAt : "",
+    };
+  },
+};
+
+const handler = createIsolatedWorkerDispatchHandler(productionDependencies);
+
+registerTask(ISOLATED_WORKER_DISPATCH_TASK_TYPE, async (job, context) => {
+  if (!context?.taskRunId) throw new Error("isolated worker dispatch TaskRun id is required");
+  return handler({ taskRunId: context.taskRunId, payload: job.data as TaskPayload });
+});

--- a/apps/worker/src/tasks/isolated-worker-termination-handler.ts
+++ b/apps/worker/src/tasks/isolated-worker-termination-handler.ts
@@ -1,0 +1,439 @@
+import { createHash } from "node:crypto";
+import type { TaskPayload } from "@cohub/protocol/task";
+import {
+  ISOLATED_WORKER_RECEIPT_SCAN_TASK_TYPE,
+  ISOLATED_WORKER_REVOKE_TASK_TYPE,
+  type IsolatedWorkerReceiptScanTaskData,
+  type IsolatedWorkerRevokeTaskData,
+  type IsolatedWorkerTerminalStatus,
+} from "@cohub/protocol/isolated-worker";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SHA256_RE = /^[a-f0-9]{64}$/;
+const TERMINAL_STATUSES = new Set<IsolatedWorkerTerminalStatus>([
+  "completed",
+  "failed",
+  "cancelled",
+  "interrupted",
+]);
+
+const REVOKE_DATA_KEYS = [
+  "authoritySpaceId",
+  "disposableSpaceId",
+  "podUid",
+  "sessionId",
+  "terminalStatus",
+  "trigger",
+  "turnId",
+] as const;
+const RECEIPT_SCAN_DATA_KEYS = [
+  "authoritySpaceId",
+  "checkpointId",
+  "checkpointTreeSha256",
+  "disposableSpaceId",
+  "podUid",
+  "revokeTaskRunId",
+  "workerSessionId",
+  "workerTurnId",
+] as const;
+const TASK_PAYLOAD_KEYS = ["data", "sessionId", "spaceId", "turnId", "type", "userId"] as const;
+const REVOKE_RESULT_KEYS = ["automatic", "manualEndpointInvoked", "receipt", "terminalStatus"] as const;
+const RECEIPT_KEYS = [
+  "automaticTrigger",
+  "checkpointAdapter",
+  "checkpointCommit",
+  "checkpointCreatedAfterPodDeletion",
+  "checkpointId",
+  "checkpointTreeSha256",
+  "credentialRevoked",
+  "manualEndpointInvoked",
+  "podDeleted",
+  "podDeletedAt",
+  "podUid",
+  "revokeTaskRunId",
+  "sandboxTerminated",
+  "terminatedAt",
+] as const;
+
+export type IsolatedWorkerRevocationReceipt = {
+  revokeTaskRunId: string;
+  automaticTrigger: "turn_terminal_event";
+  manualEndpointInvoked: false;
+  podUid: string;
+  podDeleted: true;
+  podDeletedAt: string;
+  credentialRevoked: true;
+  sandboxTerminated: true;
+  checkpointCreatedAfterPodDeletion: true;
+  checkpointAdapter: "trusted_production";
+  terminatedAt: string;
+  checkpointId: string;
+  checkpointCommit: string;
+  checkpointTreeSha256: string;
+};
+
+export type IsolatedWorkerRevokeResult = {
+  automatic: true;
+  manualEndpointInvoked: false;
+  terminalStatus: IsolatedWorkerTerminalStatus;
+  receipt: IsolatedWorkerRevocationReceipt;
+};
+
+export type IsolatedWorkerRevokeInvocation = {
+  taskRunId: string;
+  payload: TaskPayload;
+};
+
+export type IsolatedWorkerReceiptScanInvocation = {
+  taskRunId: string;
+  startedAt: Date;
+  payload: TaskPayload;
+};
+
+export type IsolatedWorkerRevokeTaskReadback = {
+  id: string;
+  jobId: string;
+  taskType: string;
+  status: string;
+  spaceId: string | null;
+  sessionId: string | null;
+  turnId: string | null;
+  userUuid: string | null;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  payload: unknown;
+  result: unknown;
+};
+
+export type IsolatedWorkerRevokeHandlerDependencies = {
+  revokeInternal(input: {
+    disposableSpaceId: string;
+    sessionId: string;
+    turnId: string;
+    body: {
+      authoritySpaceId: string;
+      disposableSpaceId: string;
+      podUid: string;
+      revokeTaskRunId: string;
+      automaticTrigger: "turn_terminal_event";
+      manualEndpointInvoked: false;
+      terminalStatus: IsolatedWorkerTerminalStatus;
+    };
+  }): Promise<unknown>;
+};
+
+export type IsolatedWorkerReceiptScanHandlerDependencies = {
+  readRevokeTaskRun(revokeTaskRunId: string): Promise<IsolatedWorkerRevokeTaskReadback | null>;
+};
+
+export type IsolatedWorkerRevokeCompletion = {
+  taskRunId: string;
+  payload: TaskPayload;
+  result: Record<string, unknown>;
+  finishedAt: Date;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+function assertExactKeys(value: Record<string, unknown>, expected: readonly string[], label: string) {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    throw new Error(`${label} fields mismatch`);
+  }
+}
+
+function assertUuid(value: unknown, label: string): asserts value is string {
+  if (typeof value !== "string" || !UUID_RE.test(value)) throw new Error(`${label} is malformed`);
+}
+
+function assertNonempty(value: unknown, label: string): asserts value is string {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${label} is required`);
+}
+
+function parseTaskPayload(payload: TaskPayload, expectedType: string) {
+  if (!isRecord(payload)) throw new Error(`${expectedType} payload is required`);
+  assertExactKeys(payload, TASK_PAYLOAD_KEYS, `${expectedType} payload`);
+  if (payload.type !== expectedType) throw new Error(`${expectedType} task type mismatch`);
+  assertUuid(payload.spaceId, `${expectedType} spaceId`);
+  assertUuid(payload.sessionId, `${expectedType} sessionId`);
+  assertUuid(payload.turnId, `${expectedType} turnId`);
+  assertNonempty(payload.userId, `${expectedType} userId`);
+  if (!isRecord(payload.data)) throw new Error(`${expectedType} data is required`);
+  return payload as TaskPayload & {
+    spaceId: string;
+    sessionId: string;
+    turnId: string;
+    userId: string;
+    data: Record<string, unknown>;
+  };
+}
+
+export function parseIsolatedWorkerRevokePayload(payload: TaskPayload) {
+  const parsed = parseTaskPayload(payload, ISOLATED_WORKER_REVOKE_TASK_TYPE);
+  assertExactKeys(parsed.data, REVOKE_DATA_KEYS, "isolated worker revoke data");
+  const data = parsed.data;
+  assertUuid(data.authoritySpaceId, "isolated worker revoke authoritySpaceId");
+  assertUuid(data.disposableSpaceId, "isolated worker revoke disposableSpaceId");
+  assertUuid(data.sessionId, "isolated worker revoke sessionId");
+  assertUuid(data.turnId, "isolated worker revoke turnId");
+  assertNonempty(data.podUid, "isolated worker revoke podUid");
+  if (data.trigger !== "turn_terminal_event") throw new Error("isolated worker revoke trigger mismatch");
+  if (!TERMINAL_STATUSES.has(data.terminalStatus as IsolatedWorkerTerminalStatus)) {
+    throw new Error("isolated worker revoke terminalStatus mismatch");
+  }
+  if (
+    parsed.spaceId !== data.disposableSpaceId
+    || parsed.sessionId !== data.sessionId
+    || parsed.turnId !== data.turnId
+  ) {
+    throw new Error("isolated worker revoke TaskRun binding mismatch");
+  }
+  return {
+    ...parsed,
+    data: data as unknown as IsolatedWorkerRevokeTaskData,
+  };
+}
+
+export function parseIsolatedWorkerReceiptScanPayload(payload: TaskPayload) {
+  const parsed = parseTaskPayload(payload, ISOLATED_WORKER_RECEIPT_SCAN_TASK_TYPE);
+  assertExactKeys(parsed.data, RECEIPT_SCAN_DATA_KEYS, "isolated worker receipt scan data");
+  const data = parsed.data;
+  for (const field of [
+    "authoritySpaceId",
+    "disposableSpaceId",
+    "workerSessionId",
+    "workerTurnId",
+    "revokeTaskRunId",
+    "checkpointId",
+  ] as const) {
+    assertUuid(data[field], `isolated worker receipt scan ${field}`);
+  }
+  assertNonempty(data.podUid, "isolated worker receipt scan podUid");
+  if (typeof data.checkpointTreeSha256 !== "string" || !SHA256_RE.test(data.checkpointTreeSha256)) {
+    throw new Error("isolated worker receipt scan checkpointTreeSha256 is malformed");
+  }
+  if (
+    parsed.spaceId !== data.authoritySpaceId
+    || parsed.sessionId !== data.workerSessionId
+    || parsed.turnId !== data.workerTurnId
+  ) {
+    throw new Error("isolated worker receipt scan TaskRun binding mismatch");
+  }
+  return {
+    ...parsed,
+    data: data as unknown as IsolatedWorkerReceiptScanTaskData,
+  };
+}
+
+function parseRevocationReceipt(
+  value: unknown,
+  expected: {
+    revokeTaskRunId: string;
+    podUid: string;
+    checkpointId?: string;
+    checkpointTreeSha256?: string;
+  },
+) {
+  if (!isRecord(value)) throw new Error("isolated worker revocation receipt is required");
+  assertExactKeys(value, RECEIPT_KEYS, "isolated worker revocation receipt");
+  if (
+    value.revokeTaskRunId !== expected.revokeTaskRunId
+    || value.automaticTrigger !== "turn_terminal_event"
+    || value.manualEndpointInvoked !== false
+    || value.podUid !== expected.podUid
+    || value.podDeleted !== true
+    || value.credentialRevoked !== true
+    || value.sandboxTerminated !== true
+    || value.checkpointCreatedAfterPodDeletion !== true
+    || value.checkpointAdapter !== "trusted_production"
+  ) {
+    throw new Error("isolated worker revocation receipt binding mismatch");
+  }
+  assertUuid(value.checkpointId, "isolated worker revocation receipt checkpointId");
+  assertNonempty(value.checkpointCommit, "isolated worker revocation receipt checkpointCommit");
+  if (typeof value.checkpointTreeSha256 !== "string" || !SHA256_RE.test(value.checkpointTreeSha256)) {
+    throw new Error("isolated worker revocation receipt checkpointTreeSha256 is malformed");
+  }
+  if (
+    (expected.checkpointId !== undefined && value.checkpointId !== expected.checkpointId)
+    || (expected.checkpointTreeSha256 !== undefined && value.checkpointTreeSha256 !== expected.checkpointTreeSha256)
+  ) {
+    throw new Error("isolated worker revocation checkpoint binding mismatch");
+  }
+  const podDeletedAt = typeof value.podDeletedAt === "string" ? Date.parse(value.podDeletedAt) : Number.NaN;
+  const terminatedAt = typeof value.terminatedAt === "string" ? Date.parse(value.terminatedAt) : Number.NaN;
+  if (!Number.isFinite(podDeletedAt) || !Number.isFinite(terminatedAt) || podDeletedAt > terminatedAt) {
+    throw new Error("isolated worker revocation receipt timestamps are invalid");
+  }
+  return value as unknown as IsolatedWorkerRevocationReceipt;
+}
+
+export function parseIsolatedWorkerRevokeResult(
+  value: unknown,
+  expected: { revokeTaskRunId: string; terminalStatus: IsolatedWorkerTerminalStatus; podUid: string },
+) {
+  if (!isRecord(value)) throw new Error("isolated worker revoke result is required");
+  assertExactKeys(value, REVOKE_RESULT_KEYS, "isolated worker revoke result");
+  if (
+    value.automatic !== true
+    || value.manualEndpointInvoked !== false
+    || value.terminalStatus !== expected.terminalStatus
+  ) {
+    throw new Error("isolated worker revoke result binding mismatch");
+  }
+  const receipt = parseRevocationReceipt(value.receipt, expected);
+  return {
+    automatic: true,
+    manualEndpointInvoked: false,
+    terminalStatus: expected.terminalStatus,
+    receipt,
+  } satisfies IsolatedWorkerRevokeResult;
+}
+
+export function createIsolatedWorkerRevokeHandler(deps: IsolatedWorkerRevokeHandlerDependencies) {
+  return async (input: IsolatedWorkerRevokeInvocation): Promise<IsolatedWorkerRevokeResult> => {
+    assertUuid(input.taskRunId, "isolated worker revoke TaskRun id");
+    const payload = parseIsolatedWorkerRevokePayload(input.payload);
+    const data = payload.data;
+    const response = await deps.revokeInternal({
+      disposableSpaceId: data.disposableSpaceId,
+      sessionId: data.sessionId,
+      turnId: data.turnId,
+      body: {
+        authoritySpaceId: data.authoritySpaceId,
+        disposableSpaceId: data.disposableSpaceId,
+        podUid: data.podUid,
+        revokeTaskRunId: input.taskRunId,
+        automaticTrigger: "turn_terminal_event",
+        manualEndpointInvoked: false,
+        terminalStatus: data.terminalStatus,
+      },
+    });
+    const body = isRecord(response) ? response : null;
+    if (body?.ok !== true || !isRecord(body.receipt)) {
+      throw new Error("isolated worker internal revoke response is incomplete");
+    }
+    const receipt = parseRevocationReceipt(body.receipt, {
+      revokeTaskRunId: input.taskRunId,
+      podUid: data.podUid,
+    });
+    return {
+      automatic: true,
+      manualEndpointInvoked: false,
+      terminalStatus: data.terminalStatus,
+      receipt,
+    };
+  };
+}
+
+export function createIsolatedWorkerReceiptScanHandler(deps: IsolatedWorkerReceiptScanHandlerDependencies) {
+  return async (input: IsolatedWorkerReceiptScanInvocation) => {
+    assertUuid(input.taskRunId, "isolated worker receipt scan TaskRun id");
+    if (!Number.isFinite(input.startedAt.getTime())) throw new Error("isolated worker receipt scan startedAt is invalid");
+    const payload = parseIsolatedWorkerReceiptScanPayload(input.payload);
+    const data = payload.data;
+    const revokeTask = await deps.readRevokeTaskRun(data.revokeTaskRunId);
+    if (!revokeTask) throw new Error("isolated worker revoke TaskRun is missing");
+    if (
+      revokeTask.id !== data.revokeTaskRunId
+      || revokeTask.jobId !== data.revokeTaskRunId
+      || revokeTask.taskType !== ISOLATED_WORKER_REVOKE_TASK_TYPE
+      || revokeTask.status !== "completed"
+      || revokeTask.spaceId !== data.disposableSpaceId
+      || revokeTask.sessionId !== data.workerSessionId
+      || revokeTask.turnId !== data.workerTurnId
+      || revokeTask.userUuid !== payload.userId
+    ) {
+      throw new Error("isolated worker revoke TaskRun readback binding mismatch");
+    }
+    if (!revokeTask.startedAt || !revokeTask.finishedAt) {
+      throw new Error("isolated worker revoke TaskRun timestamps are missing");
+    }
+    if (
+      !Number.isFinite(revokeTask.startedAt.getTime())
+      || !Number.isFinite(revokeTask.finishedAt.getTime())
+      || revokeTask.startedAt.getTime() > revokeTask.finishedAt.getTime()
+      || input.startedAt.getTime() <= revokeTask.finishedAt.getTime()
+    ) {
+      throw new Error("isolated worker receipt scan did not start after revoke completion");
+    }
+    const revokePayload = parseIsolatedWorkerRevokePayload(revokeTask.payload as TaskPayload);
+    if (
+      revokePayload.userId !== payload.userId
+      || revokePayload.data.authoritySpaceId !== data.authoritySpaceId
+      || revokePayload.data.disposableSpaceId !== data.disposableSpaceId
+      || revokePayload.data.sessionId !== data.workerSessionId
+      || revokePayload.data.turnId !== data.workerTurnId
+      || revokePayload.data.podUid !== data.podUid
+    ) {
+      throw new Error("isolated worker revoke payload and receipt scan binding mismatch");
+    }
+    const revokeResult = parseIsolatedWorkerRevokeResult(revokeTask.result, {
+      revokeTaskRunId: data.revokeTaskRunId,
+      terminalStatus: revokePayload.data.terminalStatus,
+      podUid: data.podUid,
+    });
+    if (
+      revokeResult.receipt.checkpointId !== data.checkpointId
+      || revokeResult.receipt.checkpointTreeSha256 !== data.checkpointTreeSha256
+    ) {
+      throw new Error("isolated worker receipt scan checkpoint binding mismatch");
+    }
+    return {
+      revokeTaskRunId: data.revokeTaskRunId,
+      scanStartedAfterRevoke: true,
+      receiptEligible: true,
+      checkpointId: data.checkpointId,
+      checkpointTreeSha256: data.checkpointTreeSha256,
+    } as const;
+  };
+}
+
+export function createIsolatedWorkerRevokeCompletionHook(deps: {
+  enqueueReceiptScan(input: { payload: TaskPayload; taskRunId: string }): Promise<void>;
+  waitUntilAfter?: (finishedAt: Date) => Promise<void>;
+}) {
+  const waitUntilAfter = deps.waitUntilAfter ?? (async (finishedAt: Date) => {
+    while (Date.now() <= finishedAt.getTime()) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+  });
+  return async (completion: IsolatedWorkerRevokeCompletion) => {
+    const payload = parseIsolatedWorkerRevokePayload(completion.payload);
+    const result = parseIsolatedWorkerRevokeResult(completion.result, {
+      revokeTaskRunId: completion.taskRunId,
+      terminalStatus: payload.data.terminalStatus,
+      podUid: payload.data.podUid,
+    });
+    await waitUntilAfter(completion.finishedAt);
+    const scanTaskRunId = getIsolatedWorkerReceiptScanTaskRunId(completion.taskRunId);
+    await deps.enqueueReceiptScan({
+      taskRunId: scanTaskRunId,
+      payload: {
+        type: ISOLATED_WORKER_RECEIPT_SCAN_TASK_TYPE,
+        spaceId: payload.data.authoritySpaceId,
+        sessionId: payload.data.sessionId,
+        turnId: payload.data.turnId,
+        userId: payload.userId,
+        data: {
+          authoritySpaceId: payload.data.authoritySpaceId,
+          disposableSpaceId: payload.data.disposableSpaceId,
+          workerSessionId: payload.data.sessionId,
+          workerTurnId: payload.data.turnId,
+          podUid: payload.data.podUid,
+          revokeTaskRunId: completion.taskRunId,
+          checkpointId: result.receipt.checkpointId,
+          checkpointTreeSha256: result.receipt.checkpointTreeSha256,
+        },
+      },
+    });
+  };
+}
+
+export function getIsolatedWorkerReceiptScanTaskRunId(revokeTaskRunId: string) {
+  assertUuid(revokeTaskRunId, "isolated worker revoke TaskRun id");
+  const hex = createHash("sha256").update(`${revokeTaskRunId}:receipt-scan`).digest("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-5${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
+}

--- a/apps/worker/src/tasks/isolated-worker-termination-task.test.ts
+++ b/apps/worker/src/tasks/isolated-worker-termination-task.test.ts
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import type { TaskPayload } from "@cohub/protocol/task";
+import {
+  createIsolatedWorkerReceiptScanHandler,
+  createIsolatedWorkerRevokeCompletionHook,
+  createIsolatedWorkerRevokeHandler,
+  getIsolatedWorkerReceiptScanTaskRunId,
+} from "./isolated-worker-termination-handler.js";
+
+const revokeTaskRunId = "11111111-1111-4111-8111-111111111111";
+const scanTaskRunId = "22222222-2222-4222-8222-222222222222";
+const authoritySpaceId = "33333333-3333-4333-8333-333333333333";
+const disposableSpaceId = "44444444-4444-4444-8444-444444444444";
+const sessionId = "55555555-5555-4555-8555-555555555555";
+const turnId = "66666666-6666-4666-8666-666666666666";
+const checkpointId = "77777777-7777-4777-8777-777777777777";
+const checkpointTreeSha256 = "a".repeat(64);
+const userId = "user-1";
+const podUid = "pod-uid-1";
+
+const revokePayload: TaskPayload = {
+  type: "isolated_worker_revoke",
+  spaceId: disposableSpaceId,
+  sessionId,
+  turnId,
+  userId,
+  data: {
+    trigger: "turn_terminal_event",
+    terminalStatus: "completed",
+    authoritySpaceId,
+    disposableSpaceId,
+    sessionId,
+    turnId,
+    podUid,
+  },
+};
+
+const receipt = {
+  revokeTaskRunId,
+  automaticTrigger: "turn_terminal_event" as const,
+  manualEndpointInvoked: false as const,
+  podUid,
+  podDeleted: true as const,
+  podDeletedAt: "2026-07-15T00:00:01.000Z",
+  credentialRevoked: true as const,
+  sandboxTerminated: true as const,
+  checkpointCreatedAfterPodDeletion: true as const,
+  checkpointAdapter: "trusted_production" as const,
+  terminatedAt: "2026-07-15T00:00:02.000Z",
+  checkpointId,
+  checkpointCommit: "b".repeat(40),
+  checkpointTreeSha256,
+};
+
+const revokeResult = {
+  automatic: true as const,
+  manualEndpointInvoked: false as const,
+  terminalStatus: "completed" as const,
+  receipt,
+};
+
+let internalRequest: unknown = null;
+const revokeHandler = createIsolatedWorkerRevokeHandler({
+  async revokeInternal(input) {
+    internalRequest = input;
+    return { ok: true, receipt };
+  },
+});
+assert.deepEqual(await revokeHandler({ taskRunId: revokeTaskRunId, payload: revokePayload }), revokeResult);
+assert.deepEqual(internalRequest, {
+  disposableSpaceId,
+  sessionId,
+  turnId,
+  body: {
+    authoritySpaceId,
+    disposableSpaceId,
+    podUid,
+    revokeTaskRunId,
+    automaticTrigger: "turn_terminal_event",
+    manualEndpointInvoked: false,
+    terminalStatus: "completed",
+  },
+});
+
+let badPayloadCalled = false;
+const strictRevokeHandler = createIsolatedWorkerRevokeHandler({
+  async revokeInternal() {
+    badPayloadCalled = true;
+    return { ok: true, receipt };
+  },
+});
+await assert.rejects(
+  strictRevokeHandler({
+    taskRunId: revokeTaskRunId,
+    payload: {
+      ...revokePayload,
+      data: { ...revokePayload.data, manualEndpointInvoked: false },
+    },
+  }),
+  /data fields mismatch/,
+);
+assert.equal(badPayloadCalled, false);
+
+const completionCalls: string[] = [];
+let enqueuedScan: { payload: TaskPayload; taskRunId: string } | null = null;
+const completionHook = createIsolatedWorkerRevokeCompletionHook({
+  async waitUntilAfter(finishedAt) {
+    completionCalls.push(`wait:${finishedAt.toISOString()}`);
+  },
+  async enqueueReceiptScan(input) {
+    completionCalls.push("enqueue");
+    enqueuedScan = input;
+  },
+});
+const revokeFinishedAt = new Date("2026-07-15T00:00:03.000Z");
+await completionHook({
+  taskRunId: revokeTaskRunId,
+  payload: revokePayload,
+  result: revokeResult,
+  finishedAt: revokeFinishedAt,
+});
+assert.deepEqual(completionCalls, [`wait:${revokeFinishedAt.toISOString()}`, "enqueue"]);
+assert.deepEqual(enqueuedScan, {
+  taskRunId: getIsolatedWorkerReceiptScanTaskRunId(revokeTaskRunId),
+  payload: {
+    type: "isolated_worker_receipt_scan",
+    spaceId: authoritySpaceId,
+    sessionId,
+    turnId,
+    userId,
+    data: {
+      authoritySpaceId,
+      disposableSpaceId,
+      workerSessionId: sessionId,
+      workerTurnId: turnId,
+      podUid,
+      revokeTaskRunId,
+      checkpointId,
+      checkpointTreeSha256,
+    },
+  },
+});
+
+let observedDefaultEnqueueAt = 0;
+const defaultTimingHook = createIsolatedWorkerRevokeCompletionHook({
+  async enqueueReceiptScan() {
+    observedDefaultEnqueueAt = Date.now();
+  },
+});
+const immediateFinishedAt = new Date();
+await defaultTimingHook({
+  taskRunId: revokeTaskRunId,
+  payload: revokePayload,
+  result: revokeResult,
+  finishedAt: immediateFinishedAt,
+});
+assert.ok(observedDefaultEnqueueAt > immediateFinishedAt.getTime());
+
+const scanPayload = (enqueuedScan as { payload: TaskPayload }).payload;
+const revokeStartedAt = new Date("2026-07-15T00:00:00.000Z");
+const scanStartedAt = new Date("2026-07-15T00:00:03.001Z");
+const scanHandler = createIsolatedWorkerReceiptScanHandler({
+  async readRevokeTaskRun(id) {
+    assert.equal(id, revokeTaskRunId);
+    return {
+      id: revokeTaskRunId,
+      jobId: revokeTaskRunId,
+      taskType: "isolated_worker_revoke",
+      status: "completed",
+      spaceId: disposableSpaceId,
+      sessionId,
+      turnId,
+      userUuid: userId,
+      startedAt: revokeStartedAt,
+      finishedAt: revokeFinishedAt,
+      payload: revokePayload,
+      result: revokeResult,
+    };
+  },
+});
+assert.deepEqual(await scanHandler({ taskRunId: scanTaskRunId, startedAt: scanStartedAt, payload: scanPayload }), {
+  revokeTaskRunId,
+  scanStartedAfterRevoke: true,
+  receiptEligible: true,
+  checkpointId,
+  checkpointTreeSha256,
+});
+
+await assert.rejects(
+  scanHandler({ taskRunId: scanTaskRunId, startedAt: revokeFinishedAt, payload: scanPayload }),
+  /did not start after revoke completion/,
+);
+
+const mismatchedScanHandler = createIsolatedWorkerReceiptScanHandler({
+  async readRevokeTaskRun() {
+    return {
+      id: revokeTaskRunId,
+      jobId: revokeTaskRunId,
+      taskType: "isolated_worker_revoke",
+      status: "completed",
+      spaceId: disposableSpaceId,
+      sessionId,
+      turnId,
+      userUuid: userId,
+      startedAt: revokeStartedAt,
+      finishedAt: revokeFinishedAt,
+      payload: revokePayload,
+      result: {
+        ...revokeResult,
+        receipt: { ...receipt, checkpointTreeSha256: "c".repeat(64) },
+      },
+    };
+  },
+});
+await assert.rejects(
+  mismatchedScanHandler({ taskRunId: scanTaskRunId, startedAt: scanStartedAt, payload: scanPayload }),
+  /checkpoint binding mismatch/,
+);
+
+console.log("isolated worker revoke and receipt scan task tests passed");

--- a/apps/worker/src/tasks/isolated-worker-termination-task.ts
+++ b/apps/worker/src/tasks/isolated-worker-termination-task.ts
@@ -1,0 +1,91 @@
+import { eq } from "drizzle-orm";
+import { taskRuns } from "@cohub/db";
+import type { TaskPayload } from "@cohub/protocol/task";
+import {
+  ISOLATED_WORKER_RECEIPT_SCAN_TASK_TYPE,
+  ISOLATED_WORKER_REVOKE_TASK_TYPE,
+} from "@cohub/protocol/isolated-worker";
+import { config } from "../config.js";
+import { db } from "../db.js";
+import { enqueueTask, retryFailedTask } from "./enqueue.js";
+import {
+  createIsolatedWorkerReceiptScanHandler,
+  createIsolatedWorkerRevokeCompletionHook,
+  createIsolatedWorkerRevokeHandler,
+} from "./isolated-worker-termination-handler.js";
+import { registerTask } from "./registry.js";
+
+const revokeHandler = createIsolatedWorkerRevokeHandler({
+  async revokeInternal(input) {
+    const baseUrl = config.internalApiBaseUrl.replace(/\/+$/, "");
+    const response = await fetch(
+      `${baseUrl}/internal/spaces/${input.disposableSpaceId}/sessions/${input.sessionId}/turns/${input.turnId}/isolated-worker/revoke`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-worker-secret": config.workerSecret,
+        },
+        body: JSON.stringify(input.body),
+      },
+    );
+    const body = await response.json().catch(() => null);
+    if (!response.ok) {
+      throw new Error(`isolated worker internal revoke failed ${response.status}: ${JSON.stringify(body)}`);
+    }
+    return body;
+  },
+});
+
+const receiptScanHandler = createIsolatedWorkerReceiptScanHandler({
+  async readRevokeTaskRun(revokeTaskRunId) {
+    const [row] = await db.select({
+      id: taskRuns.id,
+      jobId: taskRuns.jobId,
+      taskType: taskRuns.taskType,
+      status: taskRuns.status,
+      spaceId: taskRuns.spaceId,
+      sessionId: taskRuns.sessionId,
+      turnId: taskRuns.turnId,
+      userUuid: taskRuns.userUuid,
+      startedAt: taskRuns.startedAt,
+      finishedAt: taskRuns.finishedAt,
+      payload: taskRuns.payload,
+      result: taskRuns.result,
+    }).from(taskRuns).where(eq(taskRuns.id, revokeTaskRunId)).limit(1);
+    return row ?? null;
+  },
+});
+
+const afterRevokeCompleted = createIsolatedWorkerRevokeCompletionHook({
+  async enqueueReceiptScan(input) {
+    const [existing] = await db.select({ status: taskRuns.status }).from(taskRuns)
+      .where(eq(taskRuns.id, input.taskRunId)).limit(1);
+    if (existing?.status === "failed") {
+      await retryFailedTask(input.taskRunId);
+      return;
+    }
+    if (existing && ["pending", "running", "completed"].includes(existing.status)) return;
+    await enqueueTask(input.payload, { taskRunId: input.taskRunId });
+  },
+});
+
+registerTask(
+  ISOLATED_WORKER_REVOKE_TASK_TYPE,
+  async (job, context) => {
+    if (!context?.taskRunId) throw new Error("isolated worker revoke TaskRun id is required");
+    return revokeHandler({ taskRunId: context.taskRunId, payload: job.data as TaskPayload });
+  },
+  { afterCompleted: afterRevokeCompleted },
+);
+
+registerTask(ISOLATED_WORKER_RECEIPT_SCAN_TASK_TYPE, async (job, context) => {
+  if (!context?.taskRunId || !context.startedAt) {
+    throw new Error("isolated worker receipt scan TaskRun context is required");
+  }
+  return receiptScanHandler({
+    taskRunId: context.taskRunId,
+    startedAt: context.startedAt,
+    payload: job.data as TaskPayload,
+  });
+});

--- a/apps/worker/src/tasks/registry.ts
+++ b/apps/worker/src/tasks/registry.ts
@@ -12,6 +12,18 @@ import { createLogger } from "@cohub/infra/logging";
 const logger = createLogger({ serviceName: "cohub-worker" });
 export type TaskHandlerContext = {
   taskRunId: string;
+  startedAt: Date;
+};
+
+export type TaskCompletedContext = {
+  taskRunId: string;
+  payload: TaskPayload;
+  result: Record<string, unknown>;
+  finishedAt: Date;
+};
+
+export type RegisterTaskOptions = {
+  afterCompleted?: (context: TaskCompletedContext) => Promise<void>;
 };
 
 export type TaskHandler = (
@@ -35,12 +47,20 @@ function billingFailureResult(error: unknown) {
   return { error: serializeBillingBlocked(error) };
 }
 
+function explicitTaskFailureResult(error: unknown) {
+  if (!error || typeof error !== "object" || Array.isArray(error)) return null;
+  const result = (error as { taskResult?: unknown }).taskResult;
+  return result && typeof result === "object" && !Array.isArray(result)
+    ? result as Record<string, unknown>
+    : null;
+}
+
 export const markTaskRunFailed = async (job: Job, error: unknown) => {
   const jobId = job.id;
   if (!jobId) return;
 
   const errorMessage = error instanceof Error ? error.message : String(error);
-  const result = billingFailureResult(error);
+  const result = explicitTaskFailureResult(error) ?? billingFailureResult(error);
   const [taskRun] = await db
     .update(taskRuns)
     .set({
@@ -50,7 +70,7 @@ export const markTaskRunFailed = async (job: Job, error: unknown) => {
       finishedAt: new Date(),
       updatedAt: new Date(),
     })
-    .where(and(eq(taskRuns.jobId, jobId), ne(taskRuns.status, "failed")))
+    .where(and(eq(taskRuns.jobId, jobId), ne(taskRuns.status, "failed"), ne(taskRuns.status, "completed")))
     .returning();
 
   if (taskRun) {
@@ -61,7 +81,7 @@ export const markTaskRunFailed = async (job: Job, error: unknown) => {
   }
 };
 
-export const registerTask = (type: string, handler: TaskHandler) => {
+export const registerTask = (type: string, handler: TaskHandler, options?: RegisterTaskOptions) => {
   const wrapped: TaskHandler = async (job) => {
     const jobId = job.id;
     if (!jobId) throw new Error("Job has no id");
@@ -71,12 +91,39 @@ export const registerTask = (type: string, handler: TaskHandler) => {
 
     // UPSERT: insert if cron-spawned, or update pending → running
     const existing = await db
-      .select({ id: taskRuns.id })
+      .select({
+        id: taskRuns.id,
+        status: taskRuns.status,
+        payload: taskRuns.payload,
+        result: taskRuns.result,
+        finishedAt: taskRuns.finishedAt,
+      })
       .from(taskRuns)
       .where(eq(taskRuns.jobId, jobId))
       .limit(1);
 
     let taskRunId = existing[0]?.id ?? crypto.randomUUID();
+
+    const alreadyCompleted = existing[0];
+    if (alreadyCompleted?.status === "completed") {
+      if (
+        !alreadyCompleted.finishedAt
+        || !alreadyCompleted.result
+        || typeof alreadyCompleted.result !== "object"
+        || Array.isArray(alreadyCompleted.result)
+      ) {
+        throw new Error(`Completed task ${taskRunId} is missing its completion result`);
+      }
+      if (options?.afterCompleted) {
+        await options.afterCompleted({
+          taskRunId,
+          payload: alreadyCompleted.payload,
+          result: alreadyCompleted.result as Record<string, unknown>,
+          finishedAt: alreadyCompleted.finishedAt,
+        });
+      }
+      return alreadyCompleted.result as Record<string, unknown>;
+    }
 
     if (existing.length > 0) {
       // Already exists (API-enqueued with pending status)
@@ -129,23 +176,34 @@ export const registerTask = (type: string, handler: TaskHandler) => {
     }
 
     try {
-      const result = await handler(job, { taskRunId });
+      const result = await handler(job, { taskRunId, startedAt: now });
 
+      const finishedAt = new Date();
       const [taskRun] = await db
         .update(taskRuns)
         .set({
           status: "completed",
           result: result ?? null,
-          finishedAt: new Date(),
-          updatedAt: new Date(),
+          finishedAt,
+          updatedAt: finishedAt,
         })
-        .where(eq(taskRuns.jobId, jobId))
+        .where(and(eq(taskRuns.jobId, jobId), ne(taskRuns.status, "completed")))
         .returning();
       if (taskRun) {
         await dispatchTaskUpdated({
           task: taskRun,
           changed: ["status", "result", "finishedAt"],
         }).catch((error) => logger.warn("[Realtime] failed to dispatch task.updated", error));
+      }
+
+      if (options?.afterCompleted) {
+        if (!taskRun) throw new Error(`Task ${taskRunId} completion was not persisted`);
+        await options.afterCompleted({
+          taskRunId,
+          payload: taskRun.payload,
+          result: result ?? {},
+          finishedAt,
+        });
       }
 
       return result;

--- a/apps/worker/src/tasks/run-command-task.ts
+++ b/apps/worker/src/tasks/run-command-task.ts
@@ -11,7 +11,7 @@ import type { Job } from "bullmq";
 import type { TaskPayload } from "@cohub/protocol/task";
 import type { GenerationPolicy } from "@cohub/protocol/generation";
 import { normalizePermissionScopes } from "@cohub/core/permissions";
-import { createDelegatedPromptAuth, parsePromptEnv } from "@cohub/core/sessions";
+import { createDelegatedPromptAuth, parseAgentPromptAccessMode, parsePromptEnv } from "@cohub/core/sessions";
 import { config } from "../config.js";
 import { getPromptTemplateService } from "../prompt-templates.js";
 import { getSkillService } from "../skills.js";
@@ -117,8 +117,10 @@ async function notifyRunCommandCompletion(input: {
   result: AgentRunCommandJobResult;
   notify: RunCommandNotify | null;
   origin: RunCommandOrigin | null;
+  accessMode: "read_only" | "full_access" | "isolated_worker";
 }) {
   if (!input.notify) return;
+  if (input.accessMode === "isolated_worker") return;
   const spaceId = input.payload.spaceId;
   const userId = input.payload.userId?.trim();
   if (!spaceId || !userId) return;
@@ -158,7 +160,7 @@ async function notifyRunCommandCompletion(input: {
       })(),
       origin: input.origin,
     },
-    accessMode: "full_access",
+    accessMode: input.accessMode,
   });
 }
 
@@ -180,6 +182,7 @@ registerTask(RUN_COMMAND_TASK_TYPE, async (job) => {
   const generationPolicy = parseGenerationPolicy(data.generationPolicy);
   const promptEnv = parsePromptEnv(data.env);
   const executionScopes = normalizePermissionScopes(Array.isArray(data.executionScopes) ? data.executionScopes : []);
+  const accessMode = parseAgentPromptAccessMode(data.accessMode);
   const origin = parseOrigin(data.origin);
   const notify = parseNotify(data.notify);
   if (!spaceId) throw new Error("spaceId is required for run_command task");
@@ -198,6 +201,7 @@ registerTask(RUN_COMMAND_TASK_TYPE, async (job) => {
     ...(generationPolicy ? { generationPolicy } : {}),
     ...(promptEnv ? { env: promptEnv } : {}),
     ...(executionScopes.length > 0 ? { executionScopes } : {}),
+    accessMode,
     requestId: origin?.requestId ?? null,
     origin,
   });
@@ -220,7 +224,7 @@ registerTask(RUN_COMMAND_TASK_TYPE, async (job) => {
   try {
     const result = await agentJob.waitUntilFinished(queueEvents, ((timeout ?? RUN_COMMAND_TIMEOUT_SECONDS) + 60) * 1000) as AgentRunCommandJobResult;
     await mirrorAgentProgress(job, agentJob.id ?? `run-command-${taskRunId}`);
-    await notifyRunCommandCompletion({ payload, taskRunId, command, result, notify, origin });
+    await notifyRunCommandCompletion({ payload, taskRunId, command, result, notify, origin, accessMode });
     return result;
   } catch (error) {
     throw error instanceof Error ? error : new Error(String(error));

--- a/apps/worker/src/tasks/save-checkpoint-task.ts
+++ b/apps/worker/src/tasks/save-checkpoint-task.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { createHash } from "node:crypto";
 import { eq } from "drizzle-orm";
 import type { Job } from "bullmq";
 import type { TaskPayload } from "@cohub/protocol/task";
@@ -20,7 +21,7 @@ import {
   materializeFilePatches,
   type CheckpointDiffMeta,
 } from "../checkpoint/diff-precompute.js";
-import { ensureGitRepo, runGit, runGitWithOutput } from "../checkpoint/git.js";
+import { ensureGitRepo, runGit, runGitWithBuffer, runGitWithOutput } from "../checkpoint/git.js";
 import { collectUserGitRepos } from "../checkpoint/git-bundles.js";
 import { saveCanvasCheckpointSnapshots } from "../checkpoint/canvas.js";
 import { materializeLatest } from "../checkpoint/materialize.js";
@@ -162,6 +163,10 @@ export const saveCheckpointForSpace = async (input: SaveCheckpointInput): Promis
   await timeIt(timings, "gitCommit", () => runGit(["commit", "--allow-empty", "-m", commitMessage], dirs.repoDir));
   const head = await timeIt(timings, "gitRevParse", () => runGitWithOutput(["rev-parse", "HEAD"], dirs.repoDir));
   const commitHash = head.stdout.trim();
+  const tree = await timeIt(timings, "gitTreeRevParse", () => runGitWithOutput(["rev-parse", "HEAD^{tree}"], dirs.repoDir));
+  const treeHash = tree.stdout.trim();
+  const treeListing = await timeIt(timings, "gitTreeSha256", () => runGitWithBuffer(["ls-tree", "-r", "-z", "--full-tree", "HEAD"], dirs.repoDir));
+  const checkpointTreeSha256 = createHash("sha256").update(treeListing.stdout).digest("hex");
 
   // Persist precomputed parent diff: inline in meta when small, OSS when large.
   // Also precompute a capped set of text file patches (sequential, NFS-friendly).
@@ -238,6 +243,7 @@ export const saveCheckpointForSpace = async (input: SaveCheckpointInput): Promis
       version: SAVE_VERSION,
       branch,
       commitMessage,
+      gitTree: { hash: treeHash, sha256: checkpointTreeSha256 },
       paths: {
         assetManifest: CHECKPOINT_ASSET_MANIFEST_PATH,
         checkpointMeta: CHECKPOINT_META_PATH,
@@ -328,7 +334,7 @@ export const saveCheckpointForSpace = async (input: SaveCheckpointInput): Promis
   }
 
   await progress("completed", { checkpointId: checkpoint.id, commitHash, ...(publishWarnings.length > 0 ? { publishWarnings } : {}) });
-  return { checkpointId: checkpoint.id, commitHash, branch, commitMessage, changedFiles: diffStats.changedFileCount, stats, assetCount, detectedGitRepoCount, timings, spaceId, latestSubPath: getCheckpointLatestSubPath(spaceId), ...(publishedUserConfig ? { publishedUserConfig } : {}), ...(publishedPlatformConfig ? { publishedPlatformConfig } : {}), ...(publishWarnings.length > 0 ? { publishWarnings } : {}) };
+  return { checkpointId: checkpoint.id, commitHash, treeHash, checkpointTreeSha256, branch, commitMessage, changedFiles: diffStats.changedFileCount, stats, assetCount, detectedGitRepoCount, timings, spaceId, latestSubPath: getCheckpointLatestSubPath(spaceId), ...(publishedUserConfig ? { publishedUserConfig } : {}), ...(publishedPlatformConfig ? { publishedPlatformConfig } : {}), ...(publishWarnings.length > 0 ? { publishWarnings } : {}) };
 };
 
 const saveCheckpointHandler = async (job: Job, context?: { taskRunId: string }) => {

--- a/packages/core/src/sessions/prompt-isolated-worker.test.ts
+++ b/packages/core/src/sessions/prompt-isolated-worker.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { submitSessionPrompt, type SessionPromptDependencies } from "./prompt.js";
+
+const events: string[] = [];
+let enqueuedMeta: Record<string, unknown> | null = null;
+
+const deps: SessionPromptDependencies = {
+  randomUUID: () => "message-1",
+  expandPromptTemplate: async () => null,
+  sandboxRecovery: {
+    maybeRecoverForPrompt: async () => { events.push("sandbox-recovered"); },
+  },
+  createSessionTurn: async () => {
+    events.push("turn-created");
+    return { id: "turn-1" };
+  },
+  mergeSessionTurnMeta: async () => {
+    events.push("meta-persisted");
+  },
+  enqueueSpacePrompt: async (input) => {
+    events.push("enqueued");
+    enqueuedMeta = input.meta;
+  },
+  failSessionTurn: async () => null,
+};
+
+const isolatedWorker = {
+  podName: "sandbox-disposable-1",
+  status: "running",
+  resumable: false,
+  isolatedWorkerPolicy: {
+    authoritySpaceId: "authority-1",
+    disposableSpaceId: "disposable-1",
+    writableRoot: "/workspace/work",
+    workspaceReadOnly: true,
+    executionTokenIssued: false,
+    podUid: "pod-uid-1",
+    policySha256: "a".repeat(64),
+  },
+};
+
+await submitSessionPrompt(deps, {
+  spaceId: "authority-1",
+  sessionId: "session-1",
+  userId: "user-1",
+  clientMessageId: "client-1",
+  content: [{ type: "text", text: "work" }],
+  source: "internal",
+  accessMode: "isolated_worker",
+}, {
+  beforeEnqueue: async ({ turnId }) => {
+    assert.equal(turnId, "turn-1");
+    events.push("pod-created");
+    return { isolatedWorker };
+  },
+  afterMetaPersistedBeforeEnqueue: async () => { events.push("dispatch-completed"); },
+});
+
+assert.deepEqual(events, ["turn-created", "pod-created", "meta-persisted", "dispatch-completed", "enqueued"]);
+assert.deepEqual((enqueuedMeta as Record<string, unknown> | null)?.isolatedWorker, isolatedWorker);
+
+events.length = 0;
+await assert.rejects(
+  submitSessionPrompt(deps, {
+    spaceId: "authority-1",
+    sessionId: "session-1",
+    userId: "user-1",
+    clientMessageId: "client-2",
+    content: [{ type: "text", text: "work" }],
+    source: "internal",
+    accessMode: "isolated_worker",
+  }, {
+    beforeEnqueue: async () => {
+      events.push("pod-failed");
+      throw new Error("pod creation failed");
+    },
+  }),
+  /pod creation failed/,
+);
+assert.deepEqual(events, ["turn-created", "pod-failed"]);
+
+events.length = 0;
+await assert.rejects(
+  submitSessionPrompt({
+    ...deps,
+    enqueueSpacePrompt: async () => {
+      events.push("enqueue-failed");
+      throw new Error("queue unavailable");
+    },
+    failSessionTurn: async () => {
+      events.push("turn-failed");
+      return null;
+    },
+  }, {
+    spaceId: "disposable-1",
+    sessionId: "session-1",
+    userId: "user-1",
+    clientMessageId: "client-3",
+    content: [{ type: "text", text: "work" }],
+    source: "internal",
+    accessMode: "isolated_worker",
+  }, {
+    beforeEnqueue: async () => {
+      events.push("pod-created");
+      return { isolatedWorker };
+    },
+    beforeFailureTerminalized: async () => {
+      events.push("revoke-task-completed");
+    },
+  }),
+  /queue unavailable/,
+);
+assert.deepEqual(events, [
+  "turn-created",
+  "pod-created",
+  "meta-persisted",
+  "enqueue-failed",
+  "revoke-task-completed",
+  "turn-failed",
+]);

--- a/packages/core/src/sessions/prompt.ts
+++ b/packages/core/src/sessions/prompt.ts
@@ -116,6 +116,13 @@ export type SkillUsageMeta = {
 };
 
 export type PromptAccessMode = "read_only" | "full_access";
+export type AgentPromptAccessMode = PromptAccessMode | "isolated_worker";
+
+export function parseAgentPromptAccessMode(value: unknown): AgentPromptAccessMode {
+  if (value === undefined || value === null) return "full_access";
+  if (value === "read_only" || value === "full_access" || value === "isolated_worker") return value;
+  throw new Error("invalid prompt access mode");
+}
 
 export type SubmitSessionPromptInput = {
   spaceId: string;
@@ -127,7 +134,7 @@ export type SubmitSessionPromptInput = {
   model?: string | null;
   provider?: string | null;
   generationPolicy?: GenerationPolicy | null;
-  accessMode?: PromptAccessMode | null;
+  accessMode?: AgentPromptAccessMode | null;
   env?: PromptEnv | null;
   intent?: SessionTurnIntent | null;
   context?: SubmitSessionPromptContext | null;
@@ -143,6 +150,18 @@ export type SubmitSessionPromptHooks = {
     turnId: string;
     userMessageId: string;
     content: ContentBlock[];
+    meta: Record<string, unknown>;
+  }) => Promise<Record<string, unknown> | void>;
+  afterMetaPersistedBeforeEnqueue?: (input: {
+    turnId: string;
+    userMessageId: string;
+    content: ContentBlock[];
+    meta: Record<string, unknown>;
+  }) => Promise<void>;
+  beforeFailureTerminalized?: (input: {
+    turnId: string;
+    userMessageId: string;
+    error: unknown;
     meta: Record<string, unknown>;
   }) => Promise<void>;
 };
@@ -201,6 +220,11 @@ export type SessionPromptDependencies = {
     intent: SessionTurnIntent;
     meta: Record<string, unknown>;
   }): Promise<{ id: string }>;
+  mergeSessionTurnMeta(input: {
+    sessionId: string;
+    turnId: string;
+    metaPatch: Record<string, unknown>;
+  }): Promise<void>;
   enqueueSpacePrompt(input: {
     spaceId: string;
     sessionId: string;
@@ -320,7 +344,7 @@ export const submitSessionPrompt = async (
   if (!clientMessageId) throw new Error("clientMessageId is required");
   if (!Array.isArray(input.content) || input.content.length === 0) throw new Error("content is required");
 
-  if (deps.sandboxRecovery) {
+  if (deps.sandboxRecovery && input.accessMode !== "isolated_worker") {
     void Promise.resolve(deps.sandboxRecovery.maybeRecoverForPrompt({
       spaceId: input.spaceId,
       sessionId: input.sessionId,
@@ -338,7 +362,7 @@ export const submitSessionPrompt = async (
     spaceId: input.spaceId,
   });
   const content = normalizeContentBlocks(expandedContent);
-  const accessMode = input.accessMode ?? "full_access";
+  const accessMode = parseAgentPromptAccessMode(input.accessMode);
 
   const isDirectShellCommand = content.length === 1 && content[0]?.type === "shell_command";
   if (accessMode === "read_only" && isDirectShellCommand) {
@@ -398,7 +422,12 @@ export const submitSessionPrompt = async (
   };
 
   try {
-    await hooks.beforeEnqueue?.({ turnId, userMessageId, content, meta });
+    const metaPatch = await hooks.beforeEnqueue?.({ turnId, userMessageId, content, meta });
+    if (metaPatch && Object.keys(metaPatch).length > 0) {
+      await deps.mergeSessionTurnMeta({ sessionId: input.sessionId, turnId, metaPatch });
+      Object.assign(meta, metaPatch);
+    }
+    await hooks.afterMetaPersistedBeforeEnqueue?.({ turnId, userMessageId, content, meta });
     await deps.enqueueSpacePrompt({
       spaceId: input.spaceId,
       sessionId: input.sessionId,
@@ -408,11 +437,18 @@ export const submitSessionPrompt = async (
       meta,
     });
   } catch (error) {
-    await deps.failSessionTurn({
-      sessionId: input.sessionId,
-      turnId,
-      errorMessage: error instanceof Error ? error.message : String(error),
-    }).catch(() => undefined);
+    await hooks.beforeFailureTerminalized?.({ turnId, userMessageId, error, meta });
+    try {
+      await deps.failSessionTurn({
+        sessionId: input.sessionId,
+        turnId,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
+    } catch (terminalizationError) {
+      if (accessMode === "isolated_worker") {
+        throw new AggregateError([error, terminalizationError], "isolated worker prompt failure could not be terminalized");
+      }
+    }
 
     throw error;
   }

--- a/packages/core/src/sessions/service.ts
+++ b/packages/core/src/sessions/service.ts
@@ -190,6 +190,7 @@ export function createSessionServices(input: {
         provider,
         model,
         meta,
+        ...(meta.accessMode === "isolated_worker" ? { startedAt: null } : {}),
       }).returning();
       return { row, spaceId: sessionRow.spaceId };
     });
@@ -204,6 +205,23 @@ export function createSessionServices(input: {
       userUuids: [turnInput.userUuid],
     })).catch((error) => logger.warn("[Session] failed to publish session participant labels", error));
     return row;
+  }
+
+  async function mergeSessionTurnMeta(turnInput: {
+    sessionId: string;
+    turnId: string;
+    metaPatch: Record<string, unknown>;
+  }) {
+    const metaPatch = sanitizePostgresJsonValue(turnInput.metaPatch);
+    const [row] = await input.db.update(sessionTurns).set({
+      meta: sql`coalesce(${sessionTurns.meta}, '{}'::jsonb) || ${JSON.stringify(metaPatch)}::jsonb`,
+      updatedAt: new Date(),
+    }).where(and(
+      eq(sessionTurns.id, turnInput.turnId),
+      eq(sessionTurns.sessionId, turnInput.sessionId),
+      eq(sessionTurns.status, "queued"),
+    )).returning({ id: sessionTurns.id });
+    if (!row) throw new Error("queued session turn not found");
   }
 
   async function failSessionTurn(turnInput: { sessionId: string; turnId: string; errorMessage: string }) {
@@ -304,6 +322,7 @@ export function createSessionServices(input: {
         ? ({ text, userId, spaceId }) => input.skillService!.expand(text, { userId, spaceId })
         : undefined,
       createSessionTurn,
+      mergeSessionTurnMeta,
       enqueueSpacePrompt,
       failSessionTurn,
       billingUsageGate: input.billingUsageGate,

--- a/packages/core/src/tasks/enqueue.ts
+++ b/packages/core/src/tasks/enqueue.ts
@@ -5,7 +5,10 @@ import { taskRuns } from "@cohub/db";
 import type { TaskPayload } from "@cohub/protocol/task";
 
 export type TaskQueueJobOptions = { [key: string]: unknown; jobId?: string; delay?: number };
-export type TaskEnqueueOptions = Omit<TaskQueueJobOptions, "scheduledAt"> & { scheduledAt?: Date | null };
+export type TaskEnqueueOptions = Omit<TaskQueueJobOptions, "scheduledAt" | "taskRunId"> & {
+  scheduledAt?: Date | null;
+  taskRunId?: string;
+};
 
 type TasksDb = PostgresJsDatabase<typeof schema>;
 
@@ -18,8 +21,8 @@ export type EnqueueTaskRunInput<Job = unknown> = {
 };
 
 export async function enqueueTaskRun<Job = unknown>(input: EnqueueTaskRunInput<Job>) {
-  const taskRunId = crypto.randomUUID();
-  const { scheduledAt, ...jobOptions } = input.options ?? {};
+  const taskRunId = input.options?.taskRunId ?? crypto.randomUUID();
+  const { scheduledAt, taskRunId: _requestedTaskRunId, ...jobOptions } = input.options ?? {};
   const delay = typeof jobOptions.delay === "number" ? jobOptions.delay : 0;
   const scheduledAtValue = scheduledAt ?? (delay > 0 ? new Date(Date.now() + delay) : null);
 
@@ -35,7 +38,7 @@ export async function enqueueTaskRun<Job = unknown>(input: EnqueueTaskRunInput<J
     status: "pending",
     payload: input.payload,
     scheduledAt: scheduledAtValue,
-  }).returning();
+  }).onConflictDoNothing({ target: taskRuns.id }).returning();
 
   try {
     const job = await input.enqueue(input.payload.type, input.payload, {

--- a/packages/infra/src/agent-queue/index.ts
+++ b/packages/infra/src/agent-queue/index.ts
@@ -41,6 +41,7 @@ export type AgentRunCommandJobData = {
   generationPolicy?: GenerationPolicy | null;
   env?: Record<string, string> | null;
   executionScopes?: string[] | null;
+  accessMode?: "read_only" | "full_access" | "isolated_worker" | null;
   requestId?: string | null;
   trace?: Record<string, unknown>;
   origin?: AgentRunCommandOrigin | null;

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -50,6 +50,10 @@
       "types": "./dist/sandbox/index.d.ts",
       "default": "./dist/sandbox/index.js"
     },
+    "./isolated-worker": {
+      "types": "./dist/isolated-worker/index.d.ts",
+      "default": "./dist/isolated-worker/index.js"
+    },
     "./space-style": {
       "types": "./dist/space-style.d.ts",
       "default": "./dist/space-style.js"

--- a/packages/protocol/src/isolated-worker/index.ts
+++ b/packages/protocol/src/isolated-worker/index.ts
@@ -1,0 +1,114 @@
+import type { ContentBlock } from "../core/index.js";
+
+export const ISOLATED_WORKER_DISPATCH_TASK_TYPE = "isolated_worker_dispatch" as const;
+export const ISOLATED_WORKER_REVOKE_TASK_TYPE = "isolated_worker_revoke" as const;
+export const ISOLATED_WORKER_RECEIPT_SCAN_TASK_TYPE = "isolated_worker_receipt_scan" as const;
+export const ISOLATED_WORKER_CREATION_PATH = "dedicated_disposable_space_without_standard_sandbox" as const;
+
+export type IsolatedWorkerDispatchInput = {
+  content: ContentBlock[];
+  inputBundle: IsolatedWorkerInputBundle;
+  clientMessageId?: string | null;
+  title?: string | null;
+  source?: string | null;
+  model?: string | null;
+  provider?: string | null;
+  repairOfDisposableSpaceId?: string | null;
+};
+
+export type IsolatedWorkerInputItem = {
+  sourcePath: string;
+  destinationPath: string;
+  contentSha256: string;
+  sourceType: "regular_file";
+};
+
+export type IsolatedWorkerInputBundle = {
+  authorityCheckpointId: string;
+  authorityCheckpointCommit: string;
+  authorityTreeSha256: string;
+  inputManifestSha256: string;
+  runtimeAuthorityReadAllowed: false;
+  items: IsolatedWorkerInputItem[];
+};
+
+export type IsolatedWorkerReuseProbeInput = {
+  disposableSpaceId: string;
+  sessionId: string;
+};
+
+export type IsolatedWorkerDispatchResponse = {
+  taskRunId: string;
+  authoritySpaceId: string;
+  disposableSpaceId: string;
+  sessionId: string;
+  policySha256: string;
+  inputManifestSha256: string;
+  creationPath: typeof ISOLATED_WORKER_CREATION_PATH;
+  ordinarySandboxProvisioned: false;
+  terminatedSpaceReused: false;
+  credentialMode: "engine_scoped_dispatch_authority";
+  engineInternalSecretIssued: false;
+  publicPromptUsed: false;
+  checkpointAdapter: "trusted_production";
+};
+
+export type IsolatedWorkerReuseProbeResponse = {
+  taskRunId: string;
+  disposableSpaceId: string;
+  rejected: true;
+  reason: "terminated_space_reuse_forbidden";
+};
+
+export type IsolatedWorkerTerminalStatus = "completed" | "failed" | "cancelled" | "interrupted";
+
+export type IsolatedWorkerRevokeTaskData = {
+  trigger: "turn_terminal_event";
+  terminalStatus: IsolatedWorkerTerminalStatus;
+  authoritySpaceId: string;
+  disposableSpaceId: string;
+  sessionId: string;
+  turnId: string;
+  podUid: string;
+};
+
+export type IsolatedWorkerReceiptScanTaskData = {
+  authoritySpaceId: string;
+  disposableSpaceId: string;
+  workerSessionId: string;
+  workerTurnId: string;
+  podUid: string;
+  revokeTaskRunId: string;
+  checkpointId: string;
+  checkpointTreeSha256: string;
+};
+
+export type IsolatedWorkerDispatchTaskData = {
+  authoritySpaceId: string;
+  disposableSpaceId: string;
+  sessionId: string;
+  clientMessageId: string;
+  content: ContentBlock[];
+  source: string;
+  model: string | null;
+  provider: string | null;
+  policySha256: string;
+  inputBundle: IsolatedWorkerInputBundle;
+  inputManifestSha256: string;
+  creationPath: typeof ISOLATED_WORKER_CREATION_PATH;
+  ordinarySandboxProvisioned: false;
+  terminatedSpaceReused: false;
+  credentialMode: "engine_scoped_dispatch_authority";
+  engineInternalSecretIssued: false;
+  publicPromptUsed: false;
+  checkpointAdapter: "trusted_production";
+  repairOfDisposableSpaceId?: string;
+  reuseRejected?: false;
+};
+
+export type IsolatedWorkerReuseRejectedTaskData = {
+  authoritySpaceId: string;
+  disposableSpaceId: string;
+  reuseRejected: true;
+  reason: "terminated_space_reuse_forbidden";
+};

--- a/packages/sandbox-controller/src/index.ts
+++ b/packages/sandbox-controller/src/index.ts
@@ -217,6 +217,48 @@ export function isSandboxDialable(sandbox: {
   return Boolean(sandbox && isSandboxUsableStatus(sandbox.status) && hasSandboxEndpoint(sandbox.meta));
 }
 
+export function isIsolatedWorkerSandbox(sandbox: {
+  status?: string | null;
+  meta?: unknown;
+} | null | undefined): boolean {
+  if (!sandbox || !isRecord(sandbox.meta)) return false;
+  return isRecord(sandbox.meta.isolatedWorkerPolicy) || isRecord(sandbox.meta.isolatedWorker);
+}
+
+export function isTerminatedIsolatedWorkerSandbox(sandbox: {
+  status?: string | null;
+  meta?: unknown;
+} | null | undefined): boolean {
+  if (!isIsolatedWorkerSandbox(sandbox) || !isRecord(sandbox?.meta)) return false;
+  const termination = isRecord(sandbox.meta.termination) ? sandbox.meta.termination : null;
+  const claimId = typeof sandbox.meta.terminationClaimId === "string"
+    ? sandbox.meta.terminationClaimId.trim()
+    : "";
+  return sandbox.status === "stopping"
+    || sandbox.status === "terminated"
+    || termination?.sandboxTerminated === true
+    || Boolean(claimId);
+}
+
+export function assertSandboxCanResumeOrRecreate(sandbox: {
+  status?: string | null;
+  meta?: unknown;
+} | null | undefined): void {
+  if (isIsolatedWorkerSandbox(sandbox)) {
+    throw new Error("isolated worker sandbox cannot be resumed or recreated; allocate a new disposable space");
+  }
+}
+
+export function assertSandboxCanAutoRecover(sandbox: {
+  status?: string | null;
+  meta?: unknown;
+} | null | undefined): void {
+  assertSandboxCanResumeOrRecreate(sandbox);
+  if (sandbox?.status === "terminated") {
+    throw new Error("terminated sandbox cannot be automatically recovered");
+  }
+}
+
 /**
  * Clear connection coordinates (+ report token) so concurrent agents stop dialing
  * a dying pod and the old pod cannot report the dead endpoint back.
@@ -296,6 +338,7 @@ export function getSandboxPromptRecoveryReason(
 ): SandboxPromptRecoveryReason | null {
   if (!sandbox) return "missing";
   if (isLocalSandboxProvider(sandbox.provider)) return null;
+  if (isIsolatedWorkerSandbox(sandbox)) return null;
   if (sandbox.status === "provisioning" || sandbox.status === "pending") return null;
   if (sandbox.status === "terminated") return null;
   if (sandbox.status === "error") return "auto_recover";
@@ -451,6 +494,7 @@ export function createSandboxLifecycleController(input: {
     const lifecycleStatus = normalizeSandboxLifecycleStatus(heartbeat.status);
     const reportedImageVersion = heartbeat.metadata?.imageVersion?.trim() || null;
     const existing = await getSandbox(input.spaceId);
+    if (isTerminatedIsolatedWorkerSandbox(existing)) return existing;
     const reportMeta = toReportMeta(heartbeat);
     const shouldRefreshReport = Boolean(reportedImageVersion || heartbeat.capabilities || heartbeat.filesystem || heartbeat.metadata);
 
@@ -499,6 +543,9 @@ export function createSandboxLifecycleController(input: {
       // resumed server-side. Usable only while the local runner is connected.
       return { ok: isSandboxUsableStatus(sandbox.status), status: sandbox.status, resumed: false, local: true };
     }
+    if (isIsolatedWorkerSandbox(sandbox)) {
+      return { ok: false as const, status: sandbox?.status ?? null, resumed: false, message: "isolated worker sandbox cannot be resumed or recreated; allocate a new disposable space" };
+    }
     if (sandbox && isSandboxUsableStatus(sandbox.status)) return { ok: true as const, status: sandbox.status, resumed: false };
     if (sandbox?.status === "provisioning") return { ok: true as const, status: sandbox.status, resumed: false, provisioning: true };
     if (sandbox?.status === "terminated") return { ok: false as const, status: sandbox.status, resumed: false, message: "sandbox is terminated" };
@@ -506,6 +553,9 @@ export function createSandboxLifecycleController(input: {
 
     const result = await withLock(`sandbox:resume:${input.spaceId}`, async () => {
       const latest = await getSandbox(input.spaceId);
+      if (isIsolatedWorkerSandbox(latest)) {
+        return { ok: false as const, status: latest?.status ?? null, resumed: false, message: "isolated worker sandbox cannot be resumed or recreated; allocate a new disposable space" };
+      }
       if (latest && isSandboxUsableStatus(latest.status)) return { ok: true as const, status: latest.status, resumed: false };
       await db.update(spaceSandboxes).set({
         status: "provisioning",

--- a/packages/sandbox-controller/src/prompt-recovery.test.ts
+++ b/packages/sandbox-controller/src/prompt-recovery.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
 import {
+  assertSandboxCanResumeOrRecreate,
+  assertSandboxCanAutoRecover,
   buildInvalidatedSandboxEndpointMeta,
   getSandboxPromptRecoveryReason,
   hasSandboxEndpoint,
   isSandboxAwaitingEndpointReport,
   isSandboxDialable,
+  isTerminatedIsolatedWorkerSandbox,
   sandboxEndpointInvalidationPatch,
 } from "./index.js";
 
@@ -16,6 +19,91 @@ assert.equal(hasSandboxEndpoint(null), false);
 assert.equal(isSandboxDialable({ status: "running", meta: { podIp: "10.0.0.1" } }), true);
 assert.equal(isSandboxDialable({ status: "running", meta: {} }), false);
 assert.equal(isSandboxDialable({ status: "stopped", meta: { podIp: "10.0.0.1" } }), false);
+
+assert.equal(
+  isTerminatedIsolatedWorkerSandbox({
+    status: "running",
+    meta: {
+      isolatedWorkerPolicy: { disposableSpaceId: "space-disposable" },
+      termination: { sandboxTerminated: true },
+    },
+  }),
+  true,
+  "a persisted termination receipt is terminal even when status is stale",
+);
+assert.equal(
+  isTerminatedIsolatedWorkerSandbox({
+    status: "terminated",
+    meta: { isolatedWorkerPolicy: { disposableSpaceId: "space-disposable" } },
+  }),
+  true,
+  "terminated isolated workers cannot be recreated without a receipt readback",
+);
+assert.equal(
+  isTerminatedIsolatedWorkerSandbox({
+    status: "terminated",
+    meta: {},
+  }),
+  false,
+  "ordinary terminated sandboxes keep their existing recreate behavior",
+);
+assert.equal(
+  isTerminatedIsolatedWorkerSandbox({
+    status: "running",
+    meta: { termination: { sandboxTerminated: true } },
+  }),
+  false,
+  "a termination marker without isolated worker identity is not enough",
+);
+assert.equal(
+  isTerminatedIsolatedWorkerSandbox({
+    status: "stopping",
+    meta: {
+      isolatedWorkerPolicy: { disposableSpaceId: "space-disposable" },
+      terminationClaimId: "claim-1",
+    },
+  }),
+  true,
+  "a failed or in-flight revocation stays non-resumable",
+);
+assert.throws(
+  () => assertSandboxCanResumeOrRecreate({
+    status: "stopped",
+    meta: {
+      isolatedWorkerPolicy: { disposableSpaceId: "space-disposable" },
+      termination: { sandboxTerminated: true },
+    },
+  }),
+  /isolated worker sandbox cannot be resumed or recreated/,
+);
+assert.throws(
+  () => assertSandboxCanAutoRecover({ status: "terminated", meta: {} }),
+  /terminated sandbox cannot be automatically recovered/,
+);
+assert.throws(
+  () => assertSandboxCanAutoRecover({
+    status: "running",
+    meta: {
+      isolatedWorkerPolicy: { disposableSpaceId: "space-disposable" },
+      termination: { sandboxTerminated: true },
+    },
+  }),
+  /isolated worker sandbox cannot be resumed or recreated/,
+);
+assert.throws(
+  () => assertSandboxCanResumeOrRecreate({
+    status: "allocated",
+    meta: {
+      isolatedWorker: {
+        state: "allocated",
+        authoritySpaceId: "space-authority",
+        disposableSpaceId: "space-disposable",
+        resumable: false,
+      },
+    },
+  }),
+  /allocate a new disposable space/,
+);
 
 assert.equal(getSandboxPromptRecoveryReason(null), "missing");
 assert.equal(

--- a/packages/sdk/src/apis/spaces.ts
+++ b/packages/sdk/src/apis/spaces.ts
@@ -38,6 +38,10 @@ import type {
   SpaceDefaultResponse,
   CreateSpacePromptInput,
   CreateSpacePromptResponse,
+  IsolatedWorkerDispatchInput,
+  IsolatedWorkerDispatchResponse,
+  IsolatedWorkerReuseProbeInput,
+  IsolatedWorkerReuseProbeResponse,
   CreateSpaceCompletionInput,
   SpaceCompletionResult,
   SpaceCompletionStreamEvent,
@@ -1642,6 +1646,28 @@ export class SpaceClient {
   prompt(input: CreateSpacePromptInput) {
     return this.transport.request<CreateSpacePromptResponse>(
       `/api/spaces/${this.id}/prompt`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      },
+    );
+  }
+
+  dispatchIsolatedWorker(input: IsolatedWorkerDispatchInput) {
+    return this.transport.request<IsolatedWorkerDispatchResponse>(
+      `/api/spaces/${this.id}/isolated-workers/dispatch`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      },
+    );
+  }
+
+  probeTerminatedIsolatedWorkerReuse(input: IsolatedWorkerReuseProbeInput) {
+    return this.transport.request<IsolatedWorkerReuseProbeResponse>(
+      `/api/spaces/${this.id}/isolated-workers/reuse-probe`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/packages/sdk/src/isolated-worker-public-boundary.test.ts
+++ b/packages/sdk/src/isolated-worker-public-boundary.test.ts
@@ -1,0 +1,16 @@
+import type { CreateSpacePromptInput, SendMessageCronJobPayload } from "./types.js";
+
+const content = [{ type: "text" as const, text: "work" }];
+
+const publicPrompt: CreateSpacePromptInput = { content, accessMode: "full_access" };
+const scheduledPrompt: SendMessageCronJobPayload = { content, accessMode: "read_only" };
+void publicPrompt;
+void scheduledPrompt;
+
+// isolated_worker is available only through the dedicated disposable-worker API.
+// @ts-expect-error generic public prompt must not expose isolated_worker
+const forbiddenPublicPrompt: CreateSpacePromptInput = { content, accessMode: "isolated_worker" };
+// @ts-expect-error scheduled generic prompt must not expose isolated_worker
+const forbiddenScheduledPrompt: SendMessageCronJobPayload = { content, accessMode: "isolated_worker" };
+void forbiddenPublicPrompt;
+void forbiddenScheduledPrompt;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1041,6 +1041,13 @@ export type UserSessionsResponse = {
 
 export type PromptAccessMode = "read_only" | "full_access";
 
+export type {
+  IsolatedWorkerDispatchInput,
+  IsolatedWorkerDispatchResponse,
+  IsolatedWorkerReuseProbeInput,
+  IsolatedWorkerReuseProbeResponse,
+} from "@cohub/protocol/isolated-worker";
+
 export type CreateSpacePromptInput = {
   sessionId?: string | null;
   title?: string | null;


### PR DESCRIPTION
## Summary

- add the public isolated-worker dispatch contract and SDK boundary
- materialize a checkpoint-bound, exact input bundle into a disposable Space
- run the worker in a non-resumable Kubernetes Pod with no execution token, a read-only workspace, and only `/workspace/work` writable
- revoke the Pod automatically before checkpointing, receipt scanning, and terminalizing the Turn
- reject generic mutations, forged jobs, cross-Space queries, protocol shape drift, terminated reuse, and crash/retry bypasses

## Verification

- focused isolated-worker, disposable-guard, prompt, Pod lifecycle, queue, checkpoint, cross-Space, and terminal-order tests pass
- protocol, core, sandbox-controller, API, worker, agent, and SDK typechecks pass
- protocol, core, sandbox-controller, API, worker, agent, and SDK builds pass
- independent clean-context adversarial audit: PASS
- `git diff --check origin/main...HEAD`: PASS

Real Kubernetes lifecycle and UID-bound deletion remain an explicit dev-cluster acceptance step after deployment.
