### PR TITLE
[codex] make canvas transactions durable and idempotent

### DIFF
--- a/apps/api/drizzle/v2/0044_silky_mentallo.sql
+++ b/apps/api/drizzle/v2/0044_silky_mentallo.sql
@@ -1,0 +1,38 @@
+DROP INDEX "v2"."v2_idx_canvas_nodes_document_id";--> statement-breakpoint
+DROP INDEX "v2"."v2_idx_canvas_updates_document_id";--> statement-breakpoint
+ALTER TABLE "v2"."canvas_documents" ALTER COLUMN "meta" SET DEFAULT '{}'::jsonb;--> statement-breakpoint
+UPDATE "v2"."canvas_documents" SET "meta" = '{}'::jsonb WHERE "meta" IS NULL;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_documents" ALTER COLUMN "meta" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ADD COLUMN "tx_id" text;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ADD COLUMN "base_version" integer;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ADD COLUMN "request_hash" varchar(64);--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ADD COLUMN "result" jsonb DEFAULT '{}'::jsonb NOT NULL;--> statement-breakpoint
+UPDATE "v2"."canvas_updates"
+SET
+  "tx_id" = COALESCE(NULLIF("payload" ->> 'txId', ''), "id"::text),
+  "base_version" = CASE
+    WHEN "payload" ->> 'baseVersion' ~ '^[0-9]+$' THEN ("payload" ->> 'baseVersion')::integer
+    ELSE GREATEST("version" - 1, 0)
+  END;--> statement-breakpoint
+WITH ranked AS (
+  SELECT "id", row_number() OVER (
+    PARTITION BY "document_id", "tx_id"
+    ORDER BY "version" DESC, "id" DESC
+  ) AS duplicate_rank
+  FROM "v2"."canvas_updates"
+)
+UPDATE "v2"."canvas_updates" AS updates
+SET "tx_id" = updates."tx_id" || ':legacy:' || updates."id"::text
+FROM ranked
+WHERE updates."id" = ranked."id" AND ranked.duplicate_rank > 1;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ALTER COLUMN "tx_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ALTER COLUMN "base_version" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_documents" ADD CONSTRAINT "canvas_documents_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "v2"."spaces"("id") ON DELETE cascade ON UPDATE no action NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_nodes" ADD CONSTRAINT "canvas_nodes_document_id_canvas_documents_id_fk" FOREIGN KEY ("document_id") REFERENCES "v2"."canvas_documents"("id") ON DELETE cascade ON UPDATE no action NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ADD CONSTRAINT "canvas_updates_document_id_canvas_documents_id_fk" FOREIGN KEY ("document_id") REFERENCES "v2"."canvas_documents"("id") ON DELETE cascade ON UPDATE no action NOT VALID;--> statement-breakpoint
+CREATE UNIQUE INDEX "v2_uq_canvas_updates_document_tx" ON "v2"."canvas_updates" USING btree ("document_id","tx_id");--> statement-breakpoint
+ALTER TABLE "v2"."canvas_documents" ADD CONSTRAINT "v2_chk_canvas_documents_version" CHECK ("v2"."canvas_documents"."version" >= 0) NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_nodes" ADD CONSTRAINT "v2_chk_canvas_nodes_dimensions" CHECK ("v2"."canvas_nodes"."width" > 0 AND "v2"."canvas_nodes"."height" > 0) NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_nodes" ADD CONSTRAINT "v2_chk_canvas_nodes_version" CHECK ("v2"."canvas_nodes"."version" >= 0) NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ADD CONSTRAINT "v2_chk_canvas_updates_base_version" CHECK ("v2"."canvas_updates"."base_version" >= 0) NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ADD CONSTRAINT "v2_chk_canvas_updates_version" CHECK ("v2"."canvas_updates"."version" > "v2"."canvas_updates"."base_version") NOT VALID;

--- a/apps/api/drizzle/v2/meta/0044_snapshot.json
+++ b/apps/api/drizzle/v2/meta/0044_snapshot.json
@@ -1,0 +1,6685 @@
+{
+  "id": "5595636d-ff60-4d44-9b92-a979a96fc4ba",
+  "prevId": "d509dbad-2f53-4e93-b3df-ca527b7c18b1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "v2.access_policies": {
+      "name": "access_policies",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_in_user_role": {
+          "name": "signed_in_user_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_user_role": {
+          "name": "anonymous_user_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_access_policies_resource": {
+          "name": "v2_uq_access_policies_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_access_policies_resource": {
+          "name": "v2_idx_access_policies_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.canvas_checkpoint_snapshots": {
+      "name": "canvas_checkpoint_snapshots",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_space_id": {
+          "name": "source_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_file_path": {
+          "name": "source_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_checkpoint_snapshots_path": {
+          "name": "v2_uq_canvas_checkpoint_snapshots_path",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_checkpoint_snapshots_checkpoint_id": {
+          "name": "v2_idx_canvas_checkpoint_snapshots_checkpoint_id",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.canvas_documents": {
+      "name": "canvas_documents",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_canvas_documents_space_id": {
+          "name": "v2_idx_canvas_documents_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_canvas_documents_space_path": {
+          "name": "v2_uq_canvas_documents_space_path",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_documents_space_id_spaces_id_fk": {
+          "name": "canvas_documents_space_id_spaces_id_fk",
+          "tableFrom": "canvas_documents",
+          "tableTo": "spaces",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_documents_version": {
+          "name": "v2_chk_canvas_documents_version",
+          "value": "\"v2\".\"canvas_documents\".\"version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.canvas_nodes": {
+      "name": "canvas_nodes",
+      "schema": "v2",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 240
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 160
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ref_kind": {
+          "name": "ref_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_path": {
+          "name": "ref_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_url": {
+          "name": "ref_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view": {
+          "name": "view",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "style": {
+          "name": "style",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "animation": {
+          "name": "animation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_nodes_document_node": {
+          "name": "v2_uq_canvas_nodes_document_node",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_nodes_viewport": {
+          "name": "v2_idx_canvas_nodes_viewport",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "x",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "y",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_nodes_ref_path": {
+          "name": "v2_idx_canvas_nodes_ref_path",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_nodes_document_id_canvas_documents_id_fk": {
+          "name": "canvas_nodes_document_id_canvas_documents_id_fk",
+          "tableFrom": "canvas_nodes",
+          "tableTo": "canvas_documents",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_nodes_dimensions": {
+          "name": "v2_chk_canvas_nodes_dimensions",
+          "value": "\"v2\".\"canvas_nodes\".\"width\" > 0 AND \"v2\".\"canvas_nodes\".\"height\" > 0"
+        },
+        "v2_chk_canvas_nodes_version": {
+          "name": "v2_chk_canvas_nodes_version",
+          "value": "\"v2\".\"canvas_nodes\".\"version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.canvas_updates": {
+      "name": "canvas_updates",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_id": {
+          "name": "tx_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_version": {
+          "name": "base_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "undo_group_id": {
+          "name": "undo_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_updates_document_version": {
+          "name": "v2_uq_canvas_updates_document_version",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_canvas_updates_document_tx": {
+          "name": "v2_uq_canvas_updates_document_tx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tx_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_updates_document_id_canvas_documents_id_fk": {
+          "name": "canvas_updates_document_id_canvas_documents_id_fk",
+          "tableFrom": "canvas_updates",
+          "tableTo": "canvas_documents",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_updates_base_version": {
+          "name": "v2_chk_canvas_updates_base_version",
+          "value": "\"v2\".\"canvas_updates\".\"base_version\" >= 0"
+        },
+        "v2_chk_canvas_updates_version": {
+          "name": "v2_chk_canvas_updates_version",
+          "value": "\"v2\".\"canvas_updates\".\"version\" > \"v2\".\"canvas_updates\".\"base_version\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.checkpoints": {
+      "name": "checkpoints",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_checkpoint_id": {
+          "name": "parent_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_checkpoint_id": {
+          "name": "root_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fork_count": {
+          "name": "fork_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "save_version": {
+          "name": "save_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_checkpoints_space_id": {
+          "name": "v2_idx_checkpoints_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_parent_id": {
+          "name": "v2_idx_checkpoints_parent_id",
+          "columns": [
+            {
+              "expression": "parent_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_root_id": {
+          "name": "v2_idx_checkpoints_root_id",
+          "columns": [
+            {
+              "expression": "root_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_description_trgm": {
+          "name": "v2_idx_checkpoints_description_trgm",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_uq_checkpoints_space_commit": {
+          "name": "v2_uq_checkpoints_space_commit",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asia/Shanghai'"
+        },
+        "bull_job_key": {
+          "name": "bull_job_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_cron_jobs_user_uuid": {
+          "name": "v2_idx_cron_jobs_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_space_id": {
+          "name": "v2_idx_cron_jobs_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_enabled": {
+          "name": "v2_idx_cron_jobs_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_created_at": {
+          "name": "v2_idx_cron_jobs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.gateway_logs": {
+      "name": "gateway_logs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_payload": {
+          "name": "normalized_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'success'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_gateway_logs_channel": {
+          "name": "v2_idx_gateway_logs_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_gateway_logs_direction": {
+          "name": "v2_idx_gateway_logs_direction",
+          "columns": [
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_gateway_logs_created": {
+          "name": "v2_idx_gateway_logs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.generation_usage_stats_hourly": {
+      "name": "generation_usage_stats_hourly",
+      "schema": "v2",
+      "columns": {
+        "bucket_start_at": {
+          "name": "bucket_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_generation_usage_stats_hourly_bucket_dims": {
+          "name": "v2_uq_generation_usage_stats_hourly_bucket_dims",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usage_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_user_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_user_bucket",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_space_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_space_bucket",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_session_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_session_bucket",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_usage_type_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_usage_type_bucket",
+          "columns": [
+            {
+              "expression": "usage_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_provider_model_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_provider_model_bucket",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.label_assignments": {
+      "name": "label_assignments",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_ref": {
+          "name": "resource_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_label_assignments_label_resource": {
+          "name": "v2_uq_label_assignments_label_resource",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_label_rank": {
+          "name": "v2_idx_label_assignments_label_rank",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_scope_resource": {
+          "name": "v2_idx_label_assignments_scope_resource",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_scope_label": {
+          "name": "v2_idx_label_assignments_scope_label",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_session_label_resource": {
+          "name": "v2_idx_label_assignments_session_label_resource",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2\".\"label_assignments\".\"resource_type\" = 'session'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_resource_label": {
+          "name": "v2_idx_label_assignments_resource_label",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_resource_ref_trgm": {
+          "name": "v2_idx_label_assignments_resource_ref_trgm",
+          "columns": [
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.labels": {
+      "name": "labels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "system_key": {
+          "name": "system_key",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_labels_scope_rank": {
+          "name": "v2_idx_labels_scope_rank",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_labels_scope_parent": {
+          "name": "v2_idx_labels_scope_parent",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_labels_scope_parent_name": {
+          "name": "v2_uq_labels_scope_parent_name",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"parent_id\"::text, '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_labels_scope_system_key": {
+          "name": "v2_uq_labels_scope_system_key",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_labels_depth": {
+          "name": "v2_chk_labels_depth",
+          "value": "\"v2\".\"labels\".\"depth\" in (0, 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.proposals": {
+      "name": "proposals",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_checkpoint_id": {
+          "name": "source_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_space_id": {
+          "name": "target_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_branch_name": {
+          "name": "source_branch_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch_name": {
+          "name": "target_branch_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_pr_id": {
+          "name": "external_pr_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'open'"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_proposals_target_space_id": {
+          "name": "v2_idx_proposals_target_space_id",
+          "columns": [
+            {
+              "expression": "target_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_proposals_source_checkpoint_id": {
+          "name": "v2_idx_proposals_source_checkpoint_id",
+          "columns": [
+            {
+              "expression": "source_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_proposals_status": {
+          "name": "v2_idx_proposals_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.provider_message_refs": {
+      "name": "provider_message_refs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_session_id": {
+          "name": "space_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_channel_id": {
+          "name": "space_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_message_id": {
+          "name": "session_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_conversation_id": {
+          "name": "external_conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_external_conversation_id": {
+          "name": "parent_external_conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_external_message_id": {
+          "name": "parent_external_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_author_id": {
+          "name": "external_author_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_author_name": {
+          "name": "external_author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_provider_message_refs_provider_conversation": {
+          "name": "v2_idx_provider_message_refs_provider_conversation",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_provider_message_refs_provider_message": {
+          "name": "v2_uq_provider_message_refs_provider_message",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_space_session": {
+          "name": "v2_idx_provider_message_refs_space_session",
+          "columns": [
+            {
+              "expression": "space_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_session_message": {
+          "name": "v2_idx_provider_message_refs_session_message",
+          "columns": [
+            {
+              "expression": "session_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_parent_message": {
+          "name": "v2_idx_provider_message_refs_parent_message",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_space_channel": {
+          "name": "v2_idx_provider_message_refs_space_channel",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.referral_codes": {
+      "name": "referral_codes",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_referral_codes_code": {
+          "name": "v2_uq_referral_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_referral_codes_active_user": {
+          "name": "v2_uq_referral_codes_active_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2\".\"referral_codes\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referral_codes_user": {
+          "name": "v2_idx_referral_codes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.referrals": {
+      "name": "referrals",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referral_code_id": {
+          "name": "referral_code_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_user_id": {
+          "name": "inviter_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_user_id": {
+          "name": "invitee_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "qualified_at": {
+          "name": "qualified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewarded_at": {
+          "name": "rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_rewarded_at": {
+          "name": "inviter_rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitee_rewarded_at": {
+          "name": "invitee_rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_reward_amount_usd": {
+          "name": "inviter_reward_amount_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_reward_amount_usd": {
+          "name": "invitee_reward_amount_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_error": {
+          "name": "reward_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_attempted_at": {
+          "name": "reward_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_lease_token": {
+          "name": "reward_lease_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_lease_expires_at": {
+          "name": "reward_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_referrals_invitee": {
+          "name": "v2_uq_referrals_invitee",
+          "columns": [
+            {
+              "expression": "invitee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_inviter": {
+          "name": "v2_idx_referrals_inviter",
+          "columns": [
+            {
+              "expression": "inviter_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_code": {
+          "name": "v2_idx_referrals_code",
+          "columns": [
+            {
+              "expression": "referral_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_qualified_retry": {
+          "name": "v2_idx_referrals_qualified_retry",
+          "columns": [
+            {
+              "expression": "reward_attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2\".\"referrals\".\"status\" = 'qualified'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.resource_references": {
+      "name": "resource_references",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_turn_id": {
+          "name": "source_turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_resource_references_target": {
+          "name": "v2_idx_resource_references_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_source": {
+          "name": "v2_idx_resource_references_source",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_space_kind": {
+          "name": "v2_idx_resource_references_space_kind",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_session_kind": {
+          "name": "v2_idx_resource_references_session_kind",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_turn": {
+          "name": "v2_idx_resource_references_turn",
+          "columns": [
+            {
+              "expression": "source_turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "v2_uq_resource_references_identity": {
+          "name": "v2_uq_resource_references_identity",
+          "nullsNotDistinct": true,
+          "columns": [
+            "kind",
+            "source_type",
+            "source_id",
+            "source_turn_id",
+            "target_type",
+            "target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_forks": {
+      "name": "session_forks",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_session_id": {
+          "name": "child_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_session_id": {
+          "name": "root_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_source_session_id": {
+          "name": "anchor_source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_turn_id": {
+          "name": "anchor_turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_sequence": {
+          "name": "anchor_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_session_ids": {
+          "name": "ancestor_session_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_path": {
+          "name": "session_path",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_session_forks_child": {
+          "name": "v2_uq_session_forks_child",
+          "columns": [
+            {
+              "expression": "child_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_parent": {
+          "name": "v2_idx_session_forks_parent",
+          "columns": [
+            {
+              "expression": "parent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_root_depth": {
+          "name": "v2_idx_session_forks_root_depth",
+          "columns": [
+            {
+              "expression": "root_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_anchor_turn": {
+          "name": "v2_idx_session_forks_anchor_turn",
+          "columns": [
+            {
+              "expression": "anchor_turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_messages": {
+      "name": "session_messages",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_aggregated_at": {
+          "name": "usage_aggregated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_session_messages_session_id": {
+          "name": "v2_idx_session_messages_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_messages_session_sequence": {
+          "name": "v2_uq_session_messages_session_sequence",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_messages_session_id_idempotency_key": {
+          "name": "v2_uq_session_messages_session_id_idempotency_key",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_turn_segments": {
+      "name": "session_turn_segments",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_sequence": {
+          "name": "from_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_sequence": {
+          "name": "to_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_session_turn_segments_session_ordinal": {
+          "name": "v2_uq_session_turn_segments_session_ordinal",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turn_segments_session": {
+          "name": "v2_idx_session_turn_segments_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turn_segments_source": {
+          "name": "v2_idx_session_turn_segments_source",
+          "columns": [
+            {
+              "expression": "source_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_turns": {
+      "name": "session_turns",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "intent": {
+          "name": "intent",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'steer'"
+        },
+        "user_content": {
+          "name": "user_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_text": {
+          "name": "user_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_content": {
+          "name": "assistant_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_text": {
+          "name": "assistant_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_usage": {
+          "name": "final_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_usage": {
+          "name": "total_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intermediate_index": {
+          "name": "intermediate_index",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intermediate_summary": {
+          "name": "intermediate_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_session_turns_session_id": {
+          "name": "v2_idx_session_turns_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_turns_session_sequence": {
+          "name": "v2_uq_session_turns_session_sequence",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_user_uuid": {
+          "name": "v2_idx_session_turns_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_created_at": {
+          "name": "v2_idx_session_turns_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_user_text_trgm": {
+          "name": "v2_idx_session_turns_user_text_trgm",
+          "columns": [
+            {
+              "expression": "user_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_channels": {
+      "name": "space_channels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_channels_space": {
+          "name": "v2_idx_space_channels_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_channels_channel": {
+          "name": "v2_uq_space_channels_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_commerce_businesses": {
+      "name": "space_commerce_businesses",
+      "schema": "v2",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_business_key": {
+          "name": "billing_business_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_commerce_businesses_business_key": {
+          "name": "v2_uq_space_commerce_businesses_business_key",
+          "columns": [
+            {
+              "expression": "billing_business_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_marks": {
+      "name": "space_marks",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_ref": {
+          "name": "resource_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_marks_resource": {
+          "name": "v2_uq_space_marks_resource",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_marks_space_kind_rank": {
+          "name": "v2_idx_space_marks_space_kind_rank",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_marks_space_resource": {
+          "name": "v2_idx_space_marks_space_resource",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_members": {
+      "name": "space_members",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_members_space_user": {
+          "name": "v2_uq_space_members_space_user",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_space": {
+          "name": "v2_idx_space_members_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_user": {
+          "name": "v2_idx_space_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_user_space": {
+          "name": "v2_idx_space_members_user_space",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_space_role": {
+          "name": "v2_idx_space_members_space_role",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_mods": {
+      "name": "space_mods",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mod_space_id": {
+          "name": "mod_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mount_slug": {
+          "name": "mount_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_mods_space_id": {
+          "name": "v2_idx_space_mods_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_mods_mod_space_id": {
+          "name": "v2_idx_space_mods_mod_space_id",
+          "columns": [
+            {
+              "expression": "mod_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_mods_space_mod": {
+          "name": "v2_uq_space_mods_space_mod",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mod_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_mods_space_mount_slug": {
+          "name": "v2_uq_space_mods_space_mount_slug",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mount_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_sandboxes": {
+      "name": "space_sandboxes",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloud'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "runtime_status": {
+          "name": "runtime_status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "pod_name": {
+          "name": "pod_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_image": {
+          "name": "desired_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_image_version": {
+          "name": "reported_image_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_sandboxes_space_id": {
+          "name": "v2_uq_space_sandboxes_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_status": {
+          "name": "v2_idx_space_sandboxes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_desired_image": {
+          "name": "v2_idx_space_sandboxes_desired_image",
+          "columns": [
+            {
+              "expression": "desired_image",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_reported_image_version": {
+          "name": "v2_idx_space_sandboxes_reported_image_version",
+          "columns": [
+            {
+              "expression": "reported_image_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_last_heartbeat_at": {
+          "name": "v2_idx_space_sandboxes_last_heartbeat_at",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_last_activity_at": {
+          "name": "v2_idx_space_sandboxes_last_activity_at",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_runtime_status": {
+          "name": "v2_idx_space_sandboxes_runtime_status",
+          "columns": [
+            {
+              "expression": "runtime_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_stopped_at": {
+          "name": "v2_idx_space_sandboxes_stopped_at",
+          "columns": [
+            {
+              "expression": "stopped_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_space_sandboxes_provider": {
+          "name": "v2_chk_space_sandboxes_provider",
+          "value": "\"v2\".\"space_sandboxes\".\"provider\" in ('cloud', 'local')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.space_session_bindings": {
+      "name": "space_session_bindings",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_session_id": {
+          "name": "space_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_channel_id": {
+          "name": "space_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_key": {
+          "name": "binding_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_space_session_bindings_space": {
+          "name": "v2_idx_space_session_bindings_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_session": {
+          "name": "v2_idx_space_session_bindings_session",
+          "columns": [
+            {
+              "expression": "space_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_channel": {
+          "name": "v2_idx_space_session_bindings_channel",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_binding_key": {
+          "name": "v2_idx_space_session_bindings_binding_key",
+          "columns": [
+            {
+              "expression": "binding_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_external_chat": {
+          "name": "v2_idx_space_session_bindings_external_chat",
+          "columns": [
+            {
+              "expression": "external_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_session_bindings_channel_binding": {
+          "name": "v2_uq_space_session_bindings_channel_binding",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_sessions": {
+      "name": "space_sessions",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "external_session_id": {
+          "name": "external_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_message_text": {
+          "name": "latest_message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_id": {
+          "name": "last_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_sessions_space_id": {
+          "name": "v2_idx_space_sessions_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_user_uuid": {
+          "name": "v2_idx_space_sessions_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_last_message_id": {
+          "name": "v2_idx_space_sessions_last_message_id",
+          "columns": [
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_last_message_at": {
+          "name": "v2_idx_space_sessions_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_title_trgm": {
+          "name": "v2_idx_space_sessions_title_trgm",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_space_sessions_latest_message_text_trgm": {
+          "name": "v2_idx_space_sessions_latest_message_text_trgm",
+          "columns": [
+            {
+              "expression": "latest_message_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_space_sessions_space_last_message_id": {
+          "name": "v2_idx_space_sessions_space_last_message_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_user_last_message": {
+          "name": "v2_idx_space_sessions_user_last_message",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_participant_user_uuids": {
+          "name": "v2_idx_space_sessions_participant_user_uuids",
+          "columns": [
+            {
+              "expression": "(\"meta\" -> 'participants' -> 'userUuids')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.spaces": {
+      "name": "spaces",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_repo_name": {
+          "name": "storage_repo_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_checkpoint_id": {
+          "name": "base_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_checkpoint_id": {
+          "name": "head_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_spaces_user_uuid": {
+          "name": "v2_idx_spaces_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_base_checkpoint_id": {
+          "name": "v2_idx_spaces_base_checkpoint_id",
+          "columns": [
+            {
+              "expression": "base_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_head_checkpoint_id": {
+          "name": "v2_idx_spaces_head_checkpoint_id",
+          "columns": [
+            {
+              "expression": "head_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_last_activity_at": {
+          "name": "v2_idx_spaces_last_activity_at",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_name_trgm": {
+          "name": "v2_idx_spaces_name_trgm",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_spaces_description_trgm": {
+          "name": "v2_idx_spaces_description_trgm",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_uq_spaces_user_name": {
+          "name": "v2_uq_spaces_user_name",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_spaces_user_slug": {
+          "name": "v2_uq_spaces_user_slug",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2\".\"spaces\".\"slug\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_spaces_storage_repo_name": {
+          "name": "v2_uq_spaces_storage_repo_name",
+          "columns": [
+            {
+              "expression": "storage_repo_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_spaces_slug_format": {
+          "name": "v2_chk_spaces_slug_format",
+          "value": "\"v2\".\"spaces\".\"slug\" is null or (length(\"v2\".\"spaces\".\"slug\") between 1 and 80 and \"v2\".\"spaces\".\"slug\" !~ '[^a-z0-9_-]' and left(\"v2\".\"spaces\".\"slug\", 1) ~ '[a-z0-9]' and right(\"v2\".\"spaces\".\"slug\", 1) ~ '[a-z0-9]')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.task_runs": {
+      "name": "task_runs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_task_runs_job_id": {
+          "name": "v2_uq_task_runs_job_id",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_cron_job_id": {
+          "name": "v2_idx_task_runs_cron_job_id",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_space_id": {
+          "name": "v2_idx_task_runs_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_session_id": {
+          "name": "v2_idx_task_runs_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_turn_id": {
+          "name": "v2_idx_task_runs_turn_id",
+          "columns": [
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_session_turn": {
+          "name": "v2_idx_task_runs_session_turn",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_user_uuid": {
+          "name": "v2_idx_task_runs_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_status": {
+          "name": "v2_idx_task_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_task_type": {
+          "name": "v2_idx_task_runs_task_type",
+          "columns": [
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_space_session_type_status_created": {
+          "name": "v2_idx_task_runs_space_session_type_status_created",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_user_session_type_status_created": {
+          "name": "v2_idx_task_runs_user_session_type_status_created",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_cron_job_status_created": {
+          "name": "v2_idx_task_runs_cron_job_status_created",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_created_at": {
+          "name": "v2_idx_task_runs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_scheduled_at": {
+          "name": "v2_idx_task_runs_scheduled_at",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.token_usage_stats_hourly": {
+      "name": "token_usage_stats_hourly",
+      "schema": "v2",
+      "columns": {
+        "bucket_start_at": {
+          "name": "bucket_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_cache_read": {
+          "name": "cost_cache_read",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_token_usage_stats_hourly_bucket_dims": {
+          "name": "v2_uq_token_usage_stats_hourly_bucket_dims",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_user_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_user_bucket",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_space_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_space_bucket",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_session_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_session_bucket",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_provider_model_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_provider_model_bucket",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_channels": {
+      "name": "user_channels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_user_channels_user_uuid": {
+          "name": "v2_idx_user_channels_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_channels_provider": {
+          "name": "v2_idx_user_channels_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_git_accounts": {
+      "name": "user_git_accounts",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gitea'"
+        },
+        "gitea_user_id": {
+          "name": "gitea_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_username": {
+          "name": "gitea_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_password_encrypted": {
+          "name": "gitea_password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_access_token_encrypted": {
+          "name": "gitea_access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_user_git_accounts_user_provider": {
+          "name": "v2_uq_user_git_accounts_user_provider",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_user_git_accounts_gitea_username": {
+          "name": "v2_uq_user_git_accounts_gitea_username",
+          "columns": [
+            {
+              "expression": "gitea_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_git_accounts_user_uuid": {
+          "name": "v2_idx_user_git_accounts_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_git_accounts_provider": {
+          "name": "v2_idx_user_git_accounts_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_profiles": {
+      "name": "user_profiles",
+      "schema": "v2",
+      "columns": {
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logto_user_id": {
+          "name": "logto_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_user_profiles_logto_user_id": {
+          "name": "v2_uq_user_profiles_logto_user_id",
+          "columns": [
+            {
+              "expression": "logto_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_profiles_updated_at": {
+          "name": "v2_idx_user_profiles_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_user_profiles_username": {
+          "name": "v2_uq_user_profiles_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.work_versions": {
+      "name": "work_versions",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ref": {
+          "name": "target_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_work_versions_work_id": {
+          "name": "v2_idx_work_versions_work_id",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_work_versions_work_version": {
+          "name": "v2_uq_work_versions_work_version",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.work_viewer_grants": {
+      "name": "work_viewer_grants",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_user_uuid": {
+          "name": "viewer_user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_work_viewer_grants_work_id": {
+          "name": "v2_idx_work_viewer_grants_work_id",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_work_viewer_grants_space_id": {
+          "name": "v2_idx_work_viewer_grants_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_work_viewer_grants_viewer_user_uuid": {
+          "name": "v2_idx_work_viewer_grants_viewer_user_uuid",
+          "columns": [
+            {
+              "expression": "viewer_user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_work_viewer_grants_work_viewer": {
+          "name": "v2_uq_work_viewer_grants_work_viewer",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewer_user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.works": {
+      "name": "works",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ref": {
+          "name": "target_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_scopes": {
+          "name": "work_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_viewer_scopes": {
+          "name": "allowed_viewer_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_works_space_id": {
+          "name": "v2_idx_works_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_user_uuid": {
+          "name": "v2_idx_works_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_status": {
+          "name": "v2_idx_works_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_visibility": {
+          "name": "v2_idx_works_visibility",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_works_space_slug": {
+          "name": "v2_uq_works_space_slug",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_works_status": {
+          "name": "v2_chk_works_status",
+          "value": "\"v2\".\"works\".\"status\" in ('published', 'disabled')"
+        },
+        "v2_chk_works_visibility": {
+          "name": "v2_chk_works_visibility",
+          "value": "\"v2\".\"works\".\"visibility\" in ('public', 'space')"
+        },
+        "v2_chk_works_slug_format": {
+          "name": "v2_chk_works_slug_format",
+          "value": "length(\"v2\".\"works\".\"slug\") between 1 and 80 and \"v2\".\"works\".\"slug\" !~ '[^a-z0-9_-]' and left(\"v2\".\"works\".\"slug\", 1) ~ '[a-z0-9]' and right(\"v2\".\"works\".\"slug\", 1) ~ '[a-z0-9]'"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "v2": "v2"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/v2/meta/_journal.json
+++ b/apps/api/drizzle/v2/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1784049216721,
       "tag": "0043_greedy_expediter",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1784145201944,
+      "tag": "0044_silky_mentallo",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/canvas-protocol.ts
+++ b/apps/api/src/canvas-protocol.ts
@@ -1,0 +1,192 @@
+import { createHash } from "node:crypto";
+
+export type CanvasNodeInput = {
+  nodeId: string;
+  type: string;
+  parentId?: string | null;
+  orderKey?: string | null;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation?: number;
+  refKind?: string | null;
+  refPath?: string | null;
+  refUrl?: string | null;
+  view?: Record<string, unknown>;
+  style?: Record<string, unknown>;
+  animation?: Record<string, unknown>;
+  data?: Record<string, unknown>;
+};
+
+export type CanvasSemanticOp = {
+  opId?: string;
+  version?: 1 | 2;
+  type: "node.create" | "node.patch" | "node.data.merge" | "node.delete" | "document.meta.patch";
+  payload: Record<string, unknown>;
+  inverse?: Record<string, unknown>;
+};
+
+export class CanvasServiceError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+    public code = "canvas_error",
+    public currentVersion?: number,
+  ) {
+    super(message);
+  }
+}
+
+export const MAX_CANVAS_NODES = 2000;
+export const MAX_CANVAS_OPS = 100;
+export const MAX_NODE_ID_LENGTH = 120;
+export const MAX_NODE_TYPE_LENGTH = 40;
+export const MAX_REF_LENGTH = 4096;
+export const MAX_JSON_FIELD_BYTES = 16 * 1024;
+export const MAX_TRANSACTION_BYTES = 256 * 1024;
+
+const isRecord = (value: unknown): value is Record<string, unknown> => Boolean(value && typeof value === "object" && !Array.isArray(value));
+const jsonBytes = (value: unknown) => Buffer.byteLength(JSON.stringify(value ?? {}), "utf8");
+const cleanRecord = (value: unknown, fieldName: string) => {
+  if (value == null) return {};
+  if (!isRecord(value)) throw new CanvasServiceError(400, `${fieldName} must be an object`);
+  if (jsonBytes(value) > MAX_JSON_FIELD_BYTES) throw new CanvasServiceError(413, `${fieldName} is too large`);
+  return value;
+};
+const finiteNumber = (value: unknown, fallback: number) => typeof value === "number" && Number.isFinite(value) ? value : fallback;
+const optionalString = (value: unknown, fieldName: string, maxLength = MAX_REF_LENGTH) => {
+  if (value == null) return null;
+  if (typeof value !== "string") throw new CanvasServiceError(400, `${fieldName} must be a string`);
+  if (value.length > maxLength) throw new CanvasServiceError(400, `${fieldName} is too long`);
+  return value;
+};
+
+export function normalizeNode(input: CanvasNodeInput) {
+  if (!input || typeof input.nodeId !== "string" || !input.nodeId.trim()) throw new CanvasServiceError(400, "nodeId is required");
+  if (input.nodeId.length > MAX_NODE_ID_LENGTH) throw new CanvasServiceError(400, "nodeId is too long");
+  if (typeof input.type !== "string" || !input.type.trim()) throw new CanvasServiceError(400, "node type is required");
+  if (input.type.length > MAX_NODE_TYPE_LENGTH) throw new CanvasServiceError(400, "node type is too long");
+  return {
+    nodeId: input.nodeId.trim(),
+    type: input.type.trim(),
+    parentId: optionalString(input.parentId, "parentId"),
+    orderKey: optionalString(input.orderKey, "orderKey"),
+    x: finiteNumber(input.x, 0),
+    y: finiteNumber(input.y, 0),
+    width: Math.max(1, finiteNumber(input.width, 240)),
+    height: Math.max(1, finiteNumber(input.height, 160)),
+    rotation: finiteNumber(input.rotation, 0),
+    refKind: optionalString(input.refKind, "refKind", 40),
+    refPath: optionalString(input.refPath, "refPath"),
+    refUrl: optionalString(input.refUrl, "refUrl"),
+    view: cleanRecord(input.view, "view"),
+    style: cleanRecord(input.style, "style"),
+    animation: cleanRecord(input.animation, "animation"),
+    data: cleanRecord(input.data, "data"),
+  };
+}
+
+export function normalizeNodes(input: CanvasNodeInput[]) {
+  if (input.length > MAX_CANVAS_NODES) throw new CanvasServiceError(413, "Too many canvas nodes");
+  const nodes = input.map(normalizeNode);
+  const seen = new Set<string>();
+  for (const node of nodes) {
+    if (seen.has(node.nodeId)) throw new CanvasServiceError(400, "nodeId must be unique");
+    seen.add(node.nodeId);
+  }
+  return nodes;
+}
+
+export type NormalizedPatch = Partial<ReturnType<typeof normalizeNode>>;
+
+function normalizePatch(input: Record<string, unknown>): NormalizedPatch {
+  const patch: NormalizedPatch = {};
+  if ("type" in input) {
+    if (typeof input.type !== "string" || !input.type.trim()) throw new CanvasServiceError(400, "type must be a non-empty string");
+    if (input.type.length > MAX_NODE_TYPE_LENGTH) throw new CanvasServiceError(400, "type is too long");
+    patch.type = input.type.trim();
+  }
+  if ("parentId" in input) patch.parentId = optionalString(input.parentId, "parentId");
+  if ("orderKey" in input) patch.orderKey = optionalString(input.orderKey, "orderKey");
+  if ("x" in input) patch.x = finiteNumber(input.x, 0);
+  if ("y" in input) patch.y = finiteNumber(input.y, 0);
+  if ("width" in input) patch.width = Math.max(1, finiteNumber(input.width, 240));
+  if ("height" in input) patch.height = Math.max(1, finiteNumber(input.height, 160));
+  if ("rotation" in input) patch.rotation = finiteNumber(input.rotation, 0);
+  if ("refKind" in input) patch.refKind = optionalString(input.refKind, "refKind", 40);
+  if ("refPath" in input) patch.refPath = optionalString(input.refPath, "refPath");
+  if ("refUrl" in input) patch.refUrl = optionalString(input.refUrl, "refUrl");
+  if ("view" in input) patch.view = cleanRecord(input.view, "view");
+  if ("style" in input) patch.style = cleanRecord(input.style, "style");
+  if ("animation" in input) patch.animation = cleanRecord(input.animation, "animation");
+  if ("data" in input) patch.data = cleanRecord(input.data, "data");
+  if (Object.keys(patch).length === 0) throw new CanvasServiceError(400, "node.patch is empty");
+  return patch;
+}
+
+function normalizeOp(op: CanvasSemanticOp): CanvasSemanticOp {
+  if (!op || typeof op.type !== "string" || !isRecord(op.payload)) throw new CanvasServiceError(400, "invalid op");
+  const version = op.version === 2 ? 2 : 1;
+  if (op.type === "node.create") {
+    const node = normalizeNode(op.payload.node as CanvasNodeInput);
+    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, version, type: "node.create", payload: { node }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
+  }
+  if (op.type === "node.patch") {
+    const nodeId = optionalString(op.payload.nodeId, "nodeId", MAX_NODE_ID_LENGTH);
+    if (!nodeId) throw new CanvasServiceError(400, "node.patch requires nodeId");
+    const patch = isRecord(op.payload.patch) ? normalizePatch(op.payload.patch) : null;
+    if (!patch) throw new CanvasServiceError(400, "node.patch requires patch");
+    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, version, type: "node.patch", payload: { nodeId, patch }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
+  }
+  if (op.type === "node.data.merge") {
+    if (version !== 2) throw new CanvasServiceError(400, "node.data.merge requires operation version 2");
+    const nodeId = optionalString(op.payload.nodeId, "nodeId", MAX_NODE_ID_LENGTH);
+    if (!nodeId) throw new CanvasServiceError(400, "node.data.merge requires nodeId");
+    const data = cleanRecord(op.payload.data, "data");
+    if (Object.keys(data).length === 0) throw new CanvasServiceError(400, "node.data.merge is empty");
+    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, version, type: "node.data.merge", payload: { nodeId, data }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
+  }
+  if (op.type === "node.delete") {
+    const nodeId = optionalString(op.payload.nodeId, "nodeId", MAX_NODE_ID_LENGTH);
+    if (!nodeId) throw new CanvasServiceError(400, "node.delete requires nodeId");
+    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, version, type: "node.delete", payload: { nodeId }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
+  }
+  if (op.type === "document.meta.patch") {
+    if (version !== 2) throw new CanvasServiceError(400, "document.meta.patch requires operation version 2");
+    const patch = cleanRecord(op.payload.patch, "patch");
+    if (Object.keys(patch).length === 0) throw new CanvasServiceError(400, "document.meta.patch is empty");
+    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, version, type: "document.meta.patch", payload: { patch }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
+  }
+  throw new CanvasServiceError(400, "unsupported op type");
+}
+
+export function normalizeCanvasOps(ops: CanvasSemanticOp[]) {
+  if (!ops.length) throw new CanvasServiceError(400, "ops are required");
+  if (ops.length > MAX_CANVAS_OPS) throw new CanvasServiceError(413, "too many ops");
+  if (jsonBytes(ops) > MAX_TRANSACTION_BYTES) throw new CanvasServiceError(413, "transaction is too large");
+  const normalized = ops.map(normalizeOp);
+  if (jsonBytes(normalized) > MAX_TRANSACTION_BYTES) throw new CanvasServiceError(413, "transaction is too large");
+  return normalized;
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (isRecord(value)) {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+export function canvasRequestHash(ops: CanvasSemanticOp[]) {
+  return createHash("sha256").update(canonicalJson(ops)).digest("hex");
+}
+
+export function normalizeCanvasTransactionIdentity(input: { txId: string; baseVersion: number }) {
+  const txId = optionalString(input.txId, "txId", 120)?.trim();
+  if (!txId) throw new CanvasServiceError(400, "txId is required", "invalid_transaction");
+  if (!Number.isInteger(input.baseVersion) || input.baseVersion < 0) {
+    throw new CanvasServiceError(400, "baseVersion must be a non-negative integer", "invalid_base_version");
+  }
+  return { txId, baseVersion: input.baseVersion };
+}

--- a/apps/api/src/canvas-service.test.ts
+++ b/apps/api/src/canvas-service.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { CanvasServiceError, normalizeCanvasOps } from "./canvas-protocol.js";
+
+test("version 2 canvas operations keep merge and metadata semantics explicit", () => {
+  const operations = normalizeCanvasOps([
+    {
+      version: 2,
+      type: "node.data.merge",
+      payload: { nodeId: "text-1", data: { outputText: "new output" } },
+    },
+    {
+      version: 2,
+      type: "document.meta.patch",
+      payload: { patch: { openTap: { schema: 1 } } },
+    },
+  ]);
+
+  assert.deepEqual(operations, [
+    {
+      opId: undefined,
+      version: 2,
+      type: "node.data.merge",
+      payload: { nodeId: "text-1", data: { outputText: "new output" } },
+      inverse: undefined,
+    },
+    {
+      opId: undefined,
+      version: 2,
+      type: "document.meta.patch",
+      payload: { patch: { openTap: { schema: 1 } } },
+      inverse: undefined,
+    },
+  ]);
+});
+
+test("new canvas operation semantics reject unversioned clients", () => {
+  assert.throws(
+    () => normalizeCanvasOps([{
+      type: "node.data.merge",
+      payload: { nodeId: "text-1", data: { outputText: "new output" } },
+    }]),
+    (error) => error instanceof CanvasServiceError
+      && error.status === 400
+      && error.message.includes("version 2"),
+  );
+});
+
+test("legacy node.patch remains an explicit whole-field replacement", () => {
+  const [operation] = normalizeCanvasOps([{
+    type: "node.patch",
+    payload: { nodeId: "text-1", patch: { data: { outputText: "replacement" } } },
+  }]);
+
+  assert.equal(operation?.version, 1);
+  assert.deepEqual(operation?.payload, {
+    nodeId: "text-1",
+    patch: { data: { outputText: "replacement" } },
+  });
+});

--- a/apps/api/src/canvas-service.ts
+++ b/apps/api/src/canvas-service.ts
@@ -1,158 +1,62 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { canvasDocuments, canvasNodes, canvasUpdates } from "@cohub/db";
 import { db } from "./db/index.js";
 import { dispatchCanvasTransactionApplied } from "./canvas-events.js";
+import {
+  CanvasServiceError,
+  canvasRequestHash,
+  normalizeCanvasOps,
+  normalizeCanvasTransactionIdentity,
+  type normalizeNode,
+  type CanvasSemanticOp,
+  type NormalizedPatch,
+} from "./canvas-protocol.js";
 
-export type CanvasNodeInput = {
-  nodeId: string;
-  type: string;
-  parentId?: string | null;
-  orderKey?: string | null;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  rotation?: number;
-  refKind?: string | null;
-  refPath?: string | null;
-  refUrl?: string | null;
-  view?: Record<string, unknown>;
-  style?: Record<string, unknown>;
-  animation?: Record<string, unknown>;
-  data?: Record<string, unknown>;
+export { CanvasServiceError, normalizeNodes } from "./canvas-protocol.js";
+export type { CanvasNodeInput, CanvasSemanticOp } from "./canvas-protocol.js";
+
+export type CanvasTransactionResponse = {
+  transaction: {
+    txId: string;
+    baseVersion: number;
+    version: number;
+    replayed: boolean;
+  };
+  document: {
+    version: number;
+    meta: Record<string, unknown>;
+  };
+  changes: {
+    nodes: Array<typeof canvasNodes.$inferSelect>;
+    deletedNodeIds: string[];
+  };
 };
-
-export type CanvasSemanticOp = {
-  opId?: string;
-  type: "node.create" | "node.patch" | "node.delete";
-  payload: Record<string, unknown>;
-  inverse?: Record<string, unknown>;
-};
-
-export class CanvasServiceError extends Error {
-  constructor(
-    public status: number,
-    message: string,
-  ) {
-    super(message);
-  }
-}
-
-export const MAX_CANVAS_NODES = 2000;
-export const MAX_CANVAS_OPS = 100;
-export const MAX_NODE_ID_LENGTH = 120;
-export const MAX_NODE_TYPE_LENGTH = 40;
-export const MAX_REF_LENGTH = 4096;
-export const MAX_JSON_FIELD_BYTES = 16 * 1024;
-export const MAX_TRANSACTION_BYTES = 256 * 1024;
 
 const isRecord = (value: unknown): value is Record<string, unknown> => Boolean(value && typeof value === "object" && !Array.isArray(value));
-const jsonBytes = (value: unknown) => Buffer.byteLength(JSON.stringify(value ?? {}), "utf8");
-const cleanRecord = (value: unknown, fieldName: string) => {
-  if (value == null) return {};
-  if (!isRecord(value)) throw new CanvasServiceError(400, `${fieldName} must be an object`);
-  if (jsonBytes(value) > MAX_JSON_FIELD_BYTES) throw new CanvasServiceError(413, `${fieldName} is too large`);
-  return value;
-};
-const finiteNumber = (value: unknown, fallback: number) => typeof value === "number" && Number.isFinite(value) ? value : fallback;
-const optionalString = (value: unknown, fieldName: string, maxLength = MAX_REF_LENGTH) => {
-  if (value == null) return null;
-  if (typeof value !== "string") throw new CanvasServiceError(400, `${fieldName} must be a string`);
-  if (value.length > maxLength) throw new CanvasServiceError(400, `${fieldName} is too long`);
-  return value;
-};
 
-export function normalizeNode(input: CanvasNodeInput) {
-  if (!input || typeof input.nodeId !== "string" || !input.nodeId.trim()) throw new CanvasServiceError(400, "nodeId is required");
-  if (input.nodeId.length > MAX_NODE_ID_LENGTH) throw new CanvasServiceError(400, "nodeId is too long");
-  if (typeof input.type !== "string" || !input.type.trim()) throw new CanvasServiceError(400, "node type is required");
-  if (input.type.length > MAX_NODE_TYPE_LENGTH) throw new CanvasServiceError(400, "node type is too long");
+function readStoredTransactionResult(
+  value: Record<string, unknown>,
+  fallback: { txId: string; baseVersion: number; version: number; meta: Record<string, unknown> },
+): CanvasTransactionResponse {
+  const transaction = isRecord(value.transaction) ? value.transaction : {};
+  const document = isRecord(value.document) ? value.document : {};
+  const changes = isRecord(value.changes) ? value.changes : {};
   return {
-    nodeId: input.nodeId.trim(),
-    type: input.type.trim(),
-    parentId: optionalString(input.parentId, "parentId"),
-    orderKey: optionalString(input.orderKey, "orderKey"),
-    x: finiteNumber(input.x, 0),
-    y: finiteNumber(input.y, 0),
-    width: Math.max(1, finiteNumber(input.width, 240)),
-    height: Math.max(1, finiteNumber(input.height, 160)),
-    rotation: finiteNumber(input.rotation, 0),
-    refKind: optionalString(input.refKind, "refKind", 40),
-    refPath: optionalString(input.refPath, "refPath"),
-    refUrl: optionalString(input.refUrl, "refUrl"),
-    view: cleanRecord(input.view, "view"),
-    style: cleanRecord(input.style, "style"),
-    animation: cleanRecord(input.animation, "animation"),
-    data: cleanRecord(input.data, "data"),
+    transaction: {
+      txId: typeof transaction.txId === "string" ? transaction.txId : fallback.txId,
+      baseVersion: typeof transaction.baseVersion === "number" ? transaction.baseVersion : fallback.baseVersion,
+      version: typeof transaction.version === "number" ? transaction.version : fallback.version,
+      replayed: true,
+    },
+    document: {
+      version: typeof document.version === "number" ? document.version : fallback.version,
+      meta: isRecord(document.meta) ? document.meta : fallback.meta,
+    },
+    changes: {
+      nodes: Array.isArray(changes.nodes) ? changes.nodes as Array<typeof canvasNodes.$inferSelect> : [],
+      deletedNodeIds: Array.isArray(changes.deletedNodeIds) ? changes.deletedNodeIds.filter((id): id is string => typeof id === "string") : [],
+    },
   };
-}
-
-export function normalizeNodes(input: CanvasNodeInput[]) {
-  if (input.length > MAX_CANVAS_NODES) throw new CanvasServiceError(413, "Too many canvas nodes");
-  const nodes = input.map(normalizeNode);
-  const seen = new Set<string>();
-  for (const node of nodes) {
-    if (seen.has(node.nodeId)) throw new CanvasServiceError(400, "nodeId must be unique");
-    seen.add(node.nodeId);
-  }
-  return nodes;
-}
-
-type NormalizedPatch = Partial<ReturnType<typeof normalizeNode>>;
-
-function normalizePatch(input: Record<string, unknown>): NormalizedPatch {
-  const patch: NormalizedPatch = {};
-  if ("type" in input) {
-    if (typeof input.type !== "string" || !input.type.trim()) throw new CanvasServiceError(400, "type must be a non-empty string");
-    if (input.type.length > MAX_NODE_TYPE_LENGTH) throw new CanvasServiceError(400, "type is too long");
-    patch.type = input.type.trim();
-  }
-  if ("parentId" in input) patch.parentId = optionalString(input.parentId, "parentId");
-  if ("orderKey" in input) patch.orderKey = optionalString(input.orderKey, "orderKey");
-  if ("x" in input) patch.x = finiteNumber(input.x, 0);
-  if ("y" in input) patch.y = finiteNumber(input.y, 0);
-  if ("width" in input) patch.width = Math.max(1, finiteNumber(input.width, 240));
-  if ("height" in input) patch.height = Math.max(1, finiteNumber(input.height, 160));
-  if ("rotation" in input) patch.rotation = finiteNumber(input.rotation, 0);
-  if ("refKind" in input) patch.refKind = optionalString(input.refKind, "refKind", 40);
-  if ("refPath" in input) patch.refPath = optionalString(input.refPath, "refPath");
-  if ("refUrl" in input) patch.refUrl = optionalString(input.refUrl, "refUrl");
-  if ("view" in input) patch.view = cleanRecord(input.view, "view");
-  if ("style" in input) patch.style = cleanRecord(input.style, "style");
-  if ("animation" in input) patch.animation = cleanRecord(input.animation, "animation");
-  if ("data" in input) patch.data = cleanRecord(input.data, "data");
-  if (Object.keys(patch).length === 0) throw new CanvasServiceError(400, "node.patch is empty");
-  return patch;
-}
-
-function normalizeOp(op: CanvasSemanticOp): CanvasSemanticOp {
-  if (!op || typeof op.type !== "string" || !isRecord(op.payload)) throw new CanvasServiceError(400, "invalid op");
-  if (op.type === "node.create") {
-    const node = normalizeNode(op.payload.node as CanvasNodeInput);
-    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, type: "node.create", payload: { node }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
-  }
-  if (op.type === "node.patch") {
-    const nodeId = optionalString(op.payload.nodeId, "nodeId", MAX_NODE_ID_LENGTH);
-    if (!nodeId) throw new CanvasServiceError(400, "node.patch requires nodeId");
-    const patch = isRecord(op.payload.patch) ? normalizePatch(op.payload.patch) : null;
-    if (!patch) throw new CanvasServiceError(400, "node.patch requires patch");
-    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, type: "node.patch", payload: { nodeId, patch }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
-  }
-  if (op.type === "node.delete") {
-    const nodeId = optionalString(op.payload.nodeId, "nodeId", MAX_NODE_ID_LENGTH);
-    if (!nodeId) throw new CanvasServiceError(400, "node.delete requires nodeId");
-    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, type: "node.delete", payload: { nodeId }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
-  }
-  throw new CanvasServiceError(400, "unsupported op type");
-}
-
-export function normalizeCanvasOps(ops: CanvasSemanticOp[]) {
-  if (!ops.length) throw new CanvasServiceError(400, "ops are required");
-  if (ops.length > MAX_CANVAS_OPS) throw new CanvasServiceError(413, "too many ops");
-  if (jsonBytes(ops) > MAX_TRANSACTION_BYTES) throw new CanvasServiceError(413, "transaction is too large");
-  const normalized = ops.map(normalizeOp);
-  if (jsonBytes(normalized) > MAX_TRANSACTION_BYTES) throw new CanvasServiceError(413, "transaction is too large");
-  return normalized;
 }
 
 export async function applyCanvasTransaction(input: {
@@ -160,13 +64,15 @@ export async function applyCanvasTransaction(input: {
   documentId: string;
   actorId: string;
   txId: string;
-  baseVersion?: number | null;
+  baseVersion: number;
   clientId?: string | null;
   undoGroupId?: string | null;
   ops: CanvasSemanticOp[];
   broadcast?: boolean;
 }) {
+  const { txId } = normalizeCanvasTransactionIdentity(input);
   const normalizedOps = normalizeCanvasOps(input.ops);
+  const requestHash = canvasRequestHash(normalizedOps);
   const now = new Date();
   const result = await db.transaction(async (tx) => {
     const [document] = await tx
@@ -176,15 +82,38 @@ export async function applyCanvasTransaction(input: {
       .for("update")
       .limit(1);
     if (!document) throw new CanvasServiceError(404, "canvas not found");
-    if (input.baseVersion != null && input.baseVersion !== document.version) {
-      throw new CanvasServiceError(409, "canvas version conflict");
+    const [existingUpdate] = await tx
+      .select()
+      .from(canvasUpdates)
+      .where(and(eq(canvasUpdates.documentId, input.documentId), eq(canvasUpdates.txId, txId)))
+      .limit(1);
+    if (existingUpdate) {
+      if (existingUpdate.requestHash && existingUpdate.requestHash !== requestHash) {
+        throw new CanvasServiceError(409, "txId was already used for a different transaction", "tx_id_conflict", document.version);
+      }
+      return {
+        response: readStoredTransactionResult(existingUpdate.result, {
+          txId,
+          baseVersion: existingUpdate.baseVersion,
+          version: existingUpdate.version,
+          meta: document.meta,
+        }),
+        broadcast: false,
+        ops: normalizedOps,
+      };
+    }
+    if (input.baseVersion !== document.version) {
+      throw new CanvasServiceError(409, "canvas version conflict", "version_conflict", document.version);
     }
     const nextVersion = document.version + 1;
+    const changedNodeIds = new Set<string>();
+    const deletedNodeIds = new Set<string>();
+    let nextMeta = document.meta;
 
     for (const op of normalizedOps) {
       if (op.type === "node.create") {
         const node = (op.payload as { node: ReturnType<typeof normalizeNode> }).node;
-        await tx.insert(canvasNodes).values({
+        const values = {
           documentId: input.documentId,
           nodeId: node.nodeId,
           type: node.type,
@@ -206,29 +135,21 @@ export async function applyCanvasTransaction(input: {
           createdAt: now,
           updatedAt: now,
           deletedAt: null,
-        }).onConflictDoUpdate({
-          target: [canvasNodes.documentId, canvasNodes.nodeId],
-          set: {
-            type: node.type,
-            parentId: node.parentId,
-            orderKey: node.orderKey,
-            x: node.x,
-            y: node.y,
-            width: node.width,
-            height: node.height,
-            rotation: node.rotation,
-            refKind: node.refKind,
-            refPath: node.refPath,
-            refUrl: node.refUrl,
-            view: node.view,
-            style: node.style,
-            animation: node.animation,
-            data: node.data,
-            version: nextVersion,
-            updatedAt: now,
-            deletedAt: null,
-          },
-        });
+        };
+        const [existingNode] = await tx.select({ deletedAt: canvasNodes.deletedAt })
+          .from(canvasNodes)
+          .where(and(eq(canvasNodes.documentId, input.documentId), eq(canvasNodes.nodeId, node.nodeId)))
+          .limit(1);
+        if (existingNode && existingNode.deletedAt == null) {
+          throw new CanvasServiceError(409, "canvas node already exists", "node_exists", document.version);
+        }
+        if (existingNode) {
+          await tx.update(canvasNodes).set(values)
+            .where(and(eq(canvasNodes.documentId, input.documentId), eq(canvasNodes.nodeId, node.nodeId)));
+        } else {
+          await tx.insert(canvasNodes).values(values);
+        }
+        changedNodeIds.add(node.nodeId);
         continue;
       }
       if (op.type === "node.patch") {
@@ -238,6 +159,22 @@ export async function applyCanvasTransaction(input: {
           .where(and(eq(canvasNodes.documentId, input.documentId), eq(canvasNodes.nodeId, nodeId), isNull(canvasNodes.deletedAt)))
           .returning({ nodeId: canvasNodes.nodeId });
         if (updated.length === 0) throw new CanvasServiceError(404, "canvas node not found");
+        changedNodeIds.add(nodeId);
+        continue;
+      }
+      if (op.type === "node.data.merge") {
+        const { nodeId, data } = op.payload as { nodeId: string; data: Record<string, unknown> };
+        const updated = await tx.update(canvasNodes)
+          .set({ data: sql`${canvasNodes.data} || ${JSON.stringify(data)}::jsonb`, updatedAt: now, version: nextVersion })
+          .where(and(eq(canvasNodes.documentId, input.documentId), eq(canvasNodes.nodeId, nodeId), isNull(canvasNodes.deletedAt)))
+          .returning({ nodeId: canvasNodes.nodeId });
+        if (updated.length === 0) throw new CanvasServiceError(404, "canvas node not found");
+        changedNodeIds.add(nodeId);
+        continue;
+      }
+      if (op.type === "document.meta.patch") {
+        const { patch } = op.payload as { patch: Record<string, unknown> };
+        nextMeta = { ...nextMeta, ...patch };
         continue;
       }
       const nodeId = (op.payload as { nodeId: string }).nodeId;
@@ -246,32 +183,51 @@ export async function applyCanvasTransaction(input: {
         .where(and(eq(canvasNodes.documentId, input.documentId), eq(canvasNodes.nodeId, nodeId), isNull(canvasNodes.deletedAt)))
         .returning({ nodeId: canvasNodes.nodeId });
       if (deleted.length === 0) throw new CanvasServiceError(404, "canvas node not found");
+      changedNodeIds.delete(nodeId);
+      deletedNodeIds.add(nodeId);
     }
 
+    await tx.update(canvasDocuments)
+      .set({ version: nextVersion, meta: nextMeta, updatedAt: now })
+      .where(eq(canvasDocuments.id, input.documentId));
+    const nodes = changedNodeIds.size > 0
+      ? await tx.select().from(canvasNodes).where(and(
+          eq(canvasNodes.documentId, input.documentId),
+          inArray(canvasNodes.nodeId, [...changedNodeIds]),
+          isNull(canvasNodes.deletedAt),
+        ))
+      : [];
+    const response: CanvasTransactionResponse = {
+      transaction: { txId, baseVersion: input.baseVersion, version: nextVersion, replayed: false },
+      document: { version: nextVersion, meta: nextMeta },
+      changes: { nodes, deletedNodeIds: [...deletedNodeIds] },
+    };
     await tx.insert(canvasUpdates).values({
       documentId: input.documentId,
+      txId,
+      baseVersion: input.baseVersion,
+      requestHash,
       version: nextVersion,
       actorId: input.actorId,
       clientId: input.clientId ?? null,
       type: "canvas.tx",
-      payload: { txId: input.txId, baseVersion: input.baseVersion ?? null, ops: normalizedOps },
+      payload: { ops: normalizedOps },
+      result: response,
       undoGroupId: input.undoGroupId ?? null,
       createdAt: now,
     });
-    const [updated] = await tx.update(canvasDocuments).set({ version: nextVersion, updatedAt: now }).where(eq(canvasDocuments.id, input.documentId)).returning();
-    const nodes = await tx.select().from(canvasNodes).where(and(eq(canvasNodes.documentId, input.documentId), isNull(canvasNodes.deletedAt))).orderBy(canvasNodes.orderKey);
-    return { document: updated ?? { ...document, version: nextVersion, updatedAt: now }, nodes, version: nextVersion, ops: normalizedOps };
+    return { response, broadcast: true, ops: normalizedOps };
   });
 
-  if (input.broadcast !== false) {
+  if (input.broadcast !== false && result.broadcast) {
     await dispatchCanvasTransactionApplied({
       spaceId: input.spaceId,
       documentId: input.documentId,
       actorId: input.actorId,
-      txId: input.txId,
-      version: result.version,
+      txId,
+      version: result.response.transaction.version,
       ops: result.ops as Array<Record<string, unknown>>,
     }).catch(() => undefined);
   }
-  return { document: result.document, nodes: result.nodes, version: result.version };
+  return result.response;
 }

--- a/apps/api/src/routes/internal/canvas.route.ts
+++ b/apps/api/src/routes/internal/canvas.route.ts
@@ -14,12 +14,12 @@ router.post("/:spaceId/:documentId/tx", async (c) => {
   const body = await c.req.json<{
     actorId?: string;
     txId?: string;
-    baseVersion?: number | null;
+    baseVersion?: number;
     clientId?: string | null;
     undoGroupId?: string | null;
     ops?: CanvasSemanticOp[];
   }>().catch(() => null);
-  if (!body?.actorId || !body.txId || !Array.isArray(body.ops)) return c.json({ message: "invalid canvas transaction" }, 400);
+  if (!body?.actorId || !body.txId || typeof body.baseVersion !== "number" || !Number.isInteger(body.baseVersion) || !Array.isArray(body.ops)) return c.json({ message: "invalid canvas transaction" }, 400);
   try {
     const actor = { uuid: body.actorId } as AuthUser;
     if (!(await hasPermission(actor, "file.edit", { spaceId }))) return c.json({ message: "forbidden" }, 403);
@@ -28,7 +28,7 @@ router.post("/:spaceId/:documentId/tx", async (c) => {
       documentId,
       actorId: body.actorId,
       txId: body.txId,
-      baseVersion: body.baseVersion ?? null,
+      baseVersion: body.baseVersion,
       clientId: body.clientId ?? null,
       undoGroupId: body.undoGroupId ?? null,
       ops: body.ops,
@@ -37,7 +37,11 @@ router.post("/:spaceId/:documentId/tx", async (c) => {
   } catch (error) {
     const status = typeof (error as { status?: unknown })?.status === "number" ? (error as { status: number }).status : 500;
     const message = error instanceof Error ? error.message : "Canvas operation failed";
-    return c.json({ message }, status as never);
+    const code = typeof (error as { code?: unknown })?.code === "string" ? (error as { code: string }).code : "canvas_error";
+    const currentVersion = typeof (error as { currentVersion?: unknown })?.currentVersion === "number"
+      ? (error as { currentVersion: number }).currentVersion
+      : undefined;
+    return c.json({ message, code, currentVersion }, status as never);
   }
 });
 

--- a/apps/api/src/routes/spaces/canvas.route.ts
+++ b/apps/api/src/routes/spaces/canvas.route.ts
@@ -1,6 +1,6 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, gt, isNull } from "drizzle-orm";
 import { Hono } from "hono";
-import { canvasDocuments, canvasNodes } from "@cohub/db";
+import { canvasDocuments, canvasNodes, canvasUpdates } from "@cohub/db";
 import { applyCanvasTransaction, CanvasServiceError, normalizeNodes, type CanvasNodeInput, type CanvasSemanticOp } from "../../canvas-service.js";
 import { db } from "../../db/index.js";
 import { authzDenied, getOptionalAuth, requireValidId, useAuth } from "../../lib/middleware.js";
@@ -21,9 +21,11 @@ const serializeManifest = (input: { documentId: string; title: string }) => `${J
 }, null, 2)}\n`;
 
 function canvasErrorResponse(error: unknown) {
-  if (error instanceof CanvasServiceError) return { status: error.status, message: error.message };
-  if (error instanceof SpaceFsError) return { status: error.status, message: error.message };
-  return { status: 500, message: "Canvas operation failed" };
+  if (error instanceof CanvasServiceError) {
+    return { status: error.status, message: error.message, code: error.code, currentVersion: error.currentVersion };
+  }
+  if (error instanceof SpaceFsError) return { status: error.status, message: error.message, code: "space_fs_error" };
+  return { status: 500, message: "Canvas operation failed", code: "canvas_error" };
 }
 
 async function loadDocumentForSpace(spaceId: string, documentId: string) {
@@ -140,6 +142,39 @@ router.get("/:documentId/bootstrap", async (c) => {
   return c.json({ document, nodes });
 });
 
+router.get("/:documentId/updates", async (c) => {
+  const user = getOptionalAuth(c);
+  const spaceId = c.req.param("id");
+  const documentId = c.req.param("documentId");
+  if (!spaceId || !documentId || !requireValidId(spaceId) || !requireValidId(documentId)) return c.json({ message: "canvas not found" }, 404);
+  if (!(await hasPermission(user, "file.view", { spaceId }))) return authzDenied(c);
+  const afterVersion = Number(c.req.query("afterVersion") ?? "0");
+  const requestedLimit = Number(c.req.query("limit") ?? "100");
+  if (!Number.isInteger(afterVersion) || afterVersion < 0) return c.json({ message: "afterVersion must be a non-negative integer" }, 400);
+  const limit = Number.isInteger(requestedLimit) ? Math.min(Math.max(requestedLimit, 1), 500) : 100;
+  const document = await loadDocumentForSpace(spaceId, documentId);
+  if (!document) return c.json({ message: "canvas not found" }, 404);
+  const updates = await db.select({
+    txId: canvasUpdates.txId,
+    baseVersion: canvasUpdates.baseVersion,
+    version: canvasUpdates.version,
+    actorId: canvasUpdates.actorId,
+    clientId: canvasUpdates.clientId,
+    payload: canvasUpdates.payload,
+    createdAt: canvasUpdates.createdAt,
+  }).from(canvasUpdates)
+    .where(and(eq(canvasUpdates.documentId, documentId), gt(canvasUpdates.version, afterVersion)))
+    .orderBy(canvasUpdates.version)
+    .limit(limit);
+  const lastVersion = updates.at(-1)?.version;
+  return c.json({
+    documentVersion: document.version,
+    updates,
+    hasMore: updates.length === limit && lastVersion !== document.version,
+    requiresBootstrap: afterVersion < document.version && updates[0]?.version !== afterVersion + 1,
+  });
+});
+
 router.post("/:documentId/ops", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
@@ -149,14 +184,14 @@ router.post("/:documentId/ops", async (c) => {
   if (!(await hasPermission(user, "file.edit", { spaceId }))) return authzDenied(c);
 
   const body = await c.req.json<{ txId?: string; baseVersion?: number; clientId?: string; undoGroupId?: string; ops?: CanvasSemanticOp[] }>().catch(() => null);
-  if (!Array.isArray(body?.ops)) return c.json({ message: "ops are required" }, 400);
+  if (!body?.txId || typeof body.baseVersion !== "number" || !Number.isInteger(body.baseVersion) || !Array.isArray(body.ops)) return c.json({ message: "txId, baseVersion and ops are required" }, 400);
   try {
     const result = await applyCanvasTransaction({
       spaceId,
       documentId,
       actorId: user.uuid,
-      txId: body.txId || crypto.randomUUID(),
-      baseVersion: body.baseVersion ?? null,
+      txId: body.txId,
+      baseVersion: body.baseVersion,
       clientId: body.clientId ?? null,
       undoGroupId: body.undoGroupId ?? null,
       ops: body.ops,
@@ -164,7 +199,7 @@ router.post("/:documentId/ops", async (c) => {
     return c.json(result);
   } catch (error) {
     const response = canvasErrorResponse(error);
-    return c.json({ message: response.message }, response.status as never);
+    return c.json({ message: response.message, code: response.code, currentVersion: response.currentVersion }, response.status as never);
   }
 });
 

--- a/apps/gateway/src/api-client.ts
+++ b/apps/gateway/src/api-client.ts
@@ -165,11 +165,11 @@ export const submitCanvasTransaction = async (input: {
   spaceId: string;
   documentId: string;
   txId: string;
-  baseVersion?: number | null;
+  baseVersion: number;
   clientId?: string | null;
   undoGroupId?: string | null;
   ops: Array<Record<string, unknown>>;
-}): Promise<{ document: { version: number }; nodes: unknown[] }> => {
+}): Promise<{ document: { version: number }; transaction: { txId: string; version: number; replayed: boolean } }> => {
   const response = await fetch(`${gatewayConfig.apiBaseUrl}/internal/canvas/${input.spaceId}/${input.documentId}/tx`, {
     method: "POST",
     headers: {
@@ -180,22 +180,49 @@ export const submitCanvasTransaction = async (input: {
     body: JSON.stringify({
       actorId: input.userId,
       txId: input.txId,
-      baseVersion: input.baseVersion ?? null,
+      baseVersion: input.baseVersion,
       clientId: input.clientId ?? null,
       undoGroupId: input.undoGroupId ?? null,
       ops: input.ops,
     }),
   });
   if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    throw new Error(`Internal canvas transaction failed ${response.status}: ${text}`);
+    const data = await parseJson<{ message?: string; code?: string; currentVersion?: number }>(response);
+    throw new InternalCanvasTransactionError(
+      data?.message || `Internal canvas transaction failed ${response.status}`,
+      response.status,
+      data?.code,
+      data?.currentVersion,
+    );
   }
-  const data = await parseJson<{ document?: { version?: number }; nodes?: unknown[] }>(response);
-  if (!data?.document || typeof data.document.version !== "number" || !Array.isArray(data.nodes)) {
+  const data = await parseJson<{
+    document?: { version?: number };
+    transaction?: { txId?: string; version?: number; replayed?: boolean };
+  }>(response);
+  if (!data?.document || typeof data.document.version !== "number" || !data.transaction || typeof data.transaction.version !== "number" || typeof data.transaction.txId !== "string") {
     throw new Error("Internal canvas transaction returned an invalid response");
   }
-  return { document: { version: data.document.version }, nodes: data.nodes };
+  return {
+    document: { version: data.document.version },
+    transaction: {
+      txId: data.transaction.txId,
+      version: data.transaction.version,
+      replayed: data.transaction.replayed === true,
+    },
+  };
 };
+
+export class InternalCanvasTransactionError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code?: string,
+    readonly currentVersion?: number,
+  ) {
+    super(message);
+    this.name = "InternalCanvasTransactionError";
+  }
+}
 
 /** Carries a standard billing error body from the internal prompt API. */
 export class InternalPromptError extends Error {

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -31,7 +31,7 @@ import {
   wsClientEventSchema,
 } from "@cohub/protocol/realtime";
 import { getOrCreateRequestId } from "@cohub/infra/tracing";
-import { authenticateRealtimeToken, authorizeRealtimeRooms, notifySpacePresenceUpdated, requestGatewayChannelReconcile, submitCanvasTransaction, submitInternalSessionPrompt, InternalPromptError, type RealtimeAuthResult } from "./api-client.js";
+import { authenticateRealtimeToken, authorizeRealtimeRooms, notifySpacePresenceUpdated, requestGatewayChannelReconcile, submitCanvasTransaction, submitInternalSessionPrompt, InternalCanvasTransactionError, InternalPromptError, type RealtimeAuthResult } from "./api-client.js";
 import { listenOutboundCommands, initOutboundConsumerGroup } from "./bus.js";
 import { summarizeRedisUrl } from "./logging.js";
 import { gatewayConfig } from "./config.js";
@@ -932,13 +932,13 @@ async function main() {
             const documentId = typeof payload.documentId === "string" ? payload.documentId : "";
             const txId = typeof payload.txId === "string" ? payload.txId : "";
             const ops = Array.isArray(payload.ops) ? payload.ops.filter((op): op is Record<string, unknown> => Boolean(op && typeof op === "object" && !Array.isArray(op))) : [];
-            if (!spaceId || !documentId || !txId || ops.length === 0) throw new WsClientInputError("invalid canvas transaction");
+            if (!spaceId || !documentId || !txId || !Number.isInteger(payload.baseVersion) || payload.baseVersion < 0 || ops.length === 0) throw new WsClientInputError("invalid canvas transaction");
             const result = await submitCanvasTransaction({
               userId: ctx.userId,
               spaceId,
               documentId,
               txId,
-              baseVersion: typeof payload.baseVersion === "number" ? payload.baseVersion : null,
+              baseVersion: payload.baseVersion,
               clientId: typeof payload.clientId === "string" ? payload.clientId : null,
               undoGroupId: typeof payload.undoGroupId === "string" ? payload.undoGroupId : null,
               ops,
@@ -949,7 +949,12 @@ async function main() {
               requestId: requestId ?? null,
               spaceId,
               sessionId: null,
-              payload: { documentId, txId, version: result.document.version },
+              payload: {
+                documentId,
+                txId,
+                version: result.document.version,
+                replayed: result.transaction.replayed,
+              },
             }));
           } catch (error) {
             if (error instanceof WsClientInputError) throw error;
@@ -964,6 +969,9 @@ async function main() {
                 documentId: typeof payload.documentId === "string" ? payload.documentId : null,
                 txId: typeof payload.txId === "string" ? payload.txId : null,
                 message: error instanceof Error ? error.message : String(error),
+                code: error instanceof InternalCanvasTransactionError ? error.code : undefined,
+                status: error instanceof InternalCanvasTransactionError ? error.status : undefined,
+                currentVersion: error instanceof InternalCanvasTransactionError ? error.currentVersion : undefined,
               },
             }));
           }

--- a/apps/web/src/lib/cache/repositories/canvas-pending-tx-repo.ts
+++ b/apps/web/src/lib/cache/repositories/canvas-pending-tx-repo.ts
@@ -81,3 +81,16 @@ export async function markCanvasPendingTransactionAttempt(
 		updatedAt: Date.now(),
 	});
 }
+
+export async function rebaseCanvasPendingTransaction(
+	record: CanvasPendingTransactionCacheRecord,
+	baseVersion: number,
+) {
+	const rebased = {
+		...record,
+		baseVersion,
+		updatedAt: Date.now(),
+	};
+	await idbPut("canvas_pending_txs", rebased);
+	return rebased;
+}

--- a/apps/web/src/lib/canvas/canvas-document.ts
+++ b/apps/web/src/lib/canvas/canvas-document.ts
@@ -257,6 +257,22 @@ export function invertCanvasOps(ops: CanvasSemanticOp[]): CanvasSemanticOp[] {
 				inverse: op.payload,
 			};
 		}
+		if (op.type === "node.data.merge") {
+			return {
+				version: 2,
+				type: "node.data.merge",
+				payload: { nodeId: op.payload.nodeId, data: op.inverse ?? {} },
+				inverse: op.payload.data as Record<string, unknown>,
+			};
+		}
+		if (op.type === "document.meta.patch") {
+			return {
+				version: 2,
+				type: "document.meta.patch",
+				payload: { patch: op.inverse ?? {} },
+				inverse: op.payload.patch as Record<string, unknown>,
+			};
+		}
 		return {
 			type: "node.patch",
 			payload: { nodeId: op.payload.nodeId, patch: op.inverse ?? {} },
@@ -283,14 +299,23 @@ export function applyCanvasOps(
 				items = items.filter((item) => item.id !== nodeId);
 			continue;
 		}
+		if (op.type === "document.meta.patch") continue;
 		const nodeId = op.payload.nodeId;
-		const patch = op.payload.patch as Partial<CanvasNodeInput> | undefined;
+		const patch =
+			op.type === "node.data.merge"
+				? { data: op.payload.data as Record<string, unknown> }
+				: (op.payload.patch as Partial<CanvasNodeInput> | undefined);
 		if (typeof nodeId !== "string" || !patch) continue;
 		items = items.map((item, index) => {
 			if (item.id !== nodeId) return item;
+			const current = canvasItemToNode(item, index);
 			return nodeInputToItem({
-				...canvasItemToNode(item, index),
+				...current,
 				...patch,
+				data:
+					op.type === "node.data.merge"
+						? { ...current.data, ...(patch.data ?? {}) }
+						: (patch.data ?? current.data),
 				nodeId,
 			});
 		});

--- a/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
+++ b/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
@@ -1688,22 +1688,22 @@ onMount(() => {
 				documentId?: unknown;
 				version?: unknown;
 				actorId?: unknown;
+				ops?: unknown;
 			};
 			if (
 				typeof payload.documentId !== "string" ||
+				typeof payload.version !== "number" ||
+				!Array.isArray(payload.ops) ||
 				payload.documentId !== inlineCanvas?.documentId
 			)
 				return;
 			if (inlineCanvas?.saving) return;
-			void sdk
-				.space(spaceId)
-				.canvas.bootstrap(payload.documentId)
-				.then((bootstrap) => {
-					canvasPreview.applyBootstrap(payload.documentId as string, bootstrap);
-				})
+			const documentId = payload.documentId;
+			void canvasPreview
+				.applyRemoteTransaction(documentId, payload.version, payload.ops)
 				.catch((error) => {
 					canvasPreview.setError(
-						payload.documentId as string,
+						documentId,
 						error instanceof Error ? error.message : "Failed to sync canvas",
 					);
 				});

--- a/apps/web/src/lib/features/space/modules/canvas-preview-controller.svelte.ts
+++ b/apps/web/src/lib/features/space/modules/canvas-preview-controller.svelte.ts
@@ -3,9 +3,11 @@ import {
 	deleteCanvasPendingTransaction,
 	listCanvasPendingTransactions,
 	markCanvasPendingTransactionAttempt,
+	rebaseCanvasPendingTransaction,
 	writeCanvasPendingTransaction,
 } from "$lib/cache/repositories/canvas-pending-tx-repo";
 import {
+	applyCanvasOps,
 	canvasBootstrapToDocument,
 	parseCovasManifest,
 } from "$lib/canvas/canvas-document";
@@ -13,6 +15,24 @@ import type { CovasDocument } from "$lib/canvas/canvas-schema";
 import { sdk } from "$lib/sdk";
 
 type CanvasFileResponse = unknown;
+
+function isCanvasSemanticOp(value: unknown): value is CanvasSemanticOp {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const operation = value as Record<string, unknown>;
+	return (
+		typeof operation.type === "string" &&
+		[
+			"node.create",
+			"node.patch",
+			"node.data.merge",
+			"node.delete",
+			"document.meta.patch",
+		].includes(operation.type) &&
+		Boolean(operation.payload) &&
+		typeof operation.payload === "object" &&
+		!Array.isArray(operation.payload)
+	);
+}
 
 export type InlineCanvasPanelState = {
 	path: string;
@@ -97,12 +117,22 @@ export function createCanvasPreviewController(
 				...syncVersionByDocumentId,
 				[bootstrap.document.id]: bootstrap.document.version,
 			};
+			const pending = options.getReadonly?.()
+				? []
+				: await listCanvasPendingTransactions(
+						options.getSpaceId(),
+						bootstrap.document.id,
+					);
+			const restoredDocument = pending.reduce(
+				(document, transaction) => applyCanvasOps(document, transaction.ops),
+				canvasBootstrapToDocument(bootstrap),
+			);
 			canvases = canvases.map((item) =>
 				item.path === path
 					? {
 							path,
 							documentId: bootstrap.document.id,
-							document: canvasBootstrapToDocument(bootstrap),
+							document: restoredDocument,
 							loading: false,
 							saving: false,
 							error: null,
@@ -169,6 +199,7 @@ export function createCanvasPreviewController(
 		}
 		pendingFlush = true;
 		try {
+			let rebaseAttempted = false;
 			do {
 				pendingFlushRequested = false;
 				while (true) {
@@ -177,16 +208,30 @@ export function createCanvasPreviewController(
 						documentId,
 					);
 					if (pending.length === 0) break;
-					const tx = pending[0];
+					let tx = pending[0];
 					if (!tx) break;
+					let baseVersion = syncVersionByDocumentId[documentId];
+					if (typeof baseVersion !== "number") {
+						baseVersion = await reloadCanvasWithPendingTransactions(documentId);
+					}
+					if (tx.baseVersion !== baseVersion) {
+						tx = await rebaseCanvasPendingTransaction(tx, baseVersion);
+					}
 					await markCanvasPendingTransactionAttempt(tx);
 					const result = await sdk
 						.space(options.getSpaceId())
 						.sendCanvasTransactionRealtime(documentId, {
 							txId: tx.txId,
-							baseVersion: tx.baseVersion,
+							baseVersion,
 							ops: tx.ops,
+						})
+						.catch(async (error) => {
+							if (rebaseAttempted) throw error;
+							await reloadCanvasWithPendingTransactions(documentId);
+							rebaseAttempted = true;
+							return null;
 						});
+					if (!result) continue;
 					syncVersionByDocumentId = {
 						...syncVersionByDocumentId,
 						[documentId]: result.document.version,
@@ -196,11 +241,36 @@ export function createCanvasPreviewController(
 						documentId,
 						txId: tx.txId,
 					});
+					rebaseAttempted = false;
 				}
 			} while (pendingFlushRequested);
 		} finally {
 			pendingFlush = false;
 		}
+	}
+
+	async function reloadCanvasWithPendingTransactions(documentId: string) {
+		const bootstrap = await sdk
+			.space(options.getSpaceId())
+			.canvas.bootstrap(documentId);
+		const pending = await listCanvasPendingTransactions(
+			options.getSpaceId(),
+			documentId,
+		);
+		const document = pending.reduce(
+			(current, transaction) => applyCanvasOps(current, transaction.ops),
+			canvasBootstrapToDocument(bootstrap),
+		);
+		syncVersionByDocumentId = {
+			...syncVersionByDocumentId,
+			[documentId]: bootstrap.document.version,
+		};
+		canvases = canvases.map((canvas) =>
+			canvas.documentId === documentId
+				? { ...canvas, document, error: null }
+				: canvas,
+		);
+		return bootstrap.document.version;
 	}
 
 	async function commitCanvas(
@@ -221,7 +291,7 @@ export function createCanvasPreviewController(
 			spaceId: options.getSpaceId(),
 			documentId,
 			txId,
-			baseVersion: syncVersionByDocumentId[documentId] ?? null,
+			baseVersion: syncVersionByDocumentId[documentId] ?? 0,
 			ops,
 		});
 		canvases = canvases.map((item) =>
@@ -279,21 +349,36 @@ export function createCanvasPreviewController(
 		setCanvasError(documentId, error);
 	}
 
-	function applyBootstrap(
+	async function applyRemoteTransaction(
 		documentId: string,
-		bootstrap: Parameters<typeof canvasBootstrapToDocument>[0],
+		version: number,
+		ops: unknown[],
 	) {
 		const canvas = canvases.find((item) => item.documentId === documentId);
-		if (!canvas || canvas.saving) return;
+		if (!canvas?.document || canvas.saving) return;
+		const currentDocument = canvas.document;
+		const currentVersion = syncVersionByDocumentId[documentId];
+		if (typeof currentVersion !== "number" || version !== currentVersion + 1) {
+			await reloadCanvasWithPendingTransactions(documentId);
+			return;
+		}
+		const parsedOps = ops.filter(isCanvasSemanticOp);
+		if (parsedOps.length !== ops.length) {
+			await reloadCanvasWithPendingTransactions(documentId);
+			return;
+		}
 		syncVersionByDocumentId = {
 			...syncVersionByDocumentId,
-			[documentId]: bootstrap.document.version,
+			[documentId]: version,
 		};
 		canvases = canvases.map((item) =>
 			item.documentId === documentId
 				? {
 						...item,
-						document: canvasBootstrapToDocument(bootstrap),
+						document: applyCanvasOps(
+							item.document ?? currentDocument,
+							parsedOps,
+						),
 						error: null,
 					}
 				: item,
@@ -317,6 +402,6 @@ export function createCanvasPreviewController(
 		flushPendingTransactions,
 		renamePath,
 		setError,
-		applyBootstrap,
+		applyRemoteTransaction,
 	};
 }

--- a/packages/db/src/schema-v2.ts
+++ b/packages/db/src/schema-v2.ts
@@ -343,11 +343,11 @@ export const canvasDocuments = v2.table(
   "canvas_documents",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    spaceId: uuid("space_id").notNull(),
+    spaceId: uuid("space_id").notNull().references(() => spaces.id, { onDelete: "cascade" }),
     filePath: text("file_path").notNull(),
     title: text("title").notNull(),
     version: integer("version").notNull().default(0),
-    meta: jsonb("meta").$type<Record<string, unknown>>(),
+    meta: jsonb("meta").$type<Record<string, unknown>>().notNull().default({}),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
@@ -355,13 +355,14 @@ export const canvasDocuments = v2.table(
   (table) => ({
     spaceIdx: index("v2_idx_canvas_documents_space_id").on(table.spaceId),
     spacePathUniqueIdx: uniqueIndex("v2_uq_canvas_documents_space_path").on(table.spaceId, table.filePath),
+    versionCheck: check("v2_chk_canvas_documents_version", sql`${table.version} >= 0`),
   }),
 );
 
 export const canvasNodes = v2.table(
   "canvas_nodes",
   {
-    documentId: uuid("document_id").notNull(),
+    documentId: uuid("document_id").notNull().references(() => canvasDocuments.id, { onDelete: "cascade" }),
     nodeId: text("node_id").notNull(),
     type: varchar("type", { length: 40 }).notNull(),
     parentId: text("parent_id"),
@@ -385,9 +386,10 @@ export const canvasNodes = v2.table(
   },
   (table) => ({
     primary: uniqueIndex("v2_uq_canvas_nodes_document_node").on(table.documentId, table.nodeId),
-    documentIdx: index("v2_idx_canvas_nodes_document_id").on(table.documentId),
     viewportIdx: index("v2_idx_canvas_nodes_viewport").on(table.documentId, table.x, table.y, table.width, table.height),
     refPathIdx: index("v2_idx_canvas_nodes_ref_path").on(table.documentId, table.refPath),
+    dimensionsCheck: check("v2_chk_canvas_nodes_dimensions", sql`${table.width} > 0 AND ${table.height} > 0`),
+    versionCheck: check("v2_chk_canvas_nodes_version", sql`${table.version} >= 0`),
   }),
 );
 
@@ -395,18 +397,24 @@ export const canvasUpdates = v2.table(
   "canvas_updates",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    documentId: uuid("document_id").notNull(),
+    documentId: uuid("document_id").notNull().references(() => canvasDocuments.id, { onDelete: "cascade" }),
+    txId: text("tx_id").notNull(),
+    baseVersion: integer("base_version").notNull(),
+    requestHash: varchar("request_hash", { length: 64 }),
     version: integer("version").notNull(),
     actorId: varchar("actor_id", { length: 255 }).notNull(),
     clientId: text("client_id"),
     type: varchar("type", { length: 80 }).notNull(),
     payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
+    result: jsonb("result").$type<Record<string, unknown>>().notNull().default({}),
     undoGroupId: text("undo_group_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
   },
   (table) => ({
     documentVersionUniqueIdx: uniqueIndex("v2_uq_canvas_updates_document_version").on(table.documentId, table.version),
-    documentIdx: index("v2_idx_canvas_updates_document_id").on(table.documentId),
+    documentTxUniqueIdx: uniqueIndex("v2_uq_canvas_updates_document_tx").on(table.documentId, table.txId),
+    baseVersionCheck: check("v2_chk_canvas_updates_base_version", sql`${table.baseVersion} >= 0`),
+    versionCheck: check("v2_chk_canvas_updates_version", sql`${table.version} > ${table.baseVersion}`),
   }),
 );
 

--- a/packages/protocol/src/realtime/schema.ts
+++ b/packages/protocol/src/realtime/schema.ts
@@ -96,7 +96,7 @@ export const wsClientEventSchema = z.discriminatedUnion("type", [
       spaceId: z.string().uuid(),
       documentId: z.string().min(1),
       txId: z.string().min(1),
-      baseVersion: z.number().nullable().optional(),
+      baseVersion: z.number().int().nonnegative(),
       clientId: z.string().nullable().optional(),
       undoGroupId: z.string().nullable().optional(),
       ops: z.array(z.record(z.string(), z.unknown())).min(1),

--- a/packages/protocol/src/realtime/types.ts
+++ b/packages/protocol/src/realtime/types.ts
@@ -42,7 +42,7 @@ export type WsClientEvent =
   | { type: "subscribe"; requestId?: string; payload: { rooms: string[] } }
   | { type: "unsubscribe"; requestId?: string; payload: { rooms: string[] } }
   | { type: "session.message.create"; requestId?: string; payload: { spaceId: string; sessionId: string; clientMessageId?: string; content: ContentBlock[]; model?: string; provider?: string } }
-  | { type: "canvas.tx"; requestId?: string; payload: { spaceId: string; documentId: string; txId: string; baseVersion?: number | null; clientId?: string | null; undoGroupId?: string | null; ops: Array<Record<string, unknown>> } }
+  | { type: "canvas.tx"; requestId?: string; payload: { spaceId: string; documentId: string; txId: string; baseVersion: number; clientId?: string | null; undoGroupId?: string | null; ops: Array<Record<string, unknown>> } }
   | { type: "presence.update"; requestId?: string; payload: { spaceId: string; meta?: Record<string, unknown> | null } }
   | { type: "ping"; requestId?: string; payload?: Record<string, unknown> }
   | { type: "ack"; requestId?: string; payload?: { eventId?: string } };
@@ -495,6 +495,7 @@ export type CanvasTransactionAckEvent = {
     documentId: string;
     txId: string;
     version: number;
+    replayed?: boolean;
   };
 };
 
@@ -510,6 +511,9 @@ export type CanvasTransactionErrorEvent = {
     documentId?: string | null;
     txId?: string | null;
     message: string;
+    code?: string;
+    status?: number;
+    currentVersion?: number;
   };
 };
 

--- a/packages/sdk/src/apis/spaces.ts
+++ b/packages/sdk/src/apis/spaces.ts
@@ -76,6 +76,8 @@ import type {
   ChannelHealth,
   CanvasDocumentRecord,
   CanvasTransactionInput,
+  CanvasTransactionResponse,
+  CanvasUpdatesResponse,
 } from "../types.js";
 import { SpaceInvitationsApi } from "./invitations.js";
 
@@ -1412,8 +1414,17 @@ export class SpaceCanvasApi {
     );
   }
 
+  updates(documentId: string, input: { afterVersion: number; limit?: number }, customFetch?: Fetch) {
+    const params = new URLSearchParams({ afterVersion: String(input.afterVersion) });
+    if (input.limit !== undefined) params.set("limit", String(input.limit));
+    return this.transport.request<CanvasUpdatesResponse>(
+      `/api/spaces/${this.spaceId}/canvas/${documentId}/updates?${params.toString()}`,
+      { fetch: customFetch },
+    );
+  }
+
   sendTransaction(documentId: string, input: CanvasTransactionInput) {
-    return this.transport.request<CanvasBootstrapResponse>(
+    return this.transport.request<CanvasTransactionResponse>(
       `/api/spaces/${this.spaceId}/canvas/${documentId}/ops`,
       {
         method: "POST",
@@ -1817,7 +1828,7 @@ export class SpaceClient {
   async sendCanvasTransactionRealtime(documentId: string, input: CanvasTransactionInput) {
     if (!this.websocketClient) return this.canvas.sendTransaction(documentId, input);
     const requestId = `canvas-${input.txId}`;
-    const result = new Promise<{ document: { version: number } }>((resolve, reject) => {
+    const result = new Promise<{ document: { version: number }; transaction: { txId: string; version: number; replayed: boolean } }>((resolve, reject) => {
       let settled = false;
       let timeout: ReturnType<typeof setTimeout> | null = null;
       const settle = (fn: () => void) => {
@@ -1831,8 +1842,16 @@ export class SpaceClient {
       const cleanupAck = this.websocketClient?.on("event", (event) => {
         if (event.type !== "canvas.tx.ack" || event.requestId !== requestId) return;
         const version = event.payload.version;
+        const txId = event.payload.txId;
         settle(() => {
-          if (typeof version === "number") resolve({ document: { version } });
+          if (typeof version === "number" && typeof txId === "string") resolve({
+            document: { version },
+            transaction: {
+              txId,
+              version,
+              replayed: event.payload.replayed === true,
+            },
+          });
           else reject(new Error("Invalid canvas ack"));
         });
       });
@@ -1846,7 +1865,7 @@ export class SpaceClient {
       spaceId: this.id,
       documentId,
       txId: input.txId,
-      baseVersion: input.baseVersion ?? null,
+      baseVersion: input.baseVersion,
       clientId: input.clientId ?? null,
       undoGroupId: input.undoGroupId ?? null,
       ops: input.ops,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -748,7 +748,7 @@ export type CanvasDocumentRecord = {
   filePath: string;
   title: string;
   version: number;
-  meta?: Record<string, unknown> | null;
+  meta: Record<string, unknown>;
   createdAt: string | null;
   updatedAt: string | null;
   deletedAt?: string | null;
@@ -782,17 +782,52 @@ export type CanvasNodeInput = Omit<CanvasNodeRecord, "documentId" | "version" | 
 
 export type CanvasSemanticOp = {
   opId?: string;
-  type: "node.create" | "node.patch" | "node.delete";
+  version?: 1 | 2;
+  type: "node.create" | "node.patch" | "node.data.merge" | "node.delete" | "document.meta.patch";
   payload: Record<string, unknown>;
   inverse?: Record<string, unknown>;
 };
 
 export type CanvasTransactionInput = {
   txId: string;
-  baseVersion?: number | null;
+  baseVersion: number;
   clientId?: string | null;
   undoGroupId?: string | null;
   ops: CanvasSemanticOp[];
+};
+
+export type CanvasTransactionResponse = {
+  transaction: {
+    txId: string;
+    baseVersion: number;
+    version: number;
+    replayed: boolean;
+  };
+  document: {
+    version: number;
+    meta: Record<string, unknown>;
+  };
+  changes: {
+    nodes: CanvasNodeRecord[];
+    deletedNodeIds: string[];
+  };
+};
+
+export type CanvasUpdateRecord = {
+  txId: string;
+  baseVersion: number;
+  version: number;
+  actorId: string;
+  clientId: string | null;
+  payload: { ops?: CanvasSemanticOp[] } & Record<string, unknown>;
+  createdAt: string | null;
+};
+
+export type CanvasUpdatesResponse = {
+  documentVersion: number;
+  updates: CanvasUpdateRecord[];
+  hasMore: boolean;
+  requiresBootstrap: boolean;
 };
 
 export type CanvasCreateInput = {

--- a/packages/sdk/src/websocket.ts
+++ b/packages/sdk/src/websocket.ts
@@ -383,7 +383,7 @@ export class WebsocketClient {
     documentId: string;
     txId: string;
     ops: Array<Record<string, unknown>>;
-    baseVersion?: number | null;
+    baseVersion: number;
     clientId?: string | null;
     undoGroupId?: string | null;
     requestId?: string;
@@ -396,7 +396,7 @@ export class WebsocketClient {
         spaceId: input.spaceId,
         documentId: input.documentId,
         txId: input.txId,
-        baseVersion: input.baseVersion ?? null,
+        baseVersion: input.baseVersion,
         clientId: input.clientId ?? null,
         undoGroupId: input.undoGroupId ?? null,
         ops: input.ops,


### PR DESCRIPTION
## What changed

- make Canvas writes idempotent with durable `tx_id`, `base_version`, request hashes, and stored transaction results
- add versioned `node.data.merge` and `document.meta.patch` operations while preserving legacy `node.patch` replacement semantics
- return changed nodes instead of reloading the entire canvas after every write
- add Canvas foreign keys and invariants through a production-safe staged migration
- rebase IndexedDB pending transactions after conflicts and apply realtime operations incrementally
- expose transaction, conflict, and update-catchup contracts through the SDK and Gateway

## Why

The previous protocol stored `txId` only inside JSON payloads, accepted missing base versions, replaced complete node data objects, and reloaded every node after each operation. A timeout or concurrent edit could therefore lose fields, strand pending transactions, or duplicate writes.

## Rollout

Deploy in this order: migration `0044_silky_mentallo.sql`, API and Gateway, SDK and Web, then OpenTap. The migration backfills historical updates and adds constraints as `NOT VALID`; validate them after checking existing production rows.

## Validation

- `pnpm -r typecheck` with the required public environment variables
- `pnpm -r lint` (existing unrelated warnings only)
- API and Gateway builds
- Canvas protocol unit tests
- Web Svelte typecheck
- migration replayed from `0000` through `0044` on a fresh PostgreSQL database, followed by successful constraint validation
