### PR TITLE
fix(api): bind isolated worker UUID generation

### DIFF
--- a/apps/api/src/isolated-worker-dispatch.test.ts
+++ b/apps/api/src/isolated-worker-dispatch.test.ts
@@ -177,4 +177,14 @@ for (const text of ["content-a", "content-b"]) {
 }
 assert.notEqual(policyResults[0], policyResults[1], "policy hash must bind prompt content");
 
+const defaultRandomResult = await createIsolatedWorkerDispatch({
+  authoritySpaceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  userId: "user-1",
+  input: { clientMessageId: "default-random", content: [{ type: "text", text: "exercise production UUID generation" }], inputBundle },
+  store,
+});
+assert.match(defaultRandomResult.taskRunId, /^[0-9a-f-]{36}$/);
+assert.match(defaultRandomResult.disposableSpaceId, /^[0-9a-f-]{36}$/);
+assert.match(defaultRandomResult.sessionId, /^[0-9a-f-]{36}$/);
+
 console.log("isolated worker public dispatch allocation checks passed");

--- a/apps/api/src/isolated-worker-dispatch.ts
+++ b/apps/api/src/isolated-worker-dispatch.ts
@@ -215,7 +215,7 @@ export async function createIsolatedWorkerDispatch(input: {
   const parsedInput = parseIsolatedWorkerDispatchInput(input.input);
   const authoritySpaceId = requireText(input.authoritySpaceId, "authoritySpaceId");
   const userId = requireText(input.userId, "userId");
-  const randomUUID = input.randomUUID ?? crypto.randomUUID;
+  const randomUUID = input.randomUUID ?? (() => crypto.randomUUID());
   const disposableSpaceId = randomUUID();
   const sessionId = randomUUID();
   const taskRunId = randomUUID();
@@ -303,7 +303,7 @@ export async function createIsolatedWorkerReuseProbe(input: {
   if (target.authoritySpaceId !== input.authoritySpaceId || target.status !== "terminated") {
     throw new Error("reuse probe requires a terminated disposable space owned by the authority");
   }
-  const taskRunId = (input.randomUUID ?? crypto.randomUUID)();
+  const taskRunId = (input.randomUUID ?? (() => crypto.randomUUID()))();
   const data: IsolatedWorkerReuseRejectedTaskData = {
     authoritySpaceId: input.authoritySpaceId,
     disposableSpaceId: input.disposableSpaceId,


### PR DESCRIPTION
The first real dev dispatch exposed an unbound Web Crypto method and returned HTTP 500. A production-path regression test now reproduces the failure without an injected generator; the UUID calls are bound and the focused test, API typecheck, and dependency build all pass.