### PR TITLE
fix(sdk): resolve isolated worker protocol types

### DIFF
--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -14,6 +14,7 @@
       "@cohub/protocol/task": ["../protocol/src/task/index.ts"],
       "@cohub/protocol/fs": ["../protocol/src/fs/index.ts"],
       "@cohub/protocol/generation": ["../protocol/src/generation/index.ts"],
+      "@cohub/protocol/isolated-worker": ["../protocol/src/isolated-worker/index.ts"],
       "@cohub/protocol/ports": ["../protocol/src/ports/index.ts"]
     }
   },


### PR DESCRIPTION
Adds the missing workspace source path for the new isolated-worker protocol module. This fixes the clean web typecheck failure from the isolated-worker merge. Verified with SDK typecheck plus the full web typecheck and production build.