### PR TITLE
fix(web): resolve isolated worker protocol alias

### DIFF
--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -31,6 +31,7 @@ const config = {
 			"@cohub/protocol/realtime": `${protocolDir}/realtime/index.ts`,
 			"@cohub/protocol/task": `${protocolDir}/task/index.ts`,
 			"@cohub/protocol/generation": `${protocolDir}/generation/index.ts`,
+			"@cohub/protocol/isolated-worker": `${protocolDir}/isolated-worker/index.ts`,
 			"@cohub/protocol": `${protocolDir}/index.ts`,
 			// sdk subpaths
 			"@neta-art/cohub/debugger": `${sdkDir}/debugger.ts`,


### PR DESCRIPTION
Adds the new protocol subpath to the web workspace aliases. The clean GitHub runner reproduced the missing-module failure; local web typecheck now passes with zero diagnostics.