### PR TITLE
fix: preserve isolated dispatch failure causes

### DIFF
--- a/apps/worker/src/tasks/isolated-worker-dispatch-handler.ts
+++ b/apps/worker/src/tasks/isolated-worker-dispatch-handler.ts
@@ -322,7 +322,12 @@ export function createIsolatedWorkerDispatchHandler(deps: IsolatedWorkerDispatch
             cause: error,
           });
         } catch (rollbackError) {
-          throw new AggregateError([error, rollbackError], "isolated worker publish and reservation rollback both failed");
+          const publishMessage = error instanceof Error ? error.message : String(error);
+          const rollbackMessage = rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
+          throw new AggregateError(
+            [error, rollbackError],
+            `isolated worker publish failed: ${publishMessage}; reservation rollback failed: ${rollbackMessage}`,
+          );
         }
         throw error;
       }

--- a/apps/worker/src/tasks/isolated-worker-dispatch-task.test.ts
+++ b/apps/worker/src/tasks/isolated-worker-dispatch-task.test.ts
@@ -372,6 +372,26 @@ await assert.rejects(
 );
 assert.deepEqual(publishFailureCalls, ["recover", "prepare", "allocate", "publish", "rollback"]);
 
+const publishAndRollbackFailure = createIsolatedWorkerDispatchHandler({
+  async recoverReservation() { return { state: "none" }; },
+  async prepareWorkspace() {
+    return { inputsMaterializedAt: "2026-07-15T00:00:00.000Z", preparedWorkspace: "/stage" };
+  },
+  async cleanupPreparedWorkspace() {},
+  async allocateReservation() {},
+  async publishWorkspace() { throw new Error("publish root cause"); },
+  async rollbackReservation() { throw new Error("rollback root cause"); },
+  async readReservation() { throw new Error("must not read after publish failure"); },
+  async submitInternal() { throw new Error("must not submit after publish failure"); },
+});
+await assert.rejects(
+  publishAndRollbackFailure({
+    taskRunId,
+    payload: { type: "isolated_worker_dispatch", spaceId: authoritySpaceId, sessionId, userId: "user-1", data: dispatchData },
+  }),
+  /publish root cause.*rollback root cause/,
+);
+
 for (const recoveryState of ["staged", "prepared", "published"] as const) {
   const recoveryCalls: string[] = [];
   const recovery = createIsolatedWorkerDispatchHandler({


### PR DESCRIPTION
The live dev dispatch exposed an AggregateError whose two underlying failures were lost from task status and logs. This keeps both publish and rollback root-cause messages in the top-level error.

Verified with a red-before-green regression test and worker typecheck.