### PR TITLE
fix: publish and clean frozen worker workspaces

### DIFF
--- a/apps/worker/src/isolated-worker-inputs.test.ts
+++ b/apps/worker/src/isolated-worker-inputs.test.ts
@@ -1,9 +1,14 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { lstat, mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { materializeFrozenInputManifest } from "./isolated-worker-inputs.js";
+import {
+  materializeFrozenInputManifest,
+  prepareFrozenInputWorkspaceForPublish,
+  removeFrozenInputWorkspace,
+  sealFrozenInputWorkspace,
+} from "./isolated-worker-inputs.js";
 
 const root = await mkdtemp(join(tmpdir(), "cohub-isolated-inputs-"));
 const source = join(root, "source");
@@ -32,6 +37,15 @@ const receipt = await materializeFrozenInputManifest({ sourceRoot: source, targe
 assert.equal(await readFile(join(target, "inputs", "method.md"), "utf8"), "frozen method\n");
 await assert.rejects(readFile(join(target, "inputs", "undeclared.md")), /ENOENT/);
 assert.deepEqual(receipt.files, inputBundle.items);
+await prepareFrozenInputWorkspaceForPublish(target);
+assert.equal((await lstat(target)).mode & 0o777, 0o755);
+await sealFrozenInputWorkspace(target);
+assert.equal((await lstat(target)).mode & 0o777, 0o555);
+
+const cleanupTarget = join(root, "target-cleanup");
+await materializeFrozenInputManifest({ sourceRoot: source, targetRoot: cleanupTarget, inputBundle });
+await removeFrozenInputWorkspace(cleanupTarget);
+await assert.rejects(lstat(cleanupTarget), /ENOENT/);
 
 const symlinkTarget = join(root, "target-symlink");
 await symlink("method.md", join(source, "modules", "link.md"));

--- a/apps/worker/src/isolated-worker-inputs.ts
+++ b/apps/worker/src/isolated-worker-inputs.ts
@@ -1,6 +1,6 @@
 import { constants } from "node:fs";
 import { createHash } from "node:crypto";
-import { chmod, lstat, mkdir, open, readdir, realpath, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, open, readdir, realpath, rm, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
 import type { IsolatedWorkerInputBundle } from "@cohub/protocol/isolated-worker";
 
@@ -95,6 +95,43 @@ export async function materializeFrozenInputManifest(input: {
   for (const dir of [...createdDirs].sort((a, b) => b.length - a.length)) await chmod(dir, 0o555);
   await chmod(input.targetRoot, 0o555);
   return { files: copied, workRoot: "work/" as const };
+}
+
+async function assertWorkspaceDirectory(root: string) {
+  const entry = await lstat(root);
+  if (entry.isSymbolicLink() || !entry.isDirectory()) {
+    throw new Error(`frozen input workspace is not a directory: ${root}`);
+  }
+}
+
+export async function prepareFrozenInputWorkspaceForPublish(root: string) {
+  await assertWorkspaceDirectory(root);
+  await chmod(root, 0o755);
+}
+
+export async function sealFrozenInputWorkspace(root: string) {
+  await assertWorkspaceDirectory(root);
+  await chmod(root, 0o555);
+}
+
+async function makeFrozenDirectoryTreeRemovable(root: string): Promise<void> {
+  await assertWorkspaceDirectory(root);
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    if (entry.isDirectory() && !entry.isSymbolicLink()) {
+      await makeFrozenDirectoryTreeRemovable(resolve(root, entry.name));
+    }
+  }
+  await chmod(root, 0o700);
+}
+
+export async function removeFrozenInputWorkspace(root: string) {
+  try {
+    await makeFrozenDirectoryTreeRemovable(root);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  await rm(root, { recursive: true, force: true });
 }
 
 async function listInputFiles(root: string, relativeDir: string): Promise<string[]> {

--- a/apps/worker/src/tasks/isolated-worker-dispatch-task.ts
+++ b/apps/worker/src/tasks/isolated-worker-dispatch-task.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, readdir, rename, rm } from "node:fs/promises";
+import { lstat, mkdir, readdir, rename } from "node:fs/promises";
 import { dirname } from "node:path";
 import { and, eq } from "drizzle-orm";
 import type { TaskPayload } from "@cohub/protocol/task";
@@ -11,7 +11,13 @@ import { config } from "../config.js";
 import { getSpaceWorkspaceDir } from "../git.js";
 import { restoreWorkspaceFromCheckpoint } from "../checkpoint/restore.js";
 import { ensureWorkerLocalTmpDir, getWorkerLocalTmpDir, removeWorkerLocalTmpDir } from "../local-tmp.js";
-import { materializeFrozenInputManifest, verifyFrozenInputMaterialization } from "../isolated-worker-inputs.js";
+import {
+  materializeFrozenInputManifest,
+  prepareFrozenInputWorkspaceForPublish,
+  removeFrozenInputWorkspace,
+  sealFrozenInputWorkspace,
+  verifyFrozenInputMaterialization,
+} from "../isolated-worker-inputs.js";
 import { registerTask } from "./registry.js";
 import {
   canonicalIsolatedWorkerJson,
@@ -76,7 +82,7 @@ const productionDependencies: IsolatedWorkerDispatchHandlerDependencies = {
       try {
         await verifyFrozenInputMaterialization({ targetRoot: preparedWorkspace, inputBundle: input.data.inputBundle });
       } catch (error) {
-        await throwWithCleanup(error, [() => rm(preparedWorkspace, { recursive: true, force: true })], "isolated worker abandoned staging validation and cleanup failed");
+        await throwWithCleanup(error, [() => removeFrozenInputWorkspace(preparedWorkspace)], "isolated worker abandoned staging validation and cleanup failed");
       }
       return { state: "staged" as const, inputsMaterializedAt: new Date().toISOString(), preparedWorkspace };
     }
@@ -269,18 +275,18 @@ const productionDependencies: IsolatedWorkerDispatchHandlerDependencies = {
       try {
         await removeWorkerLocalTmpDir(evidenceRoot);
       } catch (cleanupError) {
-        await throwWithCleanup(cleanupError, [() => rm(preparedWorkspace, { recursive: true, force: true })], "isolated worker evidence and staging cleanup failed");
+        await throwWithCleanup(cleanupError, [() => removeFrozenInputWorkspace(preparedWorkspace)], "isolated worker evidence and staging cleanup failed");
       }
       return { inputsMaterializedAt, preparedWorkspace };
     } catch (error) {
       return throwWithCleanup(error, [
         () => removeWorkerLocalTmpDir(evidenceRoot),
-        () => rm(preparedWorkspace, { recursive: true, force: true }),
+        () => removeFrozenInputWorkspace(preparedWorkspace),
       ], "isolated worker input preparation and cleanup failed");
     }
   },
   async cleanupPreparedWorkspace(input) {
-    await rm(input.preparedWorkspace, { recursive: true, force: true });
+    await removeFrozenInputWorkspace(input.preparedWorkspace);
   },
   async allocateReservation(input) {
     const data = input.data;
@@ -402,7 +408,9 @@ const productionDependencies: IsolatedWorkerDispatchHandlerDependencies = {
           await mkdir(spaceBase, { mode: 0o775 });
           spaceBaseCreated = true;
         }
+        await prepareFrozenInputWorkspaceForPublish(input.preparedWorkspace);
         await rename(input.preparedWorkspace, finalWorkspace);
+        await sealFrozenInputWorkspace(finalWorkspace);
       } else {
         spaceBaseCreated = true;
       }
@@ -454,7 +462,7 @@ const productionDependencies: IsolatedWorkerDispatchHandlerDependencies = {
     if (input.cause instanceof IsolatedWorkerPublishError && input.cause.spaceBaseCreated) cleanupPaths.push(spaceBaseDir);
     for (const path of cleanupPaths) {
       try {
-        await rm(path, { recursive: true, force: true });
+        await removeFrozenInputWorkspace(path);
       } catch (error) {
         filesystemErrors.push(error);
       }


### PR DESCRIPTION
The live dev dispatch proved that the frozen staging root was read-only before the PVC rename, and the same frozen directory permissions prevented fail-closed cleanup.

This temporarily grants owner traversal only while the unpublished staging root is moved, reseals it immediately at the final path, and performs symlink-safe directory permission restoration before trusted cleanup.

A red-before-green regression now checks the publish transition and cleanup of a materialized frozen tree. Focused frozen-input and dispatch tests, worker typecheck, Biome, and diff validation pass.