### PR TITLE
[codex] fix nullable token usage aggregation

### DIFF
--- a/apps/agent/src/persistence.ts
+++ b/apps/agent/src/persistence.ts
@@ -4,7 +4,7 @@ import type { ContentBlock, Usage } from "@cohub/protocol/core";
 import type { MessageRecord, MessageToolCallsFile, PersistMessageInput, SessionTurnRecord, SessionTurnStatus, StoredIntermediateMessage, StoredToolCall, TurnIntermediateMessagesFile } from "@cohub/protocol/model";
 import type { ChannelProvider, GatewayOutboundCommand } from "@cohub/protocol/gateway";
 import { getRealtimeUserRoom } from "@cohub/protocol/realtime";
-import { sessionMessages, sessionTurns, spaceChannels, spaceSessionBindings, spaceSessions, providerMessageRefs, userChannels, userProfiles } from "@cohub/db";
+import { allocateSessionMessageSequence, sessionMessages, sessionTurns, spaceChannels, spaceSessionBindings, spaceSessions, providerMessageRefs, userChannels, userProfiles } from "@cohub/db";
 import { sanitizeContentBlocksForPostgresJson, sanitizePostgresJsonValue } from "@cohub/core/content/sanitize";
 import { countToolCallsInContent, deriveMessagePreviewText, extractPlainText } from "@cohub/core/sessions";
 import { buildTraceHeaders, getCurrentRequestId } from "@cohub/infra/tracing";
@@ -93,11 +93,6 @@ const normalizeUsage = (usage: PersistMessageInput["message"]["usage"]): Usage |
 };
 
 const normalizeRecord = (value: unknown): Record<string, unknown> | null => value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
-
-const getNextSessionSequence = async (sessionId: string) => {
-  const [row] = await db.select({ max: sql<number>`coalesce(max(${sessionMessages.sequence}), 0)::int` }).from(sessionMessages).where(eq(sessionMessages.sessionId, sessionId));
-  return (row?.max ?? 0) + 1;
-};
 
 const toIso = (value: Date | string | null | undefined) => value instanceof Date ? value.toISOString() : value ?? new Date().toISOString();
 const toIsoOrNull = (value: Date | string | null | undefined) => value ? toIso(value) : null;
@@ -240,7 +235,6 @@ async function persistMessageNode(input: PersistMessageInput & { message: Persis
     if (!previous) throw new Error("Previous message not found");
   }
 
-  const sequence = await getNextSessionSequence(input.sessionId);
   const content = sanitizeContentBlocksForPostgresJson(input.message.content);
   const text = deriveMessagePreviewText({ content }) || null;
   const messageRole = input.message.role ?? "assistant";
@@ -257,7 +251,7 @@ async function persistMessageNode(input: PersistMessageInput & { message: Persis
   const durationMs = typeof input.message.durationMs === "number" ? Math.max(0, Math.floor(input.message.durationMs)) : Math.max(0, completedAt.getTime() - startedAt.getTime());
   const anchorUserMessageId = input.anchorUserMessageId?.trim() || null;
 
-  const [messageNode] = await db.insert(sessionMessages).values({
+  const [insertedMessage] = await db.insert(sessionMessages).values({
     id: input.message.id?.trim() || undefined,
     sessionId: input.sessionId,
     role: messageRole,
@@ -265,7 +259,7 @@ async function persistMessageNode(input: PersistMessageInput & { message: Persis
     text,
     meta: sanitizePostgresJsonValue({ ...input.message.meta, messageKind, anchorUserMessageId, actorUserId: input.userId ?? null, providerResponseId: input.message.meta?.responseId ?? null }),
     idempotencyKey: input.idempotencyKey,
-    sequence,
+    sequence: allocateSessionMessageSequence(input.sessionId),
     provider: input.message.provider ?? null,
     model: input.message.model ?? null,
     stopReason: input.message.stopReason ?? null,
@@ -274,8 +268,18 @@ async function persistMessageNode(input: PersistMessageInput & { message: Persis
     startedAt,
     completedAt,
     durationMs,
+  }).onConflictDoNothing({
+    target: [sessionMessages.sessionId, sessionMessages.idempotencyKey],
   }).returning();
-  if (!messageNode) throw new Error("Failed to persist message");
+  if (!insertedMessage) {
+    const [existingAfterConflict] = await db.select().from(sessionMessages).where(and(
+      eq(sessionMessages.sessionId, input.sessionId),
+      eq(sessionMessages.idempotencyKey, input.idempotencyKey),
+    )).limit(1);
+    if (!existingAfterConflict) throw new Error("Failed to resolve idempotent message conflict");
+    return { message: existingAfterConflict, created: false };
+  }
+  const messageNode = insertedMessage;
 
   if (messageRole === "user" && !session.title?.trim()) {
     const titleText = (text ?? extractPlainText(content)).replace(/\s+/g, " ").replace(/^[:\-\s]+/, "").trim().slice(0, 60);
@@ -771,6 +775,11 @@ export async function persistCompactionTurn(input: {
 
   try {
     await db.transaction(async (tx) => {
+      const [sessionRow] = await tx.execute(sql`
+        select id from v2.space_sessions where id = ${input.sessionId} for update
+      `);
+      if (!sessionRow) throw new Error("Session not found while persisting compaction");
+
       // Step 1: Shift turns with sequence >= compactSequence by big offset.
       await tx.update(sessionTurns)
         .set({ sequence: sql`${sessionTurns.sequence} + 1000000` })
@@ -808,20 +817,19 @@ export async function persistCompactionTurn(input: {
       state.turnRow = row;
 
       // Step 4: Insert system message in the same transaction.
-      const [maxMsgRow] = await tx.select({ max: sql<number>`coalesce(max(${sessionMessages.sequence}), 0)::int` }).from(sessionMessages).where(eq(sessionMessages.sessionId, input.sessionId));
-      state.messageSequence = (maxMsgRow?.max ?? 0) + 1;
       const [msgRow] = await tx.insert(sessionMessages).values({
         sessionId: input.sessionId,
         role: "system",
         content: [{ type: "system_note", note_type: "compacted", text: input.summary }],
         text: null,
-        sequence: state.messageSequence,
+        sequence: allocateSessionMessageSequence(input.sessionId),
         meta: { messageKind: "compacted", turnId: state.turnRow?.id ?? null, ...compactionMeta },
         startedAt: now,
         completedAt: now,
         durationMs: 0,
       }).returning();
       state.messageRow = msgRow ?? null;
+      state.messageSequence = msgRow?.sequence ?? 0;
     });
   } catch (error) {
     logger.error(`[Compaction] DB transaction failed sessionId=${input.sessionId}:`, error);

--- a/apps/api/drizzle/v2/0044_silky_mentallo.sql
+++ b/apps/api/drizzle/v2/0044_silky_mentallo.sql
@@ -1,0 +1,38 @@
+DROP INDEX "v2"."v2_idx_canvas_nodes_document_id";--> statement-breakpoint
+DROP INDEX "v2"."v2_idx_canvas_updates_document_id";--> statement-breakpoint
+ALTER TABLE "v2"."canvas_documents" ALTER COLUMN "meta" SET DEFAULT '{}'::jsonb;--> statement-breakpoint
+UPDATE "v2"."canvas_documents" SET "meta" = '{}'::jsonb WHERE "meta" IS NULL;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_documents" ALTER COLUMN "meta" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ADD COLUMN "tx_id" text;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ADD COLUMN "base_version" integer;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ADD COLUMN "request_hash" varchar(64);--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ADD COLUMN "result" jsonb DEFAULT '{}'::jsonb NOT NULL;--> statement-breakpoint
+UPDATE "v2"."canvas_updates"
+SET
+  "tx_id" = COALESCE(NULLIF("payload" ->> 'txId', ''), "id"::text),
+  "base_version" = CASE
+    WHEN "payload" ->> 'baseVersion' ~ '^[0-9]+$' THEN ("payload" ->> 'baseVersion')::integer
+    ELSE GREATEST("version" - 1, 0)
+  END;--> statement-breakpoint
+WITH ranked AS (
+  SELECT "id", row_number() OVER (
+    PARTITION BY "document_id", "tx_id"
+    ORDER BY "version" DESC, "id" DESC
+  ) AS duplicate_rank
+  FROM "v2"."canvas_updates"
+)
+UPDATE "v2"."canvas_updates" AS updates
+SET "tx_id" = updates."tx_id" || ':legacy:' || updates."id"::text
+FROM ranked
+WHERE updates."id" = ranked."id" AND ranked.duplicate_rank > 1;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ALTER COLUMN "tx_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ALTER COLUMN "base_version" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_documents" ADD CONSTRAINT "canvas_documents_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "v2"."spaces"("id") ON DELETE cascade ON UPDATE no action NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_nodes" ADD CONSTRAINT "canvas_nodes_document_id_canvas_documents_id_fk" FOREIGN KEY ("document_id") REFERENCES "v2"."canvas_documents"("id") ON DELETE cascade ON UPDATE no action NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ADD CONSTRAINT "canvas_updates_document_id_canvas_documents_id_fk" FOREIGN KEY ("document_id") REFERENCES "v2"."canvas_documents"("id") ON DELETE cascade ON UPDATE no action NOT VALID;--> statement-breakpoint
+CREATE UNIQUE INDEX "v2_uq_canvas_updates_document_tx" ON "v2"."canvas_updates" USING btree ("document_id","tx_id");--> statement-breakpoint
+ALTER TABLE "v2"."canvas_documents" ADD CONSTRAINT "v2_chk_canvas_documents_version" CHECK ("v2"."canvas_documents"."version" >= 0) NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_nodes" ADD CONSTRAINT "v2_chk_canvas_nodes_dimensions" CHECK ("v2"."canvas_nodes"."width" > 0 AND "v2"."canvas_nodes"."height" > 0) NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_nodes" ADD CONSTRAINT "v2_chk_canvas_nodes_version" CHECK ("v2"."canvas_nodes"."version" >= 0) NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ADD CONSTRAINT "v2_chk_canvas_updates_base_version" CHECK ("v2"."canvas_updates"."base_version" >= 0) NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."canvas_updates" ADD CONSTRAINT "v2_chk_canvas_updates_version" CHECK ("v2"."canvas_updates"."version" > "v2"."canvas_updates"."base_version") NOT VALID;

--- a/apps/api/drizzle/v2/0045_same_doctor_octopus.sql
+++ b/apps/api/drizzle/v2/0045_same_doctor_octopus.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "v2"."user_channels" ALTER COLUMN "credentials" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "v2"."user_channels" ADD COLUMN "credential_envelope" jsonb;--> statement-breakpoint
+ALTER TABLE "v2"."user_channels" ADD COLUMN "credential_revision" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "v2"."user_channels" ADD CONSTRAINT "v2_chk_user_channels_credentials_storage" CHECK (num_nonnulls("v2"."user_channels"."credentials", "v2"."user_channels"."credential_envelope") = 1) NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."user_channels" ADD CONSTRAINT "v2_chk_user_channels_credential_envelope" CHECK ("v2"."user_channels"."credential_envelope" is null or coalesce(
+        jsonb_typeof("v2"."user_channels"."credential_envelope") = 'object'
+        and "v2"."user_channels"."credential_envelope"->'version' = '1'::jsonb
+        and "v2"."user_channels"."credential_envelope"->>'algorithm' = 'aes-256-gcm'
+        and "v2"."user_channels"."credential_envelope"->>'keyId' ~ '^[A-Za-z0-9._-]{1,64}$'
+        and "v2"."user_channels"."credential_envelope"->>'nonce' ~ '^[A-Za-z0-9_-]{16}$'
+        and "v2"."user_channels"."credential_envelope"->>'authTag' ~ '^[A-Za-z0-9_-]{22}$'
+        and "v2"."user_channels"."credential_envelope"->>'ciphertext' ~ '^[A-Za-z0-9_-]{3,}$',
+        false
+      )) NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."user_channels" ADD CONSTRAINT "v2_chk_user_channels_credential_revision" CHECK ("v2"."user_channels"."credential_revision" > 0) NOT VALID;

--- a/apps/api/drizzle/v2/0046_white_menace.sql
+++ b/apps/api/drizzle/v2/0046_white_menace.sql
@@ -1,0 +1,29 @@
+CREATE OR REPLACE FUNCTION "v2"."allocate_session_message_sequence"("p_session_id" uuid)
+RETURNS integer
+LANGUAGE plpgsql
+VOLATILE
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  next_sequence integer;
+BEGIN
+  PERFORM 1
+  FROM v2.space_sessions
+  WHERE id = p_session_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'space session % does not exist', p_session_id
+      USING ERRCODE = '23503';
+  END IF;
+
+  SELECT coalesce(max(sequence), 0)::integer + 1
+  INTO next_sequence
+  FROM v2.session_messages
+  WHERE session_id = p_session_id;
+
+  RETURN next_sequence;
+END;
+$$;--> statement-breakpoint
+ALTER TABLE "v2"."session_messages" ADD CONSTRAINT "v2_chk_session_messages_sequence" CHECK ("v2"."session_messages"."sequence" > 0) NOT VALID;--> statement-breakpoint
+ALTER TABLE "v2"."session_turns" ADD CONSTRAINT "v2_chk_session_turns_sequence" CHECK ("v2"."session_turns"."sequence" > 0) NOT VALID;

--- a/apps/api/drizzle/v2/0047_fuzzy_jigsaw.sql
+++ b/apps/api/drizzle/v2/0047_fuzzy_jigsaw.sql
@@ -1,0 +1,85 @@
+SET LOCAL lock_timeout = '30s';--> statement-breakpoint
+LOCK TABLE "v2"."token_usage_stats_hourly" IN SHARE ROW EXCLUSIVE MODE;--> statement-breakpoint
+CREATE TEMP TABLE "token_usage_stats_hourly_duplicates" AS
+SELECT
+  "bucket_start_at",
+  "user_id",
+  "space_id",
+  "session_id",
+  "provider",
+  "model",
+  sum("request_count")::integer AS "request_count",
+  sum("success_count")::integer AS "success_count",
+  sum("error_count")::integer AS "error_count",
+  sum("input_tokens")::integer AS "input_tokens",
+  sum("output_tokens")::integer AS "output_tokens",
+  sum("cache_read_tokens")::integer AS "cache_read_tokens",
+  sum("cache_write_tokens")::integer AS "cache_write_tokens",
+  sum("total_tokens")::integer AS "total_tokens",
+  sum("cost_input") AS "cost_input",
+  sum("cost_output") AS "cost_output",
+  sum("cost_cache_read") AS "cost_cache_read",
+  sum("cost_cache_write") AS "cost_cache_write",
+  sum("cost_total") AS "cost_total",
+  min("created_at") AS "created_at",
+  max("updated_at") AS "updated_at"
+FROM "v2"."token_usage_stats_hourly"
+GROUP BY "bucket_start_at", "user_id", "space_id", "session_id", "provider", "model"
+HAVING count(*) > 1;--> statement-breakpoint
+DELETE FROM "v2"."token_usage_stats_hourly" AS target
+USING "token_usage_stats_hourly_duplicates" AS duplicate
+WHERE target."bucket_start_at" = duplicate."bucket_start_at"
+  AND target."user_id" IS NOT DISTINCT FROM duplicate."user_id"
+  AND target."space_id" = duplicate."space_id"
+  AND target."session_id" = duplicate."session_id"
+  AND target."provider" IS NOT DISTINCT FROM duplicate."provider"
+  AND target."model" IS NOT DISTINCT FROM duplicate."model";--> statement-breakpoint
+INSERT INTO "v2"."token_usage_stats_hourly" (
+  "bucket_start_at",
+  "user_id",
+  "space_id",
+  "session_id",
+  "provider",
+  "model",
+  "request_count",
+  "success_count",
+  "error_count",
+  "input_tokens",
+  "output_tokens",
+  "cache_read_tokens",
+  "cache_write_tokens",
+  "total_tokens",
+  "cost_input",
+  "cost_output",
+  "cost_cache_read",
+  "cost_cache_write",
+  "cost_total",
+  "created_at",
+  "updated_at"
+)
+SELECT
+  "bucket_start_at",
+  "user_id",
+  "space_id",
+  "session_id",
+  "provider",
+  "model",
+  "request_count",
+  "success_count",
+  "error_count",
+  "input_tokens",
+  "output_tokens",
+  "cache_read_tokens",
+  "cache_write_tokens",
+  "total_tokens",
+  "cost_input",
+  "cost_output",
+  "cost_cache_read",
+  "cost_cache_write",
+  "cost_total",
+  "created_at",
+  "updated_at"
+FROM "token_usage_stats_hourly_duplicates";--> statement-breakpoint
+DROP TABLE "token_usage_stats_hourly_duplicates";--> statement-breakpoint
+DROP INDEX "v2"."v2_uq_token_usage_stats_hourly_bucket_dims";--> statement-breakpoint
+ALTER TABLE "v2"."token_usage_stats_hourly" ADD CONSTRAINT "v2_uq_token_usage_stats_hourly_bucket_dims" UNIQUE NULLS NOT DISTINCT("bucket_start_at","user_id","space_id","session_id","provider","model");

--- a/apps/api/drizzle/v2/meta/0044_snapshot.json
+++ b/apps/api/drizzle/v2/meta/0044_snapshot.json
@@ -1,0 +1,6685 @@
+{
+  "id": "5595636d-ff60-4d44-9b92-a979a96fc4ba",
+  "prevId": "d509dbad-2f53-4e93-b3df-ca527b7c18b1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "v2.access_policies": {
+      "name": "access_policies",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_in_user_role": {
+          "name": "signed_in_user_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_user_role": {
+          "name": "anonymous_user_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_access_policies_resource": {
+          "name": "v2_uq_access_policies_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_access_policies_resource": {
+          "name": "v2_idx_access_policies_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.canvas_checkpoint_snapshots": {
+      "name": "canvas_checkpoint_snapshots",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_space_id": {
+          "name": "source_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_file_path": {
+          "name": "source_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_checkpoint_snapshots_path": {
+          "name": "v2_uq_canvas_checkpoint_snapshots_path",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_checkpoint_snapshots_checkpoint_id": {
+          "name": "v2_idx_canvas_checkpoint_snapshots_checkpoint_id",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.canvas_documents": {
+      "name": "canvas_documents",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_canvas_documents_space_id": {
+          "name": "v2_idx_canvas_documents_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_canvas_documents_space_path": {
+          "name": "v2_uq_canvas_documents_space_path",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_documents_space_id_spaces_id_fk": {
+          "name": "canvas_documents_space_id_spaces_id_fk",
+          "tableFrom": "canvas_documents",
+          "tableTo": "spaces",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_documents_version": {
+          "name": "v2_chk_canvas_documents_version",
+          "value": "\"v2\".\"canvas_documents\".\"version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.canvas_nodes": {
+      "name": "canvas_nodes",
+      "schema": "v2",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 240
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 160
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ref_kind": {
+          "name": "ref_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_path": {
+          "name": "ref_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_url": {
+          "name": "ref_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view": {
+          "name": "view",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "style": {
+          "name": "style",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "animation": {
+          "name": "animation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_nodes_document_node": {
+          "name": "v2_uq_canvas_nodes_document_node",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_nodes_viewport": {
+          "name": "v2_idx_canvas_nodes_viewport",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "x",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "y",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_nodes_ref_path": {
+          "name": "v2_idx_canvas_nodes_ref_path",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_nodes_document_id_canvas_documents_id_fk": {
+          "name": "canvas_nodes_document_id_canvas_documents_id_fk",
+          "tableFrom": "canvas_nodes",
+          "tableTo": "canvas_documents",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_nodes_dimensions": {
+          "name": "v2_chk_canvas_nodes_dimensions",
+          "value": "\"v2\".\"canvas_nodes\".\"width\" > 0 AND \"v2\".\"canvas_nodes\".\"height\" > 0"
+        },
+        "v2_chk_canvas_nodes_version": {
+          "name": "v2_chk_canvas_nodes_version",
+          "value": "\"v2\".\"canvas_nodes\".\"version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.canvas_updates": {
+      "name": "canvas_updates",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_id": {
+          "name": "tx_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_version": {
+          "name": "base_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "undo_group_id": {
+          "name": "undo_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_updates_document_version": {
+          "name": "v2_uq_canvas_updates_document_version",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_canvas_updates_document_tx": {
+          "name": "v2_uq_canvas_updates_document_tx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tx_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_updates_document_id_canvas_documents_id_fk": {
+          "name": "canvas_updates_document_id_canvas_documents_id_fk",
+          "tableFrom": "canvas_updates",
+          "tableTo": "canvas_documents",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_updates_base_version": {
+          "name": "v2_chk_canvas_updates_base_version",
+          "value": "\"v2\".\"canvas_updates\".\"base_version\" >= 0"
+        },
+        "v2_chk_canvas_updates_version": {
+          "name": "v2_chk_canvas_updates_version",
+          "value": "\"v2\".\"canvas_updates\".\"version\" > \"v2\".\"canvas_updates\".\"base_version\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.checkpoints": {
+      "name": "checkpoints",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_checkpoint_id": {
+          "name": "parent_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_checkpoint_id": {
+          "name": "root_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fork_count": {
+          "name": "fork_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "save_version": {
+          "name": "save_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_checkpoints_space_id": {
+          "name": "v2_idx_checkpoints_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_parent_id": {
+          "name": "v2_idx_checkpoints_parent_id",
+          "columns": [
+            {
+              "expression": "parent_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_root_id": {
+          "name": "v2_idx_checkpoints_root_id",
+          "columns": [
+            {
+              "expression": "root_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_description_trgm": {
+          "name": "v2_idx_checkpoints_description_trgm",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_uq_checkpoints_space_commit": {
+          "name": "v2_uq_checkpoints_space_commit",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asia/Shanghai'"
+        },
+        "bull_job_key": {
+          "name": "bull_job_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_cron_jobs_user_uuid": {
+          "name": "v2_idx_cron_jobs_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_space_id": {
+          "name": "v2_idx_cron_jobs_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_enabled": {
+          "name": "v2_idx_cron_jobs_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_created_at": {
+          "name": "v2_idx_cron_jobs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.gateway_logs": {
+      "name": "gateway_logs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_payload": {
+          "name": "normalized_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'success'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_gateway_logs_channel": {
+          "name": "v2_idx_gateway_logs_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_gateway_logs_direction": {
+          "name": "v2_idx_gateway_logs_direction",
+          "columns": [
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_gateway_logs_created": {
+          "name": "v2_idx_gateway_logs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.generation_usage_stats_hourly": {
+      "name": "generation_usage_stats_hourly",
+      "schema": "v2",
+      "columns": {
+        "bucket_start_at": {
+          "name": "bucket_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_generation_usage_stats_hourly_bucket_dims": {
+          "name": "v2_uq_generation_usage_stats_hourly_bucket_dims",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usage_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_user_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_user_bucket",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_space_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_space_bucket",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_session_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_session_bucket",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_usage_type_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_usage_type_bucket",
+          "columns": [
+            {
+              "expression": "usage_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_provider_model_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_provider_model_bucket",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.label_assignments": {
+      "name": "label_assignments",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_ref": {
+          "name": "resource_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_label_assignments_label_resource": {
+          "name": "v2_uq_label_assignments_label_resource",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_label_rank": {
+          "name": "v2_idx_label_assignments_label_rank",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_scope_resource": {
+          "name": "v2_idx_label_assignments_scope_resource",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_scope_label": {
+          "name": "v2_idx_label_assignments_scope_label",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_session_label_resource": {
+          "name": "v2_idx_label_assignments_session_label_resource",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2\".\"label_assignments\".\"resource_type\" = 'session'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_resource_label": {
+          "name": "v2_idx_label_assignments_resource_label",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_resource_ref_trgm": {
+          "name": "v2_idx_label_assignments_resource_ref_trgm",
+          "columns": [
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.labels": {
+      "name": "labels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "system_key": {
+          "name": "system_key",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_labels_scope_rank": {
+          "name": "v2_idx_labels_scope_rank",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_labels_scope_parent": {
+          "name": "v2_idx_labels_scope_parent",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_labels_scope_parent_name": {
+          "name": "v2_uq_labels_scope_parent_name",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"parent_id\"::text, '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_labels_scope_system_key": {
+          "name": "v2_uq_labels_scope_system_key",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_labels_depth": {
+          "name": "v2_chk_labels_depth",
+          "value": "\"v2\".\"labels\".\"depth\" in (0, 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.proposals": {
+      "name": "proposals",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_checkpoint_id": {
+          "name": "source_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_space_id": {
+          "name": "target_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_branch_name": {
+          "name": "source_branch_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch_name": {
+          "name": "target_branch_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_pr_id": {
+          "name": "external_pr_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'open'"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_proposals_target_space_id": {
+          "name": "v2_idx_proposals_target_space_id",
+          "columns": [
+            {
+              "expression": "target_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_proposals_source_checkpoint_id": {
+          "name": "v2_idx_proposals_source_checkpoint_id",
+          "columns": [
+            {
+              "expression": "source_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_proposals_status": {
+          "name": "v2_idx_proposals_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.provider_message_refs": {
+      "name": "provider_message_refs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_session_id": {
+          "name": "space_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_channel_id": {
+          "name": "space_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_message_id": {
+          "name": "session_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_conversation_id": {
+          "name": "external_conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_external_conversation_id": {
+          "name": "parent_external_conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_external_message_id": {
+          "name": "parent_external_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_author_id": {
+          "name": "external_author_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_author_name": {
+          "name": "external_author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_provider_message_refs_provider_conversation": {
+          "name": "v2_idx_provider_message_refs_provider_conversation",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_provider_message_refs_provider_message": {
+          "name": "v2_uq_provider_message_refs_provider_message",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_space_session": {
+          "name": "v2_idx_provider_message_refs_space_session",
+          "columns": [
+            {
+              "expression": "space_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_session_message": {
+          "name": "v2_idx_provider_message_refs_session_message",
+          "columns": [
+            {
+              "expression": "session_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_parent_message": {
+          "name": "v2_idx_provider_message_refs_parent_message",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_space_channel": {
+          "name": "v2_idx_provider_message_refs_space_channel",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.referral_codes": {
+      "name": "referral_codes",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_referral_codes_code": {
+          "name": "v2_uq_referral_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_referral_codes_active_user": {
+          "name": "v2_uq_referral_codes_active_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2\".\"referral_codes\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referral_codes_user": {
+          "name": "v2_idx_referral_codes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.referrals": {
+      "name": "referrals",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referral_code_id": {
+          "name": "referral_code_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_user_id": {
+          "name": "inviter_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_user_id": {
+          "name": "invitee_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "qualified_at": {
+          "name": "qualified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewarded_at": {
+          "name": "rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_rewarded_at": {
+          "name": "inviter_rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitee_rewarded_at": {
+          "name": "invitee_rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_reward_amount_usd": {
+          "name": "inviter_reward_amount_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_reward_amount_usd": {
+          "name": "invitee_reward_amount_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_error": {
+          "name": "reward_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_attempted_at": {
+          "name": "reward_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_lease_token": {
+          "name": "reward_lease_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_lease_expires_at": {
+          "name": "reward_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_referrals_invitee": {
+          "name": "v2_uq_referrals_invitee",
+          "columns": [
+            {
+              "expression": "invitee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_inviter": {
+          "name": "v2_idx_referrals_inviter",
+          "columns": [
+            {
+              "expression": "inviter_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_code": {
+          "name": "v2_idx_referrals_code",
+          "columns": [
+            {
+              "expression": "referral_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_qualified_retry": {
+          "name": "v2_idx_referrals_qualified_retry",
+          "columns": [
+            {
+              "expression": "reward_attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2\".\"referrals\".\"status\" = 'qualified'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.resource_references": {
+      "name": "resource_references",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_turn_id": {
+          "name": "source_turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_resource_references_target": {
+          "name": "v2_idx_resource_references_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_source": {
+          "name": "v2_idx_resource_references_source",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_space_kind": {
+          "name": "v2_idx_resource_references_space_kind",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_session_kind": {
+          "name": "v2_idx_resource_references_session_kind",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_turn": {
+          "name": "v2_idx_resource_references_turn",
+          "columns": [
+            {
+              "expression": "source_turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "v2_uq_resource_references_identity": {
+          "name": "v2_uq_resource_references_identity",
+          "nullsNotDistinct": true,
+          "columns": [
+            "kind",
+            "source_type",
+            "source_id",
+            "source_turn_id",
+            "target_type",
+            "target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_forks": {
+      "name": "session_forks",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_session_id": {
+          "name": "child_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_session_id": {
+          "name": "root_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_source_session_id": {
+          "name": "anchor_source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_turn_id": {
+          "name": "anchor_turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_sequence": {
+          "name": "anchor_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_session_ids": {
+          "name": "ancestor_session_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_path": {
+          "name": "session_path",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_session_forks_child": {
+          "name": "v2_uq_session_forks_child",
+          "columns": [
+            {
+              "expression": "child_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_parent": {
+          "name": "v2_idx_session_forks_parent",
+          "columns": [
+            {
+              "expression": "parent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_root_depth": {
+          "name": "v2_idx_session_forks_root_depth",
+          "columns": [
+            {
+              "expression": "root_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_anchor_turn": {
+          "name": "v2_idx_session_forks_anchor_turn",
+          "columns": [
+            {
+              "expression": "anchor_turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_messages": {
+      "name": "session_messages",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_aggregated_at": {
+          "name": "usage_aggregated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_session_messages_session_id": {
+          "name": "v2_idx_session_messages_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_messages_session_sequence": {
+          "name": "v2_uq_session_messages_session_sequence",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_messages_session_id_idempotency_key": {
+          "name": "v2_uq_session_messages_session_id_idempotency_key",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_turn_segments": {
+      "name": "session_turn_segments",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_sequence": {
+          "name": "from_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_sequence": {
+          "name": "to_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_session_turn_segments_session_ordinal": {
+          "name": "v2_uq_session_turn_segments_session_ordinal",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turn_segments_session": {
+          "name": "v2_idx_session_turn_segments_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turn_segments_source": {
+          "name": "v2_idx_session_turn_segments_source",
+          "columns": [
+            {
+              "expression": "source_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_turns": {
+      "name": "session_turns",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "intent": {
+          "name": "intent",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'steer'"
+        },
+        "user_content": {
+          "name": "user_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_text": {
+          "name": "user_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_content": {
+          "name": "assistant_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_text": {
+          "name": "assistant_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_usage": {
+          "name": "final_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_usage": {
+          "name": "total_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intermediate_index": {
+          "name": "intermediate_index",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intermediate_summary": {
+          "name": "intermediate_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_session_turns_session_id": {
+          "name": "v2_idx_session_turns_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_turns_session_sequence": {
+          "name": "v2_uq_session_turns_session_sequence",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_user_uuid": {
+          "name": "v2_idx_session_turns_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_created_at": {
+          "name": "v2_idx_session_turns_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_user_text_trgm": {
+          "name": "v2_idx_session_turns_user_text_trgm",
+          "columns": [
+            {
+              "expression": "user_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_channels": {
+      "name": "space_channels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_channels_space": {
+          "name": "v2_idx_space_channels_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_channels_channel": {
+          "name": "v2_uq_space_channels_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_commerce_businesses": {
+      "name": "space_commerce_businesses",
+      "schema": "v2",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_business_key": {
+          "name": "billing_business_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_commerce_businesses_business_key": {
+          "name": "v2_uq_space_commerce_businesses_business_key",
+          "columns": [
+            {
+              "expression": "billing_business_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_marks": {
+      "name": "space_marks",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_ref": {
+          "name": "resource_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_marks_resource": {
+          "name": "v2_uq_space_marks_resource",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_marks_space_kind_rank": {
+          "name": "v2_idx_space_marks_space_kind_rank",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_marks_space_resource": {
+          "name": "v2_idx_space_marks_space_resource",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_members": {
+      "name": "space_members",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_members_space_user": {
+          "name": "v2_uq_space_members_space_user",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_space": {
+          "name": "v2_idx_space_members_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_user": {
+          "name": "v2_idx_space_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_user_space": {
+          "name": "v2_idx_space_members_user_space",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_space_role": {
+          "name": "v2_idx_space_members_space_role",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_mods": {
+      "name": "space_mods",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mod_space_id": {
+          "name": "mod_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mount_slug": {
+          "name": "mount_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_mods_space_id": {
+          "name": "v2_idx_space_mods_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_mods_mod_space_id": {
+          "name": "v2_idx_space_mods_mod_space_id",
+          "columns": [
+            {
+              "expression": "mod_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_mods_space_mod": {
+          "name": "v2_uq_space_mods_space_mod",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mod_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_mods_space_mount_slug": {
+          "name": "v2_uq_space_mods_space_mount_slug",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mount_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_sandboxes": {
+      "name": "space_sandboxes",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloud'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "runtime_status": {
+          "name": "runtime_status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "pod_name": {
+          "name": "pod_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_image": {
+          "name": "desired_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_image_version": {
+          "name": "reported_image_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_sandboxes_space_id": {
+          "name": "v2_uq_space_sandboxes_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_status": {
+          "name": "v2_idx_space_sandboxes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_desired_image": {
+          "name": "v2_idx_space_sandboxes_desired_image",
+          "columns": [
+            {
+              "expression": "desired_image",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_reported_image_version": {
+          "name": "v2_idx_space_sandboxes_reported_image_version",
+          "columns": [
+            {
+              "expression": "reported_image_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_last_heartbeat_at": {
+          "name": "v2_idx_space_sandboxes_last_heartbeat_at",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_last_activity_at": {
+          "name": "v2_idx_space_sandboxes_last_activity_at",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_runtime_status": {
+          "name": "v2_idx_space_sandboxes_runtime_status",
+          "columns": [
+            {
+              "expression": "runtime_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_stopped_at": {
+          "name": "v2_idx_space_sandboxes_stopped_at",
+          "columns": [
+            {
+              "expression": "stopped_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_space_sandboxes_provider": {
+          "name": "v2_chk_space_sandboxes_provider",
+          "value": "\"v2\".\"space_sandboxes\".\"provider\" in ('cloud', 'local')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.space_session_bindings": {
+      "name": "space_session_bindings",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_session_id": {
+          "name": "space_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_channel_id": {
+          "name": "space_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_key": {
+          "name": "binding_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_space_session_bindings_space": {
+          "name": "v2_idx_space_session_bindings_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_session": {
+          "name": "v2_idx_space_session_bindings_session",
+          "columns": [
+            {
+              "expression": "space_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_channel": {
+          "name": "v2_idx_space_session_bindings_channel",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_binding_key": {
+          "name": "v2_idx_space_session_bindings_binding_key",
+          "columns": [
+            {
+              "expression": "binding_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_external_chat": {
+          "name": "v2_idx_space_session_bindings_external_chat",
+          "columns": [
+            {
+              "expression": "external_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_session_bindings_channel_binding": {
+          "name": "v2_uq_space_session_bindings_channel_binding",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_sessions": {
+      "name": "space_sessions",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "external_session_id": {
+          "name": "external_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_message_text": {
+          "name": "latest_message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_id": {
+          "name": "last_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_sessions_space_id": {
+          "name": "v2_idx_space_sessions_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_user_uuid": {
+          "name": "v2_idx_space_sessions_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_last_message_id": {
+          "name": "v2_idx_space_sessions_last_message_id",
+          "columns": [
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_last_message_at": {
+          "name": "v2_idx_space_sessions_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_title_trgm": {
+          "name": "v2_idx_space_sessions_title_trgm",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_space_sessions_latest_message_text_trgm": {
+          "name": "v2_idx_space_sessions_latest_message_text_trgm",
+          "columns": [
+            {
+              "expression": "latest_message_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_space_sessions_space_last_message_id": {
+          "name": "v2_idx_space_sessions_space_last_message_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_user_last_message": {
+          "name": "v2_idx_space_sessions_user_last_message",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_participant_user_uuids": {
+          "name": "v2_idx_space_sessions_participant_user_uuids",
+          "columns": [
+            {
+              "expression": "(\"meta\" -> 'participants' -> 'userUuids')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.spaces": {
+      "name": "spaces",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_repo_name": {
+          "name": "storage_repo_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_checkpoint_id": {
+          "name": "base_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_checkpoint_id": {
+          "name": "head_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_spaces_user_uuid": {
+          "name": "v2_idx_spaces_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_base_checkpoint_id": {
+          "name": "v2_idx_spaces_base_checkpoint_id",
+          "columns": [
+            {
+              "expression": "base_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_head_checkpoint_id": {
+          "name": "v2_idx_spaces_head_checkpoint_id",
+          "columns": [
+            {
+              "expression": "head_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_last_activity_at": {
+          "name": "v2_idx_spaces_last_activity_at",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_name_trgm": {
+          "name": "v2_idx_spaces_name_trgm",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_spaces_description_trgm": {
+          "name": "v2_idx_spaces_description_trgm",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_uq_spaces_user_name": {
+          "name": "v2_uq_spaces_user_name",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_spaces_user_slug": {
+          "name": "v2_uq_spaces_user_slug",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2\".\"spaces\".\"slug\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_spaces_storage_repo_name": {
+          "name": "v2_uq_spaces_storage_repo_name",
+          "columns": [
+            {
+              "expression": "storage_repo_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_spaces_slug_format": {
+          "name": "v2_chk_spaces_slug_format",
+          "value": "\"v2\".\"spaces\".\"slug\" is null or (length(\"v2\".\"spaces\".\"slug\") between 1 and 80 and \"v2\".\"spaces\".\"slug\" !~ '[^a-z0-9_-]' and left(\"v2\".\"spaces\".\"slug\", 1) ~ '[a-z0-9]' and right(\"v2\".\"spaces\".\"slug\", 1) ~ '[a-z0-9]')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.task_runs": {
+      "name": "task_runs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_task_runs_job_id": {
+          "name": "v2_uq_task_runs_job_id",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_cron_job_id": {
+          "name": "v2_idx_task_runs_cron_job_id",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_space_id": {
+          "name": "v2_idx_task_runs_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_session_id": {
+          "name": "v2_idx_task_runs_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_turn_id": {
+          "name": "v2_idx_task_runs_turn_id",
+          "columns": [
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_session_turn": {
+          "name": "v2_idx_task_runs_session_turn",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_user_uuid": {
+          "name": "v2_idx_task_runs_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_status": {
+          "name": "v2_idx_task_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_task_type": {
+          "name": "v2_idx_task_runs_task_type",
+          "columns": [
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_space_session_type_status_created": {
+          "name": "v2_idx_task_runs_space_session_type_status_created",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_user_session_type_status_created": {
+          "name": "v2_idx_task_runs_user_session_type_status_created",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_cron_job_status_created": {
+          "name": "v2_idx_task_runs_cron_job_status_created",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_created_at": {
+          "name": "v2_idx_task_runs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_scheduled_at": {
+          "name": "v2_idx_task_runs_scheduled_at",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.token_usage_stats_hourly": {
+      "name": "token_usage_stats_hourly",
+      "schema": "v2",
+      "columns": {
+        "bucket_start_at": {
+          "name": "bucket_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_cache_read": {
+          "name": "cost_cache_read",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_token_usage_stats_hourly_bucket_dims": {
+          "name": "v2_uq_token_usage_stats_hourly_bucket_dims",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_user_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_user_bucket",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_space_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_space_bucket",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_session_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_session_bucket",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_provider_model_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_provider_model_bucket",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_channels": {
+      "name": "user_channels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_user_channels_user_uuid": {
+          "name": "v2_idx_user_channels_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_channels_provider": {
+          "name": "v2_idx_user_channels_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_git_accounts": {
+      "name": "user_git_accounts",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gitea'"
+        },
+        "gitea_user_id": {
+          "name": "gitea_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_username": {
+          "name": "gitea_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_password_encrypted": {
+          "name": "gitea_password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_access_token_encrypted": {
+          "name": "gitea_access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_user_git_accounts_user_provider": {
+          "name": "v2_uq_user_git_accounts_user_provider",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_user_git_accounts_gitea_username": {
+          "name": "v2_uq_user_git_accounts_gitea_username",
+          "columns": [
+            {
+              "expression": "gitea_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_git_accounts_user_uuid": {
+          "name": "v2_idx_user_git_accounts_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_git_accounts_provider": {
+          "name": "v2_idx_user_git_accounts_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_profiles": {
+      "name": "user_profiles",
+      "schema": "v2",
+      "columns": {
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logto_user_id": {
+          "name": "logto_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_user_profiles_logto_user_id": {
+          "name": "v2_uq_user_profiles_logto_user_id",
+          "columns": [
+            {
+              "expression": "logto_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_profiles_updated_at": {
+          "name": "v2_idx_user_profiles_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_user_profiles_username": {
+          "name": "v2_uq_user_profiles_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.work_versions": {
+      "name": "work_versions",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ref": {
+          "name": "target_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_work_versions_work_id": {
+          "name": "v2_idx_work_versions_work_id",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_work_versions_work_version": {
+          "name": "v2_uq_work_versions_work_version",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.work_viewer_grants": {
+      "name": "work_viewer_grants",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_user_uuid": {
+          "name": "viewer_user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_work_viewer_grants_work_id": {
+          "name": "v2_idx_work_viewer_grants_work_id",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_work_viewer_grants_space_id": {
+          "name": "v2_idx_work_viewer_grants_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_work_viewer_grants_viewer_user_uuid": {
+          "name": "v2_idx_work_viewer_grants_viewer_user_uuid",
+          "columns": [
+            {
+              "expression": "viewer_user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_work_viewer_grants_work_viewer": {
+          "name": "v2_uq_work_viewer_grants_work_viewer",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewer_user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.works": {
+      "name": "works",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ref": {
+          "name": "target_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_scopes": {
+          "name": "work_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_viewer_scopes": {
+          "name": "allowed_viewer_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_works_space_id": {
+          "name": "v2_idx_works_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_user_uuid": {
+          "name": "v2_idx_works_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_status": {
+          "name": "v2_idx_works_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_visibility": {
+          "name": "v2_idx_works_visibility",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_works_space_slug": {
+          "name": "v2_uq_works_space_slug",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_works_status": {
+          "name": "v2_chk_works_status",
+          "value": "\"v2\".\"works\".\"status\" in ('published', 'disabled')"
+        },
+        "v2_chk_works_visibility": {
+          "name": "v2_chk_works_visibility",
+          "value": "\"v2\".\"works\".\"visibility\" in ('public', 'space')"
+        },
+        "v2_chk_works_slug_format": {
+          "name": "v2_chk_works_slug_format",
+          "value": "length(\"v2\".\"works\".\"slug\") between 1 and 80 and \"v2\".\"works\".\"slug\" !~ '[^a-z0-9_-]' and left(\"v2\".\"works\".\"slug\", 1) ~ '[a-z0-9]' and right(\"v2\".\"works\".\"slug\", 1) ~ '[a-z0-9]'"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "v2": "v2"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/v2/meta/0045_snapshot.json
+++ b/apps/api/drizzle/v2/meta/0045_snapshot.json
@@ -1,0 +1,6711 @@
+{
+  "id": "b6840161-8898-4d8b-9cf8-5af265a56013",
+  "prevId": "5595636d-ff60-4d44-9b92-a979a96fc4ba",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "v2.access_policies": {
+      "name": "access_policies",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_in_user_role": {
+          "name": "signed_in_user_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_user_role": {
+          "name": "anonymous_user_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_access_policies_resource": {
+          "name": "v2_uq_access_policies_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_access_policies_resource": {
+          "name": "v2_idx_access_policies_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.canvas_checkpoint_snapshots": {
+      "name": "canvas_checkpoint_snapshots",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_space_id": {
+          "name": "source_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_file_path": {
+          "name": "source_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_checkpoint_snapshots_path": {
+          "name": "v2_uq_canvas_checkpoint_snapshots_path",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_checkpoint_snapshots_checkpoint_id": {
+          "name": "v2_idx_canvas_checkpoint_snapshots_checkpoint_id",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.canvas_documents": {
+      "name": "canvas_documents",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_canvas_documents_space_id": {
+          "name": "v2_idx_canvas_documents_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_canvas_documents_space_path": {
+          "name": "v2_uq_canvas_documents_space_path",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_documents_space_id_spaces_id_fk": {
+          "name": "canvas_documents_space_id_spaces_id_fk",
+          "tableFrom": "canvas_documents",
+          "tableTo": "spaces",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_documents_version": {
+          "name": "v2_chk_canvas_documents_version",
+          "value": "\"v2\".\"canvas_documents\".\"version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.canvas_nodes": {
+      "name": "canvas_nodes",
+      "schema": "v2",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 240
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 160
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ref_kind": {
+          "name": "ref_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_path": {
+          "name": "ref_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_url": {
+          "name": "ref_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view": {
+          "name": "view",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "style": {
+          "name": "style",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "animation": {
+          "name": "animation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_nodes_document_node": {
+          "name": "v2_uq_canvas_nodes_document_node",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_nodes_viewport": {
+          "name": "v2_idx_canvas_nodes_viewport",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "x",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "y",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_nodes_ref_path": {
+          "name": "v2_idx_canvas_nodes_ref_path",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_nodes_document_id_canvas_documents_id_fk": {
+          "name": "canvas_nodes_document_id_canvas_documents_id_fk",
+          "tableFrom": "canvas_nodes",
+          "tableTo": "canvas_documents",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_nodes_dimensions": {
+          "name": "v2_chk_canvas_nodes_dimensions",
+          "value": "\"v2\".\"canvas_nodes\".\"width\" > 0 AND \"v2\".\"canvas_nodes\".\"height\" > 0"
+        },
+        "v2_chk_canvas_nodes_version": {
+          "name": "v2_chk_canvas_nodes_version",
+          "value": "\"v2\".\"canvas_nodes\".\"version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.canvas_updates": {
+      "name": "canvas_updates",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_id": {
+          "name": "tx_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_version": {
+          "name": "base_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "undo_group_id": {
+          "name": "undo_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_updates_document_version": {
+          "name": "v2_uq_canvas_updates_document_version",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_canvas_updates_document_tx": {
+          "name": "v2_uq_canvas_updates_document_tx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tx_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_updates_document_id_canvas_documents_id_fk": {
+          "name": "canvas_updates_document_id_canvas_documents_id_fk",
+          "tableFrom": "canvas_updates",
+          "tableTo": "canvas_documents",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_updates_base_version": {
+          "name": "v2_chk_canvas_updates_base_version",
+          "value": "\"v2\".\"canvas_updates\".\"base_version\" >= 0"
+        },
+        "v2_chk_canvas_updates_version": {
+          "name": "v2_chk_canvas_updates_version",
+          "value": "\"v2\".\"canvas_updates\".\"version\" > \"v2\".\"canvas_updates\".\"base_version\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.checkpoints": {
+      "name": "checkpoints",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_checkpoint_id": {
+          "name": "parent_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_checkpoint_id": {
+          "name": "root_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fork_count": {
+          "name": "fork_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "save_version": {
+          "name": "save_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_checkpoints_space_id": {
+          "name": "v2_idx_checkpoints_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_parent_id": {
+          "name": "v2_idx_checkpoints_parent_id",
+          "columns": [
+            {
+              "expression": "parent_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_root_id": {
+          "name": "v2_idx_checkpoints_root_id",
+          "columns": [
+            {
+              "expression": "root_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_description_trgm": {
+          "name": "v2_idx_checkpoints_description_trgm",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_uq_checkpoints_space_commit": {
+          "name": "v2_uq_checkpoints_space_commit",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asia/Shanghai'"
+        },
+        "bull_job_key": {
+          "name": "bull_job_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_cron_jobs_user_uuid": {
+          "name": "v2_idx_cron_jobs_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_space_id": {
+          "name": "v2_idx_cron_jobs_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_enabled": {
+          "name": "v2_idx_cron_jobs_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_created_at": {
+          "name": "v2_idx_cron_jobs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.gateway_logs": {
+      "name": "gateway_logs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_payload": {
+          "name": "normalized_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'success'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_gateway_logs_channel": {
+          "name": "v2_idx_gateway_logs_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_gateway_logs_direction": {
+          "name": "v2_idx_gateway_logs_direction",
+          "columns": [
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_gateway_logs_created": {
+          "name": "v2_idx_gateway_logs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.generation_usage_stats_hourly": {
+      "name": "generation_usage_stats_hourly",
+      "schema": "v2",
+      "columns": {
+        "bucket_start_at": {
+          "name": "bucket_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_generation_usage_stats_hourly_bucket_dims": {
+          "name": "v2_uq_generation_usage_stats_hourly_bucket_dims",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usage_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_user_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_user_bucket",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_space_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_space_bucket",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_session_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_session_bucket",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_usage_type_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_usage_type_bucket",
+          "columns": [
+            {
+              "expression": "usage_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_provider_model_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_provider_model_bucket",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.label_assignments": {
+      "name": "label_assignments",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_ref": {
+          "name": "resource_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_label_assignments_label_resource": {
+          "name": "v2_uq_label_assignments_label_resource",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_label_rank": {
+          "name": "v2_idx_label_assignments_label_rank",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_scope_resource": {
+          "name": "v2_idx_label_assignments_scope_resource",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_scope_label": {
+          "name": "v2_idx_label_assignments_scope_label",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_session_label_resource": {
+          "name": "v2_idx_label_assignments_session_label_resource",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2\".\"label_assignments\".\"resource_type\" = 'session'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_resource_label": {
+          "name": "v2_idx_label_assignments_resource_label",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_resource_ref_trgm": {
+          "name": "v2_idx_label_assignments_resource_ref_trgm",
+          "columns": [
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.labels": {
+      "name": "labels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "system_key": {
+          "name": "system_key",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_labels_scope_rank": {
+          "name": "v2_idx_labels_scope_rank",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_labels_scope_parent": {
+          "name": "v2_idx_labels_scope_parent",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_labels_scope_parent_name": {
+          "name": "v2_uq_labels_scope_parent_name",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"parent_id\"::text, '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_labels_scope_system_key": {
+          "name": "v2_uq_labels_scope_system_key",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_labels_depth": {
+          "name": "v2_chk_labels_depth",
+          "value": "\"v2\".\"labels\".\"depth\" in (0, 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.proposals": {
+      "name": "proposals",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_checkpoint_id": {
+          "name": "source_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_space_id": {
+          "name": "target_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_branch_name": {
+          "name": "source_branch_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch_name": {
+          "name": "target_branch_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_pr_id": {
+          "name": "external_pr_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'open'"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_proposals_target_space_id": {
+          "name": "v2_idx_proposals_target_space_id",
+          "columns": [
+            {
+              "expression": "target_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_proposals_source_checkpoint_id": {
+          "name": "v2_idx_proposals_source_checkpoint_id",
+          "columns": [
+            {
+              "expression": "source_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_proposals_status": {
+          "name": "v2_idx_proposals_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.provider_message_refs": {
+      "name": "provider_message_refs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_session_id": {
+          "name": "space_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_channel_id": {
+          "name": "space_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_message_id": {
+          "name": "session_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_conversation_id": {
+          "name": "external_conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_external_conversation_id": {
+          "name": "parent_external_conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_external_message_id": {
+          "name": "parent_external_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_author_id": {
+          "name": "external_author_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_author_name": {
+          "name": "external_author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_provider_message_refs_provider_conversation": {
+          "name": "v2_idx_provider_message_refs_provider_conversation",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_provider_message_refs_provider_message": {
+          "name": "v2_uq_provider_message_refs_provider_message",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_space_session": {
+          "name": "v2_idx_provider_message_refs_space_session",
+          "columns": [
+            {
+              "expression": "space_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_session_message": {
+          "name": "v2_idx_provider_message_refs_session_message",
+          "columns": [
+            {
+              "expression": "session_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_parent_message": {
+          "name": "v2_idx_provider_message_refs_parent_message",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_space_channel": {
+          "name": "v2_idx_provider_message_refs_space_channel",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.referral_codes": {
+      "name": "referral_codes",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_referral_codes_code": {
+          "name": "v2_uq_referral_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_referral_codes_active_user": {
+          "name": "v2_uq_referral_codes_active_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2\".\"referral_codes\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referral_codes_user": {
+          "name": "v2_idx_referral_codes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.referrals": {
+      "name": "referrals",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referral_code_id": {
+          "name": "referral_code_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_user_id": {
+          "name": "inviter_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_user_id": {
+          "name": "invitee_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "qualified_at": {
+          "name": "qualified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewarded_at": {
+          "name": "rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_rewarded_at": {
+          "name": "inviter_rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitee_rewarded_at": {
+          "name": "invitee_rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_reward_amount_usd": {
+          "name": "inviter_reward_amount_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_reward_amount_usd": {
+          "name": "invitee_reward_amount_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_error": {
+          "name": "reward_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_attempted_at": {
+          "name": "reward_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_lease_token": {
+          "name": "reward_lease_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_lease_expires_at": {
+          "name": "reward_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_referrals_invitee": {
+          "name": "v2_uq_referrals_invitee",
+          "columns": [
+            {
+              "expression": "invitee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_inviter": {
+          "name": "v2_idx_referrals_inviter",
+          "columns": [
+            {
+              "expression": "inviter_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_code": {
+          "name": "v2_idx_referrals_code",
+          "columns": [
+            {
+              "expression": "referral_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_qualified_retry": {
+          "name": "v2_idx_referrals_qualified_retry",
+          "columns": [
+            {
+              "expression": "reward_attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2\".\"referrals\".\"status\" = 'qualified'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.resource_references": {
+      "name": "resource_references",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_turn_id": {
+          "name": "source_turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_resource_references_target": {
+          "name": "v2_idx_resource_references_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_source": {
+          "name": "v2_idx_resource_references_source",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_space_kind": {
+          "name": "v2_idx_resource_references_space_kind",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_session_kind": {
+          "name": "v2_idx_resource_references_session_kind",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_turn": {
+          "name": "v2_idx_resource_references_turn",
+          "columns": [
+            {
+              "expression": "source_turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "v2_uq_resource_references_identity": {
+          "name": "v2_uq_resource_references_identity",
+          "nullsNotDistinct": true,
+          "columns": [
+            "kind",
+            "source_type",
+            "source_id",
+            "source_turn_id",
+            "target_type",
+            "target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_forks": {
+      "name": "session_forks",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_session_id": {
+          "name": "child_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_session_id": {
+          "name": "root_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_source_session_id": {
+          "name": "anchor_source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_turn_id": {
+          "name": "anchor_turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_sequence": {
+          "name": "anchor_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_session_ids": {
+          "name": "ancestor_session_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_path": {
+          "name": "session_path",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_session_forks_child": {
+          "name": "v2_uq_session_forks_child",
+          "columns": [
+            {
+              "expression": "child_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_parent": {
+          "name": "v2_idx_session_forks_parent",
+          "columns": [
+            {
+              "expression": "parent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_root_depth": {
+          "name": "v2_idx_session_forks_root_depth",
+          "columns": [
+            {
+              "expression": "root_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_anchor_turn": {
+          "name": "v2_idx_session_forks_anchor_turn",
+          "columns": [
+            {
+              "expression": "anchor_turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_messages": {
+      "name": "session_messages",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_aggregated_at": {
+          "name": "usage_aggregated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_session_messages_session_id": {
+          "name": "v2_idx_session_messages_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_messages_session_sequence": {
+          "name": "v2_uq_session_messages_session_sequence",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_messages_session_id_idempotency_key": {
+          "name": "v2_uq_session_messages_session_id_idempotency_key",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_turn_segments": {
+      "name": "session_turn_segments",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_sequence": {
+          "name": "from_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_sequence": {
+          "name": "to_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_session_turn_segments_session_ordinal": {
+          "name": "v2_uq_session_turn_segments_session_ordinal",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turn_segments_session": {
+          "name": "v2_idx_session_turn_segments_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turn_segments_source": {
+          "name": "v2_idx_session_turn_segments_source",
+          "columns": [
+            {
+              "expression": "source_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_turns": {
+      "name": "session_turns",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "intent": {
+          "name": "intent",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'steer'"
+        },
+        "user_content": {
+          "name": "user_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_text": {
+          "name": "user_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_content": {
+          "name": "assistant_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_text": {
+          "name": "assistant_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_usage": {
+          "name": "final_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_usage": {
+          "name": "total_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intermediate_index": {
+          "name": "intermediate_index",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intermediate_summary": {
+          "name": "intermediate_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_session_turns_session_id": {
+          "name": "v2_idx_session_turns_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_turns_session_sequence": {
+          "name": "v2_uq_session_turns_session_sequence",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_user_uuid": {
+          "name": "v2_idx_session_turns_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_created_at": {
+          "name": "v2_idx_session_turns_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_user_text_trgm": {
+          "name": "v2_idx_session_turns_user_text_trgm",
+          "columns": [
+            {
+              "expression": "user_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_channels": {
+      "name": "space_channels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_channels_space": {
+          "name": "v2_idx_space_channels_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_channels_channel": {
+          "name": "v2_uq_space_channels_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_commerce_businesses": {
+      "name": "space_commerce_businesses",
+      "schema": "v2",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_business_key": {
+          "name": "billing_business_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_commerce_businesses_business_key": {
+          "name": "v2_uq_space_commerce_businesses_business_key",
+          "columns": [
+            {
+              "expression": "billing_business_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_marks": {
+      "name": "space_marks",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_ref": {
+          "name": "resource_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_marks_resource": {
+          "name": "v2_uq_space_marks_resource",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_marks_space_kind_rank": {
+          "name": "v2_idx_space_marks_space_kind_rank",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_marks_space_resource": {
+          "name": "v2_idx_space_marks_space_resource",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_members": {
+      "name": "space_members",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_members_space_user": {
+          "name": "v2_uq_space_members_space_user",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_space": {
+          "name": "v2_idx_space_members_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_user": {
+          "name": "v2_idx_space_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_user_space": {
+          "name": "v2_idx_space_members_user_space",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_space_role": {
+          "name": "v2_idx_space_members_space_role",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_mods": {
+      "name": "space_mods",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mod_space_id": {
+          "name": "mod_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mount_slug": {
+          "name": "mount_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_mods_space_id": {
+          "name": "v2_idx_space_mods_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_mods_mod_space_id": {
+          "name": "v2_idx_space_mods_mod_space_id",
+          "columns": [
+            {
+              "expression": "mod_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_mods_space_mod": {
+          "name": "v2_uq_space_mods_space_mod",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mod_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_mods_space_mount_slug": {
+          "name": "v2_uq_space_mods_space_mount_slug",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mount_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_sandboxes": {
+      "name": "space_sandboxes",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloud'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "runtime_status": {
+          "name": "runtime_status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "pod_name": {
+          "name": "pod_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_image": {
+          "name": "desired_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_image_version": {
+          "name": "reported_image_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_sandboxes_space_id": {
+          "name": "v2_uq_space_sandboxes_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_status": {
+          "name": "v2_idx_space_sandboxes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_desired_image": {
+          "name": "v2_idx_space_sandboxes_desired_image",
+          "columns": [
+            {
+              "expression": "desired_image",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_reported_image_version": {
+          "name": "v2_idx_space_sandboxes_reported_image_version",
+          "columns": [
+            {
+              "expression": "reported_image_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_last_heartbeat_at": {
+          "name": "v2_idx_space_sandboxes_last_heartbeat_at",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_last_activity_at": {
+          "name": "v2_idx_space_sandboxes_last_activity_at",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_runtime_status": {
+          "name": "v2_idx_space_sandboxes_runtime_status",
+          "columns": [
+            {
+              "expression": "runtime_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_stopped_at": {
+          "name": "v2_idx_space_sandboxes_stopped_at",
+          "columns": [
+            {
+              "expression": "stopped_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_space_sandboxes_provider": {
+          "name": "v2_chk_space_sandboxes_provider",
+          "value": "\"v2\".\"space_sandboxes\".\"provider\" in ('cloud', 'local')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.space_session_bindings": {
+      "name": "space_session_bindings",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_session_id": {
+          "name": "space_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_channel_id": {
+          "name": "space_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_key": {
+          "name": "binding_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_space_session_bindings_space": {
+          "name": "v2_idx_space_session_bindings_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_session": {
+          "name": "v2_idx_space_session_bindings_session",
+          "columns": [
+            {
+              "expression": "space_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_channel": {
+          "name": "v2_idx_space_session_bindings_channel",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_binding_key": {
+          "name": "v2_idx_space_session_bindings_binding_key",
+          "columns": [
+            {
+              "expression": "binding_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_external_chat": {
+          "name": "v2_idx_space_session_bindings_external_chat",
+          "columns": [
+            {
+              "expression": "external_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_session_bindings_channel_binding": {
+          "name": "v2_uq_space_session_bindings_channel_binding",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_sessions": {
+      "name": "space_sessions",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "external_session_id": {
+          "name": "external_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_message_text": {
+          "name": "latest_message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_id": {
+          "name": "last_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_sessions_space_id": {
+          "name": "v2_idx_space_sessions_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_user_uuid": {
+          "name": "v2_idx_space_sessions_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_last_message_id": {
+          "name": "v2_idx_space_sessions_last_message_id",
+          "columns": [
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_last_message_at": {
+          "name": "v2_idx_space_sessions_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_title_trgm": {
+          "name": "v2_idx_space_sessions_title_trgm",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_space_sessions_latest_message_text_trgm": {
+          "name": "v2_idx_space_sessions_latest_message_text_trgm",
+          "columns": [
+            {
+              "expression": "latest_message_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_space_sessions_space_last_message_id": {
+          "name": "v2_idx_space_sessions_space_last_message_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_user_last_message": {
+          "name": "v2_idx_space_sessions_user_last_message",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_participant_user_uuids": {
+          "name": "v2_idx_space_sessions_participant_user_uuids",
+          "columns": [
+            {
+              "expression": "(\"meta\" -> 'participants' -> 'userUuids')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.spaces": {
+      "name": "spaces",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_repo_name": {
+          "name": "storage_repo_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_checkpoint_id": {
+          "name": "base_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_checkpoint_id": {
+          "name": "head_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_spaces_user_uuid": {
+          "name": "v2_idx_spaces_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_base_checkpoint_id": {
+          "name": "v2_idx_spaces_base_checkpoint_id",
+          "columns": [
+            {
+              "expression": "base_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_head_checkpoint_id": {
+          "name": "v2_idx_spaces_head_checkpoint_id",
+          "columns": [
+            {
+              "expression": "head_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_last_activity_at": {
+          "name": "v2_idx_spaces_last_activity_at",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_name_trgm": {
+          "name": "v2_idx_spaces_name_trgm",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_spaces_description_trgm": {
+          "name": "v2_idx_spaces_description_trgm",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_uq_spaces_user_name": {
+          "name": "v2_uq_spaces_user_name",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_spaces_user_slug": {
+          "name": "v2_uq_spaces_user_slug",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2\".\"spaces\".\"slug\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_spaces_storage_repo_name": {
+          "name": "v2_uq_spaces_storage_repo_name",
+          "columns": [
+            {
+              "expression": "storage_repo_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_spaces_slug_format": {
+          "name": "v2_chk_spaces_slug_format",
+          "value": "\"v2\".\"spaces\".\"slug\" is null or (length(\"v2\".\"spaces\".\"slug\") between 1 and 80 and \"v2\".\"spaces\".\"slug\" !~ '[^a-z0-9_-]' and left(\"v2\".\"spaces\".\"slug\", 1) ~ '[a-z0-9]' and right(\"v2\".\"spaces\".\"slug\", 1) ~ '[a-z0-9]')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.task_runs": {
+      "name": "task_runs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_task_runs_job_id": {
+          "name": "v2_uq_task_runs_job_id",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_cron_job_id": {
+          "name": "v2_idx_task_runs_cron_job_id",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_space_id": {
+          "name": "v2_idx_task_runs_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_session_id": {
+          "name": "v2_idx_task_runs_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_turn_id": {
+          "name": "v2_idx_task_runs_turn_id",
+          "columns": [
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_session_turn": {
+          "name": "v2_idx_task_runs_session_turn",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_user_uuid": {
+          "name": "v2_idx_task_runs_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_status": {
+          "name": "v2_idx_task_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_task_type": {
+          "name": "v2_idx_task_runs_task_type",
+          "columns": [
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_space_session_type_status_created": {
+          "name": "v2_idx_task_runs_space_session_type_status_created",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_user_session_type_status_created": {
+          "name": "v2_idx_task_runs_user_session_type_status_created",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_cron_job_status_created": {
+          "name": "v2_idx_task_runs_cron_job_status_created",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_created_at": {
+          "name": "v2_idx_task_runs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_scheduled_at": {
+          "name": "v2_idx_task_runs_scheduled_at",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.token_usage_stats_hourly": {
+      "name": "token_usage_stats_hourly",
+      "schema": "v2",
+      "columns": {
+        "bucket_start_at": {
+          "name": "bucket_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_cache_read": {
+          "name": "cost_cache_read",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_token_usage_stats_hourly_bucket_dims": {
+          "name": "v2_uq_token_usage_stats_hourly_bucket_dims",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_user_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_user_bucket",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_space_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_space_bucket",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_session_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_session_bucket",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_provider_model_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_provider_model_bucket",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_channels": {
+      "name": "user_channels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_envelope": {
+          "name": "credential_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_revision": {
+          "name": "credential_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_user_channels_user_uuid": {
+          "name": "v2_idx_user_channels_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_channels_provider": {
+          "name": "v2_idx_user_channels_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_user_channels_credentials_storage": {
+          "name": "v2_chk_user_channels_credentials_storage",
+          "value": "num_nonnulls(\"v2\".\"user_channels\".\"credentials\", \"v2\".\"user_channels\".\"credential_envelope\") = 1"
+        },
+        "v2_chk_user_channels_credential_envelope": {
+          "name": "v2_chk_user_channels_credential_envelope",
+          "value": "\"v2\".\"user_channels\".\"credential_envelope\" is null or coalesce(\n        jsonb_typeof(\"v2\".\"user_channels\".\"credential_envelope\") = 'object'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->'version' = '1'::jsonb\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'algorithm' = 'aes-256-gcm'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'keyId' ~ '^[A-Za-z0-9._-]{1,64}$'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'nonce' ~ '^[A-Za-z0-9_-]{16}$'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'authTag' ~ '^[A-Za-z0-9_-]{22}$'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'ciphertext' ~ '^[A-Za-z0-9_-]{3,}$',\n        false\n      )"
+        },
+        "v2_chk_user_channels_credential_revision": {
+          "name": "v2_chk_user_channels_credential_revision",
+          "value": "\"v2\".\"user_channels\".\"credential_revision\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.user_git_accounts": {
+      "name": "user_git_accounts",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gitea'"
+        },
+        "gitea_user_id": {
+          "name": "gitea_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_username": {
+          "name": "gitea_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_password_encrypted": {
+          "name": "gitea_password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_access_token_encrypted": {
+          "name": "gitea_access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_user_git_accounts_user_provider": {
+          "name": "v2_uq_user_git_accounts_user_provider",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_user_git_accounts_gitea_username": {
+          "name": "v2_uq_user_git_accounts_gitea_username",
+          "columns": [
+            {
+              "expression": "gitea_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_git_accounts_user_uuid": {
+          "name": "v2_idx_user_git_accounts_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_git_accounts_provider": {
+          "name": "v2_idx_user_git_accounts_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_profiles": {
+      "name": "user_profiles",
+      "schema": "v2",
+      "columns": {
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logto_user_id": {
+          "name": "logto_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_user_profiles_logto_user_id": {
+          "name": "v2_uq_user_profiles_logto_user_id",
+          "columns": [
+            {
+              "expression": "logto_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_profiles_updated_at": {
+          "name": "v2_idx_user_profiles_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_user_profiles_username": {
+          "name": "v2_uq_user_profiles_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.work_versions": {
+      "name": "work_versions",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ref": {
+          "name": "target_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_work_versions_work_id": {
+          "name": "v2_idx_work_versions_work_id",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_work_versions_work_version": {
+          "name": "v2_uq_work_versions_work_version",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.work_viewer_grants": {
+      "name": "work_viewer_grants",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_user_uuid": {
+          "name": "viewer_user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_work_viewer_grants_work_id": {
+          "name": "v2_idx_work_viewer_grants_work_id",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_work_viewer_grants_space_id": {
+          "name": "v2_idx_work_viewer_grants_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_work_viewer_grants_viewer_user_uuid": {
+          "name": "v2_idx_work_viewer_grants_viewer_user_uuid",
+          "columns": [
+            {
+              "expression": "viewer_user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_work_viewer_grants_work_viewer": {
+          "name": "v2_uq_work_viewer_grants_work_viewer",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewer_user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.works": {
+      "name": "works",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ref": {
+          "name": "target_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_scopes": {
+          "name": "work_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_viewer_scopes": {
+          "name": "allowed_viewer_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_works_space_id": {
+          "name": "v2_idx_works_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_user_uuid": {
+          "name": "v2_idx_works_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_status": {
+          "name": "v2_idx_works_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_visibility": {
+          "name": "v2_idx_works_visibility",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_works_space_slug": {
+          "name": "v2_uq_works_space_slug",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_works_status": {
+          "name": "v2_chk_works_status",
+          "value": "\"v2\".\"works\".\"status\" in ('published', 'disabled')"
+        },
+        "v2_chk_works_visibility": {
+          "name": "v2_chk_works_visibility",
+          "value": "\"v2\".\"works\".\"visibility\" in ('public', 'space')"
+        },
+        "v2_chk_works_slug_format": {
+          "name": "v2_chk_works_slug_format",
+          "value": "length(\"v2\".\"works\".\"slug\") between 1 and 80 and \"v2\".\"works\".\"slug\" !~ '[^a-z0-9_-]' and left(\"v2\".\"works\".\"slug\", 1) ~ '[a-z0-9]' and right(\"v2\".\"works\".\"slug\", 1) ~ '[a-z0-9]'"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "v2": "v2"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/v2/meta/0046_snapshot.json
+++ b/apps/api/drizzle/v2/meta/0046_snapshot.json
@@ -1,0 +1,6721 @@
+{
+  "id": "8ebf5b73-8c44-47d3-8a6e-7f851c18eed7",
+  "prevId": "b6840161-8898-4d8b-9cf8-5af265a56013",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "v2.access_policies": {
+      "name": "access_policies",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_in_user_role": {
+          "name": "signed_in_user_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_user_role": {
+          "name": "anonymous_user_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_access_policies_resource": {
+          "name": "v2_uq_access_policies_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_access_policies_resource": {
+          "name": "v2_idx_access_policies_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.canvas_checkpoint_snapshots": {
+      "name": "canvas_checkpoint_snapshots",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_space_id": {
+          "name": "source_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_file_path": {
+          "name": "source_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_checkpoint_snapshots_path": {
+          "name": "v2_uq_canvas_checkpoint_snapshots_path",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_checkpoint_snapshots_checkpoint_id": {
+          "name": "v2_idx_canvas_checkpoint_snapshots_checkpoint_id",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.canvas_documents": {
+      "name": "canvas_documents",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_canvas_documents_space_id": {
+          "name": "v2_idx_canvas_documents_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_canvas_documents_space_path": {
+          "name": "v2_uq_canvas_documents_space_path",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_documents_space_id_spaces_id_fk": {
+          "name": "canvas_documents_space_id_spaces_id_fk",
+          "tableFrom": "canvas_documents",
+          "tableTo": "spaces",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_documents_version": {
+          "name": "v2_chk_canvas_documents_version",
+          "value": "\"v2\".\"canvas_documents\".\"version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.canvas_nodes": {
+      "name": "canvas_nodes",
+      "schema": "v2",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 240
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 160
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ref_kind": {
+          "name": "ref_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_path": {
+          "name": "ref_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_url": {
+          "name": "ref_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view": {
+          "name": "view",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "style": {
+          "name": "style",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "animation": {
+          "name": "animation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_nodes_document_node": {
+          "name": "v2_uq_canvas_nodes_document_node",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_nodes_viewport": {
+          "name": "v2_idx_canvas_nodes_viewport",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "x",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "y",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_nodes_ref_path": {
+          "name": "v2_idx_canvas_nodes_ref_path",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_nodes_document_id_canvas_documents_id_fk": {
+          "name": "canvas_nodes_document_id_canvas_documents_id_fk",
+          "tableFrom": "canvas_nodes",
+          "tableTo": "canvas_documents",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_nodes_dimensions": {
+          "name": "v2_chk_canvas_nodes_dimensions",
+          "value": "\"v2\".\"canvas_nodes\".\"width\" > 0 AND \"v2\".\"canvas_nodes\".\"height\" > 0"
+        },
+        "v2_chk_canvas_nodes_version": {
+          "name": "v2_chk_canvas_nodes_version",
+          "value": "\"v2\".\"canvas_nodes\".\"version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.canvas_updates": {
+      "name": "canvas_updates",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_id": {
+          "name": "tx_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_version": {
+          "name": "base_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "undo_group_id": {
+          "name": "undo_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_updates_document_version": {
+          "name": "v2_uq_canvas_updates_document_version",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_canvas_updates_document_tx": {
+          "name": "v2_uq_canvas_updates_document_tx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tx_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_updates_document_id_canvas_documents_id_fk": {
+          "name": "canvas_updates_document_id_canvas_documents_id_fk",
+          "tableFrom": "canvas_updates",
+          "tableTo": "canvas_documents",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_updates_base_version": {
+          "name": "v2_chk_canvas_updates_base_version",
+          "value": "\"v2\".\"canvas_updates\".\"base_version\" >= 0"
+        },
+        "v2_chk_canvas_updates_version": {
+          "name": "v2_chk_canvas_updates_version",
+          "value": "\"v2\".\"canvas_updates\".\"version\" > \"v2\".\"canvas_updates\".\"base_version\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.checkpoints": {
+      "name": "checkpoints",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_checkpoint_id": {
+          "name": "parent_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_checkpoint_id": {
+          "name": "root_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fork_count": {
+          "name": "fork_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "save_version": {
+          "name": "save_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_checkpoints_space_id": {
+          "name": "v2_idx_checkpoints_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_parent_id": {
+          "name": "v2_idx_checkpoints_parent_id",
+          "columns": [
+            {
+              "expression": "parent_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_root_id": {
+          "name": "v2_idx_checkpoints_root_id",
+          "columns": [
+            {
+              "expression": "root_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_description_trgm": {
+          "name": "v2_idx_checkpoints_description_trgm",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_uq_checkpoints_space_commit": {
+          "name": "v2_uq_checkpoints_space_commit",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asia/Shanghai'"
+        },
+        "bull_job_key": {
+          "name": "bull_job_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_cron_jobs_user_uuid": {
+          "name": "v2_idx_cron_jobs_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_space_id": {
+          "name": "v2_idx_cron_jobs_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_enabled": {
+          "name": "v2_idx_cron_jobs_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_created_at": {
+          "name": "v2_idx_cron_jobs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.gateway_logs": {
+      "name": "gateway_logs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_payload": {
+          "name": "normalized_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'success'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_gateway_logs_channel": {
+          "name": "v2_idx_gateway_logs_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_gateway_logs_direction": {
+          "name": "v2_idx_gateway_logs_direction",
+          "columns": [
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_gateway_logs_created": {
+          "name": "v2_idx_gateway_logs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.generation_usage_stats_hourly": {
+      "name": "generation_usage_stats_hourly",
+      "schema": "v2",
+      "columns": {
+        "bucket_start_at": {
+          "name": "bucket_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_generation_usage_stats_hourly_bucket_dims": {
+          "name": "v2_uq_generation_usage_stats_hourly_bucket_dims",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usage_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_user_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_user_bucket",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_space_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_space_bucket",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_session_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_session_bucket",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_usage_type_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_usage_type_bucket",
+          "columns": [
+            {
+              "expression": "usage_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_provider_model_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_provider_model_bucket",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.label_assignments": {
+      "name": "label_assignments",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_ref": {
+          "name": "resource_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_label_assignments_label_resource": {
+          "name": "v2_uq_label_assignments_label_resource",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_label_rank": {
+          "name": "v2_idx_label_assignments_label_rank",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_scope_resource": {
+          "name": "v2_idx_label_assignments_scope_resource",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_scope_label": {
+          "name": "v2_idx_label_assignments_scope_label",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_session_label_resource": {
+          "name": "v2_idx_label_assignments_session_label_resource",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2\".\"label_assignments\".\"resource_type\" = 'session'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_resource_label": {
+          "name": "v2_idx_label_assignments_resource_label",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_resource_ref_trgm": {
+          "name": "v2_idx_label_assignments_resource_ref_trgm",
+          "columns": [
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.labels": {
+      "name": "labels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "system_key": {
+          "name": "system_key",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_labels_scope_rank": {
+          "name": "v2_idx_labels_scope_rank",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_labels_scope_parent": {
+          "name": "v2_idx_labels_scope_parent",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_labels_scope_parent_name": {
+          "name": "v2_uq_labels_scope_parent_name",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"parent_id\"::text, '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_labels_scope_system_key": {
+          "name": "v2_uq_labels_scope_system_key",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_labels_depth": {
+          "name": "v2_chk_labels_depth",
+          "value": "\"v2\".\"labels\".\"depth\" in (0, 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.proposals": {
+      "name": "proposals",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_checkpoint_id": {
+          "name": "source_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_space_id": {
+          "name": "target_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_branch_name": {
+          "name": "source_branch_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch_name": {
+          "name": "target_branch_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_pr_id": {
+          "name": "external_pr_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'open'"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_proposals_target_space_id": {
+          "name": "v2_idx_proposals_target_space_id",
+          "columns": [
+            {
+              "expression": "target_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_proposals_source_checkpoint_id": {
+          "name": "v2_idx_proposals_source_checkpoint_id",
+          "columns": [
+            {
+              "expression": "source_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_proposals_status": {
+          "name": "v2_idx_proposals_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.provider_message_refs": {
+      "name": "provider_message_refs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_session_id": {
+          "name": "space_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_channel_id": {
+          "name": "space_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_message_id": {
+          "name": "session_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_conversation_id": {
+          "name": "external_conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_external_conversation_id": {
+          "name": "parent_external_conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_external_message_id": {
+          "name": "parent_external_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_author_id": {
+          "name": "external_author_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_author_name": {
+          "name": "external_author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_provider_message_refs_provider_conversation": {
+          "name": "v2_idx_provider_message_refs_provider_conversation",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_provider_message_refs_provider_message": {
+          "name": "v2_uq_provider_message_refs_provider_message",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_space_session": {
+          "name": "v2_idx_provider_message_refs_space_session",
+          "columns": [
+            {
+              "expression": "space_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_session_message": {
+          "name": "v2_idx_provider_message_refs_session_message",
+          "columns": [
+            {
+              "expression": "session_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_parent_message": {
+          "name": "v2_idx_provider_message_refs_parent_message",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_space_channel": {
+          "name": "v2_idx_provider_message_refs_space_channel",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.referral_codes": {
+      "name": "referral_codes",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_referral_codes_code": {
+          "name": "v2_uq_referral_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_referral_codes_active_user": {
+          "name": "v2_uq_referral_codes_active_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2\".\"referral_codes\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referral_codes_user": {
+          "name": "v2_idx_referral_codes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.referrals": {
+      "name": "referrals",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referral_code_id": {
+          "name": "referral_code_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_user_id": {
+          "name": "inviter_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_user_id": {
+          "name": "invitee_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "qualified_at": {
+          "name": "qualified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewarded_at": {
+          "name": "rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_rewarded_at": {
+          "name": "inviter_rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitee_rewarded_at": {
+          "name": "invitee_rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_reward_amount_usd": {
+          "name": "inviter_reward_amount_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_reward_amount_usd": {
+          "name": "invitee_reward_amount_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_error": {
+          "name": "reward_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_attempted_at": {
+          "name": "reward_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_lease_token": {
+          "name": "reward_lease_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_lease_expires_at": {
+          "name": "reward_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_referrals_invitee": {
+          "name": "v2_uq_referrals_invitee",
+          "columns": [
+            {
+              "expression": "invitee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_inviter": {
+          "name": "v2_idx_referrals_inviter",
+          "columns": [
+            {
+              "expression": "inviter_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_code": {
+          "name": "v2_idx_referrals_code",
+          "columns": [
+            {
+              "expression": "referral_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_qualified_retry": {
+          "name": "v2_idx_referrals_qualified_retry",
+          "columns": [
+            {
+              "expression": "reward_attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2\".\"referrals\".\"status\" = 'qualified'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.resource_references": {
+      "name": "resource_references",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_turn_id": {
+          "name": "source_turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_resource_references_target": {
+          "name": "v2_idx_resource_references_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_source": {
+          "name": "v2_idx_resource_references_source",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_space_kind": {
+          "name": "v2_idx_resource_references_space_kind",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_session_kind": {
+          "name": "v2_idx_resource_references_session_kind",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_turn": {
+          "name": "v2_idx_resource_references_turn",
+          "columns": [
+            {
+              "expression": "source_turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "v2_uq_resource_references_identity": {
+          "name": "v2_uq_resource_references_identity",
+          "nullsNotDistinct": true,
+          "columns": [
+            "kind",
+            "source_type",
+            "source_id",
+            "source_turn_id",
+            "target_type",
+            "target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_forks": {
+      "name": "session_forks",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_session_id": {
+          "name": "child_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_session_id": {
+          "name": "root_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_source_session_id": {
+          "name": "anchor_source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_turn_id": {
+          "name": "anchor_turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_sequence": {
+          "name": "anchor_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_session_ids": {
+          "name": "ancestor_session_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_path": {
+          "name": "session_path",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_session_forks_child": {
+          "name": "v2_uq_session_forks_child",
+          "columns": [
+            {
+              "expression": "child_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_parent": {
+          "name": "v2_idx_session_forks_parent",
+          "columns": [
+            {
+              "expression": "parent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_root_depth": {
+          "name": "v2_idx_session_forks_root_depth",
+          "columns": [
+            {
+              "expression": "root_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_anchor_turn": {
+          "name": "v2_idx_session_forks_anchor_turn",
+          "columns": [
+            {
+              "expression": "anchor_turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_messages": {
+      "name": "session_messages",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_aggregated_at": {
+          "name": "usage_aggregated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_session_messages_session_id": {
+          "name": "v2_idx_session_messages_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_messages_session_sequence": {
+          "name": "v2_uq_session_messages_session_sequence",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_messages_session_id_idempotency_key": {
+          "name": "v2_uq_session_messages_session_id_idempotency_key",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_session_messages_sequence": {
+          "name": "v2_chk_session_messages_sequence",
+          "value": "\"v2\".\"session_messages\".\"sequence\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.session_turn_segments": {
+      "name": "session_turn_segments",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_sequence": {
+          "name": "from_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_sequence": {
+          "name": "to_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_session_turn_segments_session_ordinal": {
+          "name": "v2_uq_session_turn_segments_session_ordinal",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turn_segments_session": {
+          "name": "v2_idx_session_turn_segments_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turn_segments_source": {
+          "name": "v2_idx_session_turn_segments_source",
+          "columns": [
+            {
+              "expression": "source_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_turns": {
+      "name": "session_turns",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "intent": {
+          "name": "intent",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'steer'"
+        },
+        "user_content": {
+          "name": "user_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_text": {
+          "name": "user_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_content": {
+          "name": "assistant_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_text": {
+          "name": "assistant_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_usage": {
+          "name": "final_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_usage": {
+          "name": "total_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intermediate_index": {
+          "name": "intermediate_index",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intermediate_summary": {
+          "name": "intermediate_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_session_turns_session_id": {
+          "name": "v2_idx_session_turns_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_turns_session_sequence": {
+          "name": "v2_uq_session_turns_session_sequence",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_user_uuid": {
+          "name": "v2_idx_session_turns_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_created_at": {
+          "name": "v2_idx_session_turns_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_user_text_trgm": {
+          "name": "v2_idx_session_turns_user_text_trgm",
+          "columns": [
+            {
+              "expression": "user_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_session_turns_sequence": {
+          "name": "v2_chk_session_turns_sequence",
+          "value": "\"v2\".\"session_turns\".\"sequence\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.space_channels": {
+      "name": "space_channels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_channels_space": {
+          "name": "v2_idx_space_channels_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_channels_channel": {
+          "name": "v2_uq_space_channels_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_commerce_businesses": {
+      "name": "space_commerce_businesses",
+      "schema": "v2",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_business_key": {
+          "name": "billing_business_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_commerce_businesses_business_key": {
+          "name": "v2_uq_space_commerce_businesses_business_key",
+          "columns": [
+            {
+              "expression": "billing_business_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_marks": {
+      "name": "space_marks",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_ref": {
+          "name": "resource_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_marks_resource": {
+          "name": "v2_uq_space_marks_resource",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_marks_space_kind_rank": {
+          "name": "v2_idx_space_marks_space_kind_rank",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_marks_space_resource": {
+          "name": "v2_idx_space_marks_space_resource",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_members": {
+      "name": "space_members",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_members_space_user": {
+          "name": "v2_uq_space_members_space_user",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_space": {
+          "name": "v2_idx_space_members_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_user": {
+          "name": "v2_idx_space_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_user_space": {
+          "name": "v2_idx_space_members_user_space",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_space_role": {
+          "name": "v2_idx_space_members_space_role",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_mods": {
+      "name": "space_mods",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mod_space_id": {
+          "name": "mod_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mount_slug": {
+          "name": "mount_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_mods_space_id": {
+          "name": "v2_idx_space_mods_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_mods_mod_space_id": {
+          "name": "v2_idx_space_mods_mod_space_id",
+          "columns": [
+            {
+              "expression": "mod_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_mods_space_mod": {
+          "name": "v2_uq_space_mods_space_mod",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mod_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_mods_space_mount_slug": {
+          "name": "v2_uq_space_mods_space_mount_slug",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mount_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_sandboxes": {
+      "name": "space_sandboxes",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloud'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "runtime_status": {
+          "name": "runtime_status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "pod_name": {
+          "name": "pod_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_image": {
+          "name": "desired_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_image_version": {
+          "name": "reported_image_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_sandboxes_space_id": {
+          "name": "v2_uq_space_sandboxes_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_status": {
+          "name": "v2_idx_space_sandboxes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_desired_image": {
+          "name": "v2_idx_space_sandboxes_desired_image",
+          "columns": [
+            {
+              "expression": "desired_image",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_reported_image_version": {
+          "name": "v2_idx_space_sandboxes_reported_image_version",
+          "columns": [
+            {
+              "expression": "reported_image_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_last_heartbeat_at": {
+          "name": "v2_idx_space_sandboxes_last_heartbeat_at",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_last_activity_at": {
+          "name": "v2_idx_space_sandboxes_last_activity_at",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_runtime_status": {
+          "name": "v2_idx_space_sandboxes_runtime_status",
+          "columns": [
+            {
+              "expression": "runtime_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_stopped_at": {
+          "name": "v2_idx_space_sandboxes_stopped_at",
+          "columns": [
+            {
+              "expression": "stopped_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_space_sandboxes_provider": {
+          "name": "v2_chk_space_sandboxes_provider",
+          "value": "\"v2\".\"space_sandboxes\".\"provider\" in ('cloud', 'local')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.space_session_bindings": {
+      "name": "space_session_bindings",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_session_id": {
+          "name": "space_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_channel_id": {
+          "name": "space_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_key": {
+          "name": "binding_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_space_session_bindings_space": {
+          "name": "v2_idx_space_session_bindings_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_session": {
+          "name": "v2_idx_space_session_bindings_session",
+          "columns": [
+            {
+              "expression": "space_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_channel": {
+          "name": "v2_idx_space_session_bindings_channel",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_binding_key": {
+          "name": "v2_idx_space_session_bindings_binding_key",
+          "columns": [
+            {
+              "expression": "binding_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_external_chat": {
+          "name": "v2_idx_space_session_bindings_external_chat",
+          "columns": [
+            {
+              "expression": "external_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_session_bindings_channel_binding": {
+          "name": "v2_uq_space_session_bindings_channel_binding",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_sessions": {
+      "name": "space_sessions",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "external_session_id": {
+          "name": "external_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_message_text": {
+          "name": "latest_message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_id": {
+          "name": "last_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_sessions_space_id": {
+          "name": "v2_idx_space_sessions_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_user_uuid": {
+          "name": "v2_idx_space_sessions_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_last_message_id": {
+          "name": "v2_idx_space_sessions_last_message_id",
+          "columns": [
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_last_message_at": {
+          "name": "v2_idx_space_sessions_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_title_trgm": {
+          "name": "v2_idx_space_sessions_title_trgm",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_space_sessions_latest_message_text_trgm": {
+          "name": "v2_idx_space_sessions_latest_message_text_trgm",
+          "columns": [
+            {
+              "expression": "latest_message_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_space_sessions_space_last_message_id": {
+          "name": "v2_idx_space_sessions_space_last_message_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_user_last_message": {
+          "name": "v2_idx_space_sessions_user_last_message",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_participant_user_uuids": {
+          "name": "v2_idx_space_sessions_participant_user_uuids",
+          "columns": [
+            {
+              "expression": "(\"meta\" -> 'participants' -> 'userUuids')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.spaces": {
+      "name": "spaces",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_repo_name": {
+          "name": "storage_repo_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_checkpoint_id": {
+          "name": "base_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_checkpoint_id": {
+          "name": "head_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_spaces_user_uuid": {
+          "name": "v2_idx_spaces_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_base_checkpoint_id": {
+          "name": "v2_idx_spaces_base_checkpoint_id",
+          "columns": [
+            {
+              "expression": "base_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_head_checkpoint_id": {
+          "name": "v2_idx_spaces_head_checkpoint_id",
+          "columns": [
+            {
+              "expression": "head_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_last_activity_at": {
+          "name": "v2_idx_spaces_last_activity_at",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_name_trgm": {
+          "name": "v2_idx_spaces_name_trgm",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_spaces_description_trgm": {
+          "name": "v2_idx_spaces_description_trgm",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_uq_spaces_user_name": {
+          "name": "v2_uq_spaces_user_name",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_spaces_user_slug": {
+          "name": "v2_uq_spaces_user_slug",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2\".\"spaces\".\"slug\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_spaces_storage_repo_name": {
+          "name": "v2_uq_spaces_storage_repo_name",
+          "columns": [
+            {
+              "expression": "storage_repo_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_spaces_slug_format": {
+          "name": "v2_chk_spaces_slug_format",
+          "value": "\"v2\".\"spaces\".\"slug\" is null or (length(\"v2\".\"spaces\".\"slug\") between 1 and 80 and \"v2\".\"spaces\".\"slug\" !~ '[^a-z0-9_-]' and left(\"v2\".\"spaces\".\"slug\", 1) ~ '[a-z0-9]' and right(\"v2\".\"spaces\".\"slug\", 1) ~ '[a-z0-9]')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.task_runs": {
+      "name": "task_runs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_task_runs_job_id": {
+          "name": "v2_uq_task_runs_job_id",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_cron_job_id": {
+          "name": "v2_idx_task_runs_cron_job_id",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_space_id": {
+          "name": "v2_idx_task_runs_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_session_id": {
+          "name": "v2_idx_task_runs_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_turn_id": {
+          "name": "v2_idx_task_runs_turn_id",
+          "columns": [
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_session_turn": {
+          "name": "v2_idx_task_runs_session_turn",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_user_uuid": {
+          "name": "v2_idx_task_runs_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_status": {
+          "name": "v2_idx_task_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_task_type": {
+          "name": "v2_idx_task_runs_task_type",
+          "columns": [
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_space_session_type_status_created": {
+          "name": "v2_idx_task_runs_space_session_type_status_created",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_user_session_type_status_created": {
+          "name": "v2_idx_task_runs_user_session_type_status_created",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_cron_job_status_created": {
+          "name": "v2_idx_task_runs_cron_job_status_created",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_created_at": {
+          "name": "v2_idx_task_runs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_scheduled_at": {
+          "name": "v2_idx_task_runs_scheduled_at",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.token_usage_stats_hourly": {
+      "name": "token_usage_stats_hourly",
+      "schema": "v2",
+      "columns": {
+        "bucket_start_at": {
+          "name": "bucket_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_cache_read": {
+          "name": "cost_cache_read",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_token_usage_stats_hourly_bucket_dims": {
+          "name": "v2_uq_token_usage_stats_hourly_bucket_dims",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_user_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_user_bucket",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_space_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_space_bucket",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_session_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_session_bucket",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_provider_model_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_provider_model_bucket",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_channels": {
+      "name": "user_channels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_envelope": {
+          "name": "credential_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_revision": {
+          "name": "credential_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_user_channels_user_uuid": {
+          "name": "v2_idx_user_channels_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_channels_provider": {
+          "name": "v2_idx_user_channels_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_user_channels_credentials_storage": {
+          "name": "v2_chk_user_channels_credentials_storage",
+          "value": "num_nonnulls(\"v2\".\"user_channels\".\"credentials\", \"v2\".\"user_channels\".\"credential_envelope\") = 1"
+        },
+        "v2_chk_user_channels_credential_envelope": {
+          "name": "v2_chk_user_channels_credential_envelope",
+          "value": "\"v2\".\"user_channels\".\"credential_envelope\" is null or coalesce(\n        jsonb_typeof(\"v2\".\"user_channels\".\"credential_envelope\") = 'object'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->'version' = '1'::jsonb\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'algorithm' = 'aes-256-gcm'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'keyId' ~ '^[A-Za-z0-9._-]{1,64}$'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'nonce' ~ '^[A-Za-z0-9_-]{16}$'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'authTag' ~ '^[A-Za-z0-9_-]{22}$'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'ciphertext' ~ '^[A-Za-z0-9_-]{3,}$',\n        false\n      )"
+        },
+        "v2_chk_user_channels_credential_revision": {
+          "name": "v2_chk_user_channels_credential_revision",
+          "value": "\"v2\".\"user_channels\".\"credential_revision\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.user_git_accounts": {
+      "name": "user_git_accounts",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gitea'"
+        },
+        "gitea_user_id": {
+          "name": "gitea_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_username": {
+          "name": "gitea_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_password_encrypted": {
+          "name": "gitea_password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_access_token_encrypted": {
+          "name": "gitea_access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_user_git_accounts_user_provider": {
+          "name": "v2_uq_user_git_accounts_user_provider",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_user_git_accounts_gitea_username": {
+          "name": "v2_uq_user_git_accounts_gitea_username",
+          "columns": [
+            {
+              "expression": "gitea_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_git_accounts_user_uuid": {
+          "name": "v2_idx_user_git_accounts_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_git_accounts_provider": {
+          "name": "v2_idx_user_git_accounts_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_profiles": {
+      "name": "user_profiles",
+      "schema": "v2",
+      "columns": {
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logto_user_id": {
+          "name": "logto_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_user_profiles_logto_user_id": {
+          "name": "v2_uq_user_profiles_logto_user_id",
+          "columns": [
+            {
+              "expression": "logto_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_profiles_updated_at": {
+          "name": "v2_idx_user_profiles_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_user_profiles_username": {
+          "name": "v2_uq_user_profiles_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.work_versions": {
+      "name": "work_versions",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ref": {
+          "name": "target_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_work_versions_work_id": {
+          "name": "v2_idx_work_versions_work_id",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_work_versions_work_version": {
+          "name": "v2_uq_work_versions_work_version",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.work_viewer_grants": {
+      "name": "work_viewer_grants",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_user_uuid": {
+          "name": "viewer_user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_work_viewer_grants_work_id": {
+          "name": "v2_idx_work_viewer_grants_work_id",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_work_viewer_grants_space_id": {
+          "name": "v2_idx_work_viewer_grants_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_work_viewer_grants_viewer_user_uuid": {
+          "name": "v2_idx_work_viewer_grants_viewer_user_uuid",
+          "columns": [
+            {
+              "expression": "viewer_user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_work_viewer_grants_work_viewer": {
+          "name": "v2_uq_work_viewer_grants_work_viewer",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewer_user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.works": {
+      "name": "works",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ref": {
+          "name": "target_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_scopes": {
+          "name": "work_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_viewer_scopes": {
+          "name": "allowed_viewer_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_works_space_id": {
+          "name": "v2_idx_works_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_user_uuid": {
+          "name": "v2_idx_works_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_status": {
+          "name": "v2_idx_works_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_visibility": {
+          "name": "v2_idx_works_visibility",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_works_space_slug": {
+          "name": "v2_uq_works_space_slug",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_works_status": {
+          "name": "v2_chk_works_status",
+          "value": "\"v2\".\"works\".\"status\" in ('published', 'disabled')"
+        },
+        "v2_chk_works_visibility": {
+          "name": "v2_chk_works_visibility",
+          "value": "\"v2\".\"works\".\"visibility\" in ('public', 'space')"
+        },
+        "v2_chk_works_slug_format": {
+          "name": "v2_chk_works_slug_format",
+          "value": "length(\"v2\".\"works\".\"slug\") between 1 and 80 and \"v2\".\"works\".\"slug\" !~ '[^a-z0-9_-]' and left(\"v2\".\"works\".\"slug\", 1) ~ '[a-z0-9]' and right(\"v2\".\"works\".\"slug\", 1) ~ '[a-z0-9]'"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "v2": "v2"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/v2/meta/0047_snapshot.json
+++ b/apps/api/drizzle/v2/meta/0047_snapshot.json
@@ -1,0 +1,6689 @@
+{
+  "id": "63f3866a-7b89-491e-aea7-928dde454c1a",
+  "prevId": "8ebf5b73-8c44-47d3-8a6e-7f851c18eed7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "v2.access_policies": {
+      "name": "access_policies",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_in_user_role": {
+          "name": "signed_in_user_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_user_role": {
+          "name": "anonymous_user_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_access_policies_resource": {
+          "name": "v2_uq_access_policies_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_access_policies_resource": {
+          "name": "v2_idx_access_policies_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.canvas_checkpoint_snapshots": {
+      "name": "canvas_checkpoint_snapshots",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_space_id": {
+          "name": "source_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_file_path": {
+          "name": "source_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_checkpoint_snapshots_path": {
+          "name": "v2_uq_canvas_checkpoint_snapshots_path",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_checkpoint_snapshots_checkpoint_id": {
+          "name": "v2_idx_canvas_checkpoint_snapshots_checkpoint_id",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.canvas_documents": {
+      "name": "canvas_documents",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_canvas_documents_space_id": {
+          "name": "v2_idx_canvas_documents_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_canvas_documents_space_path": {
+          "name": "v2_uq_canvas_documents_space_path",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_documents_space_id_spaces_id_fk": {
+          "name": "canvas_documents_space_id_spaces_id_fk",
+          "tableFrom": "canvas_documents",
+          "tableTo": "spaces",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_documents_version": {
+          "name": "v2_chk_canvas_documents_version",
+          "value": "\"v2\".\"canvas_documents\".\"version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.canvas_nodes": {
+      "name": "canvas_nodes",
+      "schema": "v2",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 240
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 160
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ref_kind": {
+          "name": "ref_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_path": {
+          "name": "ref_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_url": {
+          "name": "ref_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view": {
+          "name": "view",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "style": {
+          "name": "style",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "animation": {
+          "name": "animation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_nodes_document_node": {
+          "name": "v2_uq_canvas_nodes_document_node",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_nodes_viewport": {
+          "name": "v2_idx_canvas_nodes_viewport",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "x",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "y",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "width",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_canvas_nodes_ref_path": {
+          "name": "v2_idx_canvas_nodes_ref_path",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_nodes_document_id_canvas_documents_id_fk": {
+          "name": "canvas_nodes_document_id_canvas_documents_id_fk",
+          "tableFrom": "canvas_nodes",
+          "tableTo": "canvas_documents",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_nodes_dimensions": {
+          "name": "v2_chk_canvas_nodes_dimensions",
+          "value": "\"v2\".\"canvas_nodes\".\"width\" > 0 AND \"v2\".\"canvas_nodes\".\"height\" > 0"
+        },
+        "v2_chk_canvas_nodes_version": {
+          "name": "v2_chk_canvas_nodes_version",
+          "value": "\"v2\".\"canvas_nodes\".\"version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.canvas_updates": {
+      "name": "canvas_updates",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_id": {
+          "name": "tx_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_version": {
+          "name": "base_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "undo_group_id": {
+          "name": "undo_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_canvas_updates_document_version": {
+          "name": "v2_uq_canvas_updates_document_version",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_canvas_updates_document_tx": {
+          "name": "v2_uq_canvas_updates_document_tx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tx_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "canvas_updates_document_id_canvas_documents_id_fk": {
+          "name": "canvas_updates_document_id_canvas_documents_id_fk",
+          "tableFrom": "canvas_updates",
+          "tableTo": "canvas_documents",
+          "schemaTo": "v2",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_canvas_updates_base_version": {
+          "name": "v2_chk_canvas_updates_base_version",
+          "value": "\"v2\".\"canvas_updates\".\"base_version\" >= 0"
+        },
+        "v2_chk_canvas_updates_version": {
+          "name": "v2_chk_canvas_updates_version",
+          "value": "\"v2\".\"canvas_updates\".\"version\" > \"v2\".\"canvas_updates\".\"base_version\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.checkpoints": {
+      "name": "checkpoints",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_checkpoint_id": {
+          "name": "parent_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_checkpoint_id": {
+          "name": "root_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fork_count": {
+          "name": "fork_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "save_version": {
+          "name": "save_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_checkpoints_space_id": {
+          "name": "v2_idx_checkpoints_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_parent_id": {
+          "name": "v2_idx_checkpoints_parent_id",
+          "columns": [
+            {
+              "expression": "parent_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_root_id": {
+          "name": "v2_idx_checkpoints_root_id",
+          "columns": [
+            {
+              "expression": "root_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_checkpoints_description_trgm": {
+          "name": "v2_idx_checkpoints_description_trgm",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_uq_checkpoints_space_commit": {
+          "name": "v2_uq_checkpoints_space_commit",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asia/Shanghai'"
+        },
+        "bull_job_key": {
+          "name": "bull_job_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_cron_jobs_user_uuid": {
+          "name": "v2_idx_cron_jobs_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_space_id": {
+          "name": "v2_idx_cron_jobs_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_enabled": {
+          "name": "v2_idx_cron_jobs_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_cron_jobs_created_at": {
+          "name": "v2_idx_cron_jobs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.gateway_logs": {
+      "name": "gateway_logs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_payload": {
+          "name": "normalized_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'success'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_gateway_logs_channel": {
+          "name": "v2_idx_gateway_logs_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_gateway_logs_direction": {
+          "name": "v2_idx_gateway_logs_direction",
+          "columns": [
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_gateway_logs_created": {
+          "name": "v2_idx_gateway_logs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.generation_usage_stats_hourly": {
+      "name": "generation_usage_stats_hourly",
+      "schema": "v2",
+      "columns": {
+        "bucket_start_at": {
+          "name": "bucket_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_generation_usage_stats_hourly_bucket_dims": {
+          "name": "v2_uq_generation_usage_stats_hourly_bucket_dims",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usage_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_user_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_user_bucket",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_space_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_space_bucket",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_session_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_session_bucket",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_usage_type_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_usage_type_bucket",
+          "columns": [
+            {
+              "expression": "usage_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_generation_usage_stats_hourly_provider_model_bucket": {
+          "name": "v2_idx_generation_usage_stats_hourly_provider_model_bucket",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.label_assignments": {
+      "name": "label_assignments",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_ref": {
+          "name": "resource_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_label_assignments_label_resource": {
+          "name": "v2_uq_label_assignments_label_resource",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_label_rank": {
+          "name": "v2_idx_label_assignments_label_rank",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_scope_resource": {
+          "name": "v2_idx_label_assignments_scope_resource",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_scope_label": {
+          "name": "v2_idx_label_assignments_scope_label",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_session_label_resource": {
+          "name": "v2_idx_label_assignments_session_label_resource",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2\".\"label_assignments\".\"resource_type\" = 'session'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_resource_label": {
+          "name": "v2_idx_label_assignments_resource_label",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_label_assignments_resource_ref_trgm": {
+          "name": "v2_idx_label_assignments_resource_ref_trgm",
+          "columns": [
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.labels": {
+      "name": "labels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "system_key": {
+          "name": "system_key",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_labels_scope_rank": {
+          "name": "v2_idx_labels_scope_rank",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_labels_scope_parent": {
+          "name": "v2_idx_labels_scope_parent",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_labels_scope_parent_name": {
+          "name": "v2_uq_labels_scope_parent_name",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"parent_id\"::text, '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_labels_scope_system_key": {
+          "name": "v2_uq_labels_scope_system_key",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_labels_depth": {
+          "name": "v2_chk_labels_depth",
+          "value": "\"v2\".\"labels\".\"depth\" in (0, 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.proposals": {
+      "name": "proposals",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_checkpoint_id": {
+          "name": "source_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_space_id": {
+          "name": "target_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_branch_name": {
+          "name": "source_branch_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch_name": {
+          "name": "target_branch_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_pr_id": {
+          "name": "external_pr_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'open'"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_proposals_target_space_id": {
+          "name": "v2_idx_proposals_target_space_id",
+          "columns": [
+            {
+              "expression": "target_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_proposals_source_checkpoint_id": {
+          "name": "v2_idx_proposals_source_checkpoint_id",
+          "columns": [
+            {
+              "expression": "source_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_proposals_status": {
+          "name": "v2_idx_proposals_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.provider_message_refs": {
+      "name": "provider_message_refs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_session_id": {
+          "name": "space_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_channel_id": {
+          "name": "space_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_message_id": {
+          "name": "session_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_conversation_id": {
+          "name": "external_conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_external_conversation_id": {
+          "name": "parent_external_conversation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_external_message_id": {
+          "name": "parent_external_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_author_id": {
+          "name": "external_author_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_author_name": {
+          "name": "external_author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_provider_message_refs_provider_conversation": {
+          "name": "v2_idx_provider_message_refs_provider_conversation",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_provider_message_refs_provider_message": {
+          "name": "v2_uq_provider_message_refs_provider_message",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_space_session": {
+          "name": "v2_idx_provider_message_refs_space_session",
+          "columns": [
+            {
+              "expression": "space_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_session_message": {
+          "name": "v2_idx_provider_message_refs_session_message",
+          "columns": [
+            {
+              "expression": "session_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_parent_message": {
+          "name": "v2_idx_provider_message_refs_parent_message",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_external_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_external_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_provider_message_refs_space_channel": {
+          "name": "v2_idx_provider_message_refs_space_channel",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.referral_codes": {
+      "name": "referral_codes",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_referral_codes_code": {
+          "name": "v2_uq_referral_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_referral_codes_active_user": {
+          "name": "v2_uq_referral_codes_active_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2\".\"referral_codes\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referral_codes_user": {
+          "name": "v2_idx_referral_codes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.referrals": {
+      "name": "referrals",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referral_code_id": {
+          "name": "referral_code_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_user_id": {
+          "name": "inviter_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_user_id": {
+          "name": "invitee_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "qualified_at": {
+          "name": "qualified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewarded_at": {
+          "name": "rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_rewarded_at": {
+          "name": "inviter_rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitee_rewarded_at": {
+          "name": "invitee_rewarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_reward_amount_usd": {
+          "name": "inviter_reward_amount_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_reward_amount_usd": {
+          "name": "invitee_reward_amount_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_error": {
+          "name": "reward_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_attempted_at": {
+          "name": "reward_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_lease_token": {
+          "name": "reward_lease_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_lease_expires_at": {
+          "name": "reward_lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_referrals_invitee": {
+          "name": "v2_uq_referrals_invitee",
+          "columns": [
+            {
+              "expression": "invitee_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_inviter": {
+          "name": "v2_idx_referrals_inviter",
+          "columns": [
+            {
+              "expression": "inviter_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_code": {
+          "name": "v2_idx_referrals_code",
+          "columns": [
+            {
+              "expression": "referral_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_referrals_qualified_retry": {
+          "name": "v2_idx_referrals_qualified_retry",
+          "columns": [
+            {
+              "expression": "reward_attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2\".\"referrals\".\"status\" = 'qualified'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.resource_references": {
+      "name": "resource_references",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_turn_id": {
+          "name": "source_turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_resource_references_target": {
+          "name": "v2_idx_resource_references_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_source": {
+          "name": "v2_idx_resource_references_source",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_space_kind": {
+          "name": "v2_idx_resource_references_space_kind",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_session_kind": {
+          "name": "v2_idx_resource_references_session_kind",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_resource_references_turn": {
+          "name": "v2_idx_resource_references_turn",
+          "columns": [
+            {
+              "expression": "source_turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "v2_uq_resource_references_identity": {
+          "name": "v2_uq_resource_references_identity",
+          "nullsNotDistinct": true,
+          "columns": [
+            "kind",
+            "source_type",
+            "source_id",
+            "source_turn_id",
+            "target_type",
+            "target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_forks": {
+      "name": "session_forks",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_session_id": {
+          "name": "child_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_session_id": {
+          "name": "root_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_source_session_id": {
+          "name": "anchor_source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_turn_id": {
+          "name": "anchor_turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_sequence": {
+          "name": "anchor_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_session_ids": {
+          "name": "ancestor_session_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_path": {
+          "name": "session_path",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_session_forks_child": {
+          "name": "v2_uq_session_forks_child",
+          "columns": [
+            {
+              "expression": "child_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_parent": {
+          "name": "v2_idx_session_forks_parent",
+          "columns": [
+            {
+              "expression": "parent_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_root_depth": {
+          "name": "v2_idx_session_forks_root_depth",
+          "columns": [
+            {
+              "expression": "root_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_forks_anchor_turn": {
+          "name": "v2_idx_session_forks_anchor_turn",
+          "columns": [
+            {
+              "expression": "anchor_turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_messages": {
+      "name": "session_messages",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_aggregated_at": {
+          "name": "usage_aggregated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_session_messages_session_id": {
+          "name": "v2_idx_session_messages_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_messages_session_sequence": {
+          "name": "v2_uq_session_messages_session_sequence",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_messages_session_id_idempotency_key": {
+          "name": "v2_uq_session_messages_session_id_idempotency_key",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_session_messages_sequence": {
+          "name": "v2_chk_session_messages_sequence",
+          "value": "\"v2\".\"session_messages\".\"sequence\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.session_turn_segments": {
+      "name": "session_turn_segments",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_sequence": {
+          "name": "from_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_sequence": {
+          "name": "to_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_session_turn_segments_session_ordinal": {
+          "name": "v2_uq_session_turn_segments_session_ordinal",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turn_segments_session": {
+          "name": "v2_idx_session_turn_segments_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turn_segments_source": {
+          "name": "v2_idx_session_turn_segments_source",
+          "columns": [
+            {
+              "expression": "source_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.session_turns": {
+      "name": "session_turns",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "intent": {
+          "name": "intent",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'steer'"
+        },
+        "user_content": {
+          "name": "user_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_text": {
+          "name": "user_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_content": {
+          "name": "assistant_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assistant_text": {
+          "name": "assistant_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_usage": {
+          "name": "final_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_usage": {
+          "name": "total_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intermediate_index": {
+          "name": "intermediate_index",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intermediate_summary": {
+          "name": "intermediate_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_session_turns_session_id": {
+          "name": "v2_idx_session_turns_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_session_turns_session_sequence": {
+          "name": "v2_uq_session_turns_session_sequence",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_user_uuid": {
+          "name": "v2_idx_session_turns_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_created_at": {
+          "name": "v2_idx_session_turns_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_session_turns_user_text_trgm": {
+          "name": "v2_idx_session_turns_user_text_trgm",
+          "columns": [
+            {
+              "expression": "user_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_session_turns_sequence": {
+          "name": "v2_chk_session_turns_sequence",
+          "value": "\"v2\".\"session_turns\".\"sequence\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.space_channels": {
+      "name": "space_channels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_channels_space": {
+          "name": "v2_idx_space_channels_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_channels_channel": {
+          "name": "v2_uq_space_channels_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_commerce_businesses": {
+      "name": "space_commerce_businesses",
+      "schema": "v2",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_business_key": {
+          "name": "billing_business_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_commerce_businesses_business_key": {
+          "name": "v2_uq_space_commerce_businesses_business_key",
+          "columns": [
+            {
+              "expression": "billing_business_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_marks": {
+      "name": "space_marks",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_ref": {
+          "name": "resource_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_marks_resource": {
+          "name": "v2_uq_space_marks_resource",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_marks_space_kind_rank": {
+          "name": "v2_idx_space_marks_space_kind_rank",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_marks_space_resource": {
+          "name": "v2_idx_space_marks_space_resource",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_members": {
+      "name": "space_members",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_members_space_user": {
+          "name": "v2_uq_space_members_space_user",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_space": {
+          "name": "v2_idx_space_members_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_user": {
+          "name": "v2_idx_space_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_user_space": {
+          "name": "v2_idx_space_members_user_space",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_members_space_role": {
+          "name": "v2_idx_space_members_space_role",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_mods": {
+      "name": "space_mods",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mod_space_id": {
+          "name": "mod_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mount_slug": {
+          "name": "mount_slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_mods_space_id": {
+          "name": "v2_idx_space_mods_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_mods_mod_space_id": {
+          "name": "v2_idx_space_mods_mod_space_id",
+          "columns": [
+            {
+              "expression": "mod_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_mods_space_mod": {
+          "name": "v2_uq_space_mods_space_mod",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mod_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_mods_space_mount_slug": {
+          "name": "v2_uq_space_mods_space_mount_slug",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mount_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_sandboxes": {
+      "name": "space_sandboxes",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloud'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "runtime_status": {
+          "name": "runtime_status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "pod_name": {
+          "name": "pod_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_image": {
+          "name": "desired_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_image_version": {
+          "name": "reported_image_version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_space_sandboxes_space_id": {
+          "name": "v2_uq_space_sandboxes_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_status": {
+          "name": "v2_idx_space_sandboxes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_desired_image": {
+          "name": "v2_idx_space_sandboxes_desired_image",
+          "columns": [
+            {
+              "expression": "desired_image",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_reported_image_version": {
+          "name": "v2_idx_space_sandboxes_reported_image_version",
+          "columns": [
+            {
+              "expression": "reported_image_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_last_heartbeat_at": {
+          "name": "v2_idx_space_sandboxes_last_heartbeat_at",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_last_activity_at": {
+          "name": "v2_idx_space_sandboxes_last_activity_at",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_runtime_status": {
+          "name": "v2_idx_space_sandboxes_runtime_status",
+          "columns": [
+            {
+              "expression": "runtime_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sandboxes_stopped_at": {
+          "name": "v2_idx_space_sandboxes_stopped_at",
+          "columns": [
+            {
+              "expression": "stopped_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_space_sandboxes_provider": {
+          "name": "v2_chk_space_sandboxes_provider",
+          "value": "\"v2\".\"space_sandboxes\".\"provider\" in ('cloud', 'local')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.space_session_bindings": {
+      "name": "space_session_bindings",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_session_id": {
+          "name": "space_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_channel_id": {
+          "name": "space_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_key": {
+          "name": "binding_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_space_session_bindings_space": {
+          "name": "v2_idx_space_session_bindings_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_session": {
+          "name": "v2_idx_space_session_bindings_session",
+          "columns": [
+            {
+              "expression": "space_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_channel": {
+          "name": "v2_idx_space_session_bindings_channel",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_binding_key": {
+          "name": "v2_idx_space_session_bindings_binding_key",
+          "columns": [
+            {
+              "expression": "binding_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_session_bindings_external_chat": {
+          "name": "v2_idx_space_session_bindings_external_chat",
+          "columns": [
+            {
+              "expression": "external_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_space_session_bindings_channel_binding": {
+          "name": "v2_uq_space_session_bindings_channel_binding",
+          "columns": [
+            {
+              "expression": "space_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.space_sessions": {
+      "name": "space_sessions",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "external_session_id": {
+          "name": "external_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_message_text": {
+          "name": "latest_message_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_id": {
+          "name": "last_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_space_sessions_space_id": {
+          "name": "v2_idx_space_sessions_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_user_uuid": {
+          "name": "v2_idx_space_sessions_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_last_message_id": {
+          "name": "v2_idx_space_sessions_last_message_id",
+          "columns": [
+            {
+              "expression": "last_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_last_message_at": {
+          "name": "v2_idx_space_sessions_last_message_at",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_title_trgm": {
+          "name": "v2_idx_space_sessions_title_trgm",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_space_sessions_latest_message_text_trgm": {
+          "name": "v2_idx_space_sessions_latest_message_text_trgm",
+          "columns": [
+            {
+              "expression": "latest_message_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_space_sessions_space_last_message_id": {
+          "name": "v2_idx_space_sessions_space_last_message_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_user_last_message": {
+          "name": "v2_idx_space_sessions_user_last_message",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_space_sessions_participant_user_uuids": {
+          "name": "v2_idx_space_sessions_participant_user_uuids",
+          "columns": [
+            {
+              "expression": "(\"meta\" -> 'participants' -> 'userUuids')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.spaces": {
+      "name": "spaces",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_repo_name": {
+          "name": "storage_repo_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_checkpoint_id": {
+          "name": "base_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_checkpoint_id": {
+          "name": "head_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_idx_spaces_user_uuid": {
+          "name": "v2_idx_spaces_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_base_checkpoint_id": {
+          "name": "v2_idx_spaces_base_checkpoint_id",
+          "columns": [
+            {
+              "expression": "base_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_head_checkpoint_id": {
+          "name": "v2_idx_spaces_head_checkpoint_id",
+          "columns": [
+            {
+              "expression": "head_checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_last_activity_at": {
+          "name": "v2_idx_spaces_last_activity_at",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_spaces_name_trgm": {
+          "name": "v2_idx_spaces_name_trgm",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_idx_spaces_description_trgm": {
+          "name": "v2_idx_spaces_description_trgm",
+          "columns": [
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "v2_uq_spaces_user_name": {
+          "name": "v2_uq_spaces_user_name",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_spaces_user_slug": {
+          "name": "v2_uq_spaces_user_slug",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2\".\"spaces\".\"slug\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_spaces_storage_repo_name": {
+          "name": "v2_uq_spaces_storage_repo_name",
+          "columns": [
+            {
+              "expression": "storage_repo_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_spaces_slug_format": {
+          "name": "v2_chk_spaces_slug_format",
+          "value": "\"v2\".\"spaces\".\"slug\" is null or (length(\"v2\".\"spaces\".\"slug\") between 1 and 80 and \"v2\".\"spaces\".\"slug\" !~ '[^a-z0-9_-]' and left(\"v2\".\"spaces\".\"slug\", 1) ~ '[a-z0-9]' and right(\"v2\".\"spaces\".\"slug\", 1) ~ '[a-z0-9]')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.task_runs": {
+      "name": "task_runs",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_task_runs_job_id": {
+          "name": "v2_uq_task_runs_job_id",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_cron_job_id": {
+          "name": "v2_idx_task_runs_cron_job_id",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_space_id": {
+          "name": "v2_idx_task_runs_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_session_id": {
+          "name": "v2_idx_task_runs_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_turn_id": {
+          "name": "v2_idx_task_runs_turn_id",
+          "columns": [
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_session_turn": {
+          "name": "v2_idx_task_runs_session_turn",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_user_uuid": {
+          "name": "v2_idx_task_runs_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_status": {
+          "name": "v2_idx_task_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_task_type": {
+          "name": "v2_idx_task_runs_task_type",
+          "columns": [
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_space_session_type_status_created": {
+          "name": "v2_idx_task_runs_space_session_type_status_created",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_user_session_type_status_created": {
+          "name": "v2_idx_task_runs_user_session_type_status_created",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_cron_job_status_created": {
+          "name": "v2_idx_task_runs_cron_job_status_created",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_created_at": {
+          "name": "v2_idx_task_runs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_task_runs_scheduled_at": {
+          "name": "v2_idx_task_runs_scheduled_at",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.token_usage_stats_hourly": {
+      "name": "token_usage_stats_hourly",
+      "schema": "v2",
+      "columns": {
+        "bucket_start_at": {
+          "name": "bucket_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_cache_read": {
+          "name": "cost_cache_read",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_token_usage_stats_hourly_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_user_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_user_bucket",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_space_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_space_bucket",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_session_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_session_bucket",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_token_usage_stats_hourly_provider_model_bucket": {
+          "name": "v2_idx_token_usage_stats_hourly_provider_model_bucket",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "v2_uq_token_usage_stats_hourly_bucket_dims": {
+          "name": "v2_uq_token_usage_stats_hourly_bucket_dims",
+          "nullsNotDistinct": true,
+          "columns": [
+            "bucket_start_at",
+            "user_id",
+            "space_id",
+            "session_id",
+            "provider",
+            "model"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_channels": {
+      "name": "user_channels",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_envelope": {
+          "name": "credential_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_revision": {
+          "name": "credential_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_user_channels_user_uuid": {
+          "name": "v2_idx_user_channels_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_channels_provider": {
+          "name": "v2_idx_user_channels_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_user_channels_credentials_storage": {
+          "name": "v2_chk_user_channels_credentials_storage",
+          "value": "num_nonnulls(\"v2\".\"user_channels\".\"credentials\", \"v2\".\"user_channels\".\"credential_envelope\") = 1"
+        },
+        "v2_chk_user_channels_credential_envelope": {
+          "name": "v2_chk_user_channels_credential_envelope",
+          "value": "\"v2\".\"user_channels\".\"credential_envelope\" is null or coalesce(\n        jsonb_typeof(\"v2\".\"user_channels\".\"credential_envelope\") = 'object'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->'version' = '1'::jsonb\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'algorithm' = 'aes-256-gcm'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'keyId' ~ '^[A-Za-z0-9._-]{1,64}$'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'nonce' ~ '^[A-Za-z0-9_-]{16}$'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'authTag' ~ '^[A-Za-z0-9_-]{22}$'\n        and \"v2\".\"user_channels\".\"credential_envelope\"->>'ciphertext' ~ '^[A-Za-z0-9_-]{3,}$',\n        false\n      )"
+        },
+        "v2_chk_user_channels_credential_revision": {
+          "name": "v2_chk_user_channels_credential_revision",
+          "value": "\"v2\".\"user_channels\".\"credential_revision\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "v2.user_git_accounts": {
+      "name": "user_git_accounts",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gitea'"
+        },
+        "gitea_user_id": {
+          "name": "gitea_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_username": {
+          "name": "gitea_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_password_encrypted": {
+          "name": "gitea_password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gitea_access_token_encrypted": {
+          "name": "gitea_access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_user_git_accounts_user_provider": {
+          "name": "v2_uq_user_git_accounts_user_provider",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_user_git_accounts_gitea_username": {
+          "name": "v2_uq_user_git_accounts_gitea_username",
+          "columns": [
+            {
+              "expression": "gitea_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_git_accounts_user_uuid": {
+          "name": "v2_idx_user_git_accounts_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_git_accounts_provider": {
+          "name": "v2_idx_user_git_accounts_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.user_profiles": {
+      "name": "user_profiles",
+      "schema": "v2",
+      "columns": {
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logto_user_id": {
+          "name": "logto_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_uq_user_profiles_logto_user_id": {
+          "name": "v2_uq_user_profiles_logto_user_id",
+          "columns": [
+            {
+              "expression": "logto_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_user_profiles_updated_at": {
+          "name": "v2_idx_user_profiles_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_user_profiles_username": {
+          "name": "v2_uq_user_profiles_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.work_versions": {
+      "name": "work_versions",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ref": {
+          "name": "target_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_work_versions_work_id": {
+          "name": "v2_idx_work_versions_work_id",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_work_versions_work_version": {
+          "name": "v2_uq_work_versions_work_version",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.work_viewer_grants": {
+      "name": "work_viewer_grants",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "work_id": {
+          "name": "work_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewer_user_uuid": {
+          "name": "viewer_user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_work_viewer_grants_work_id": {
+          "name": "v2_idx_work_viewer_grants_work_id",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_work_viewer_grants_space_id": {
+          "name": "v2_idx_work_viewer_grants_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_work_viewer_grants_viewer_user_uuid": {
+          "name": "v2_idx_work_viewer_grants_viewer_user_uuid",
+          "columns": [
+            {
+              "expression": "viewer_user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_work_viewer_grants_work_viewer": {
+          "name": "v2_uq_work_viewer_grants_work_viewer",
+          "columns": [
+            {
+              "expression": "work_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewer_user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "v2.works": {
+      "name": "works",
+      "schema": "v2",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_uuid": {
+          "name": "user_uuid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ref": {
+          "name": "target_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_key": {
+          "name": "asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_scopes": {
+          "name": "work_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_viewer_scopes": {
+          "name": "allowed_viewer_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_idx_works_space_id": {
+          "name": "v2_idx_works_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_user_uuid": {
+          "name": "v2_idx_works_user_uuid",
+          "columns": [
+            {
+              "expression": "user_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_status": {
+          "name": "v2_idx_works_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_idx_works_visibility": {
+          "name": "v2_idx_works_visibility",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_uq_works_space_slug": {
+          "name": "v2_uq_works_space_slug",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_chk_works_status": {
+          "name": "v2_chk_works_status",
+          "value": "\"v2\".\"works\".\"status\" in ('published', 'disabled')"
+        },
+        "v2_chk_works_visibility": {
+          "name": "v2_chk_works_visibility",
+          "value": "\"v2\".\"works\".\"visibility\" in ('public', 'space')"
+        },
+        "v2_chk_works_slug_format": {
+          "name": "v2_chk_works_slug_format",
+          "value": "length(\"v2\".\"works\".\"slug\") between 1 and 80 and \"v2\".\"works\".\"slug\" !~ '[^a-z0-9_-]' and left(\"v2\".\"works\".\"slug\", 1) ~ '[a-z0-9]' and right(\"v2\".\"works\".\"slug\", 1) ~ '[a-z0-9]'"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "v2": "v2"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/v2/meta/_journal.json
+++ b/apps/api/drizzle/v2/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1784149553538,
       "tag": "0045_same_doctor_octopus",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1784150558297,
+      "tag": "0046_white_menace",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/drizzle/v2/meta/_journal.json
+++ b/apps/api/drizzle/v2/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1784150558297,
       "tag": "0046_white_menace",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1784152038511,
+      "tag": "0047_fuzzy_jigsaw",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/drizzle/v2/meta/_journal.json
+++ b/apps/api/drizzle/v2/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1784145201944,
       "tag": "0044_silky_mentallo",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1784149553538,
+      "tag": "0045_same_doctor_octopus",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/drizzle/v2/meta/_journal.json
+++ b/apps/api/drizzle/v2/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1784049216721,
       "tag": "0043_greedy_expediter",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1784145201944,
+      "tag": "0044_silky_mentallo",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "start": "node --import ./dist/register-otel-esm-hook.js dist/index.js",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx src/db/migrate.ts",
+    "db:migrate:channel-credentials": "tsx src/db/migrate-channel-credentials.ts",
     "db:migrate:data:v2": "tsx src/db/migrate-v2-data.ts",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio"

--- a/apps/api/src/canvas-protocol.ts
+++ b/apps/api/src/canvas-protocol.ts
@@ -1,0 +1,192 @@
+import { createHash } from "node:crypto";
+
+export type CanvasNodeInput = {
+  nodeId: string;
+  type: string;
+  parentId?: string | null;
+  orderKey?: string | null;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation?: number;
+  refKind?: string | null;
+  refPath?: string | null;
+  refUrl?: string | null;
+  view?: Record<string, unknown>;
+  style?: Record<string, unknown>;
+  animation?: Record<string, unknown>;
+  data?: Record<string, unknown>;
+};
+
+export type CanvasSemanticOp = {
+  opId?: string;
+  version?: 1 | 2;
+  type: "node.create" | "node.patch" | "node.data.merge" | "node.delete" | "document.meta.patch";
+  payload: Record<string, unknown>;
+  inverse?: Record<string, unknown>;
+};
+
+export class CanvasServiceError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+    public code = "canvas_error",
+    public currentVersion?: number,
+  ) {
+    super(message);
+  }
+}
+
+export const MAX_CANVAS_NODES = 2000;
+export const MAX_CANVAS_OPS = 100;
+export const MAX_NODE_ID_LENGTH = 120;
+export const MAX_NODE_TYPE_LENGTH = 40;
+export const MAX_REF_LENGTH = 4096;
+export const MAX_JSON_FIELD_BYTES = 16 * 1024;
+export const MAX_TRANSACTION_BYTES = 256 * 1024;
+
+const isRecord = (value: unknown): value is Record<string, unknown> => Boolean(value && typeof value === "object" && !Array.isArray(value));
+const jsonBytes = (value: unknown) => Buffer.byteLength(JSON.stringify(value ?? {}), "utf8");
+const cleanRecord = (value: unknown, fieldName: string) => {
+  if (value == null) return {};
+  if (!isRecord(value)) throw new CanvasServiceError(400, `${fieldName} must be an object`);
+  if (jsonBytes(value) > MAX_JSON_FIELD_BYTES) throw new CanvasServiceError(413, `${fieldName} is too large`);
+  return value;
+};
+const finiteNumber = (value: unknown, fallback: number) => typeof value === "number" && Number.isFinite(value) ? value : fallback;
+const optionalString = (value: unknown, fieldName: string, maxLength = MAX_REF_LENGTH) => {
+  if (value == null) return null;
+  if (typeof value !== "string") throw new CanvasServiceError(400, `${fieldName} must be a string`);
+  if (value.length > maxLength) throw new CanvasServiceError(400, `${fieldName} is too long`);
+  return value;
+};
+
+export function normalizeNode(input: CanvasNodeInput) {
+  if (!input || typeof input.nodeId !== "string" || !input.nodeId.trim()) throw new CanvasServiceError(400, "nodeId is required");
+  if (input.nodeId.length > MAX_NODE_ID_LENGTH) throw new CanvasServiceError(400, "nodeId is too long");
+  if (typeof input.type !== "string" || !input.type.trim()) throw new CanvasServiceError(400, "node type is required");
+  if (input.type.length > MAX_NODE_TYPE_LENGTH) throw new CanvasServiceError(400, "node type is too long");
+  return {
+    nodeId: input.nodeId.trim(),
+    type: input.type.trim(),
+    parentId: optionalString(input.parentId, "parentId"),
+    orderKey: optionalString(input.orderKey, "orderKey"),
+    x: finiteNumber(input.x, 0),
+    y: finiteNumber(input.y, 0),
+    width: Math.max(1, finiteNumber(input.width, 240)),
+    height: Math.max(1, finiteNumber(input.height, 160)),
+    rotation: finiteNumber(input.rotation, 0),
+    refKind: optionalString(input.refKind, "refKind", 40),
+    refPath: optionalString(input.refPath, "refPath"),
+    refUrl: optionalString(input.refUrl, "refUrl"),
+    view: cleanRecord(input.view, "view"),
+    style: cleanRecord(input.style, "style"),
+    animation: cleanRecord(input.animation, "animation"),
+    data: cleanRecord(input.data, "data"),
+  };
+}
+
+export function normalizeNodes(input: CanvasNodeInput[]) {
+  if (input.length > MAX_CANVAS_NODES) throw new CanvasServiceError(413, "Too many canvas nodes");
+  const nodes = input.map(normalizeNode);
+  const seen = new Set<string>();
+  for (const node of nodes) {
+    if (seen.has(node.nodeId)) throw new CanvasServiceError(400, "nodeId must be unique");
+    seen.add(node.nodeId);
+  }
+  return nodes;
+}
+
+export type NormalizedPatch = Partial<ReturnType<typeof normalizeNode>>;
+
+function normalizePatch(input: Record<string, unknown>): NormalizedPatch {
+  const patch: NormalizedPatch = {};
+  if ("type" in input) {
+    if (typeof input.type !== "string" || !input.type.trim()) throw new CanvasServiceError(400, "type must be a non-empty string");
+    if (input.type.length > MAX_NODE_TYPE_LENGTH) throw new CanvasServiceError(400, "type is too long");
+    patch.type = input.type.trim();
+  }
+  if ("parentId" in input) patch.parentId = optionalString(input.parentId, "parentId");
+  if ("orderKey" in input) patch.orderKey = optionalString(input.orderKey, "orderKey");
+  if ("x" in input) patch.x = finiteNumber(input.x, 0);
+  if ("y" in input) patch.y = finiteNumber(input.y, 0);
+  if ("width" in input) patch.width = Math.max(1, finiteNumber(input.width, 240));
+  if ("height" in input) patch.height = Math.max(1, finiteNumber(input.height, 160));
+  if ("rotation" in input) patch.rotation = finiteNumber(input.rotation, 0);
+  if ("refKind" in input) patch.refKind = optionalString(input.refKind, "refKind", 40);
+  if ("refPath" in input) patch.refPath = optionalString(input.refPath, "refPath");
+  if ("refUrl" in input) patch.refUrl = optionalString(input.refUrl, "refUrl");
+  if ("view" in input) patch.view = cleanRecord(input.view, "view");
+  if ("style" in input) patch.style = cleanRecord(input.style, "style");
+  if ("animation" in input) patch.animation = cleanRecord(input.animation, "animation");
+  if ("data" in input) patch.data = cleanRecord(input.data, "data");
+  if (Object.keys(patch).length === 0) throw new CanvasServiceError(400, "node.patch is empty");
+  return patch;
+}
+
+function normalizeOp(op: CanvasSemanticOp): CanvasSemanticOp {
+  if (!op || typeof op.type !== "string" || !isRecord(op.payload)) throw new CanvasServiceError(400, "invalid op");
+  const version = op.version === 2 ? 2 : 1;
+  if (op.type === "node.create") {
+    const node = normalizeNode(op.payload.node as CanvasNodeInput);
+    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, version, type: "node.create", payload: { node }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
+  }
+  if (op.type === "node.patch") {
+    const nodeId = optionalString(op.payload.nodeId, "nodeId", MAX_NODE_ID_LENGTH);
+    if (!nodeId) throw new CanvasServiceError(400, "node.patch requires nodeId");
+    const patch = isRecord(op.payload.patch) ? normalizePatch(op.payload.patch) : null;
+    if (!patch) throw new CanvasServiceError(400, "node.patch requires patch");
+    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, version, type: "node.patch", payload: { nodeId, patch }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
+  }
+  if (op.type === "node.data.merge") {
+    if (version !== 2) throw new CanvasServiceError(400, "node.data.merge requires operation version 2");
+    const nodeId = optionalString(op.payload.nodeId, "nodeId", MAX_NODE_ID_LENGTH);
+    if (!nodeId) throw new CanvasServiceError(400, "node.data.merge requires nodeId");
+    const data = cleanRecord(op.payload.data, "data");
+    if (Object.keys(data).length === 0) throw new CanvasServiceError(400, "node.data.merge is empty");
+    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, version, type: "node.data.merge", payload: { nodeId, data }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
+  }
+  if (op.type === "node.delete") {
+    const nodeId = optionalString(op.payload.nodeId, "nodeId", MAX_NODE_ID_LENGTH);
+    if (!nodeId) throw new CanvasServiceError(400, "node.delete requires nodeId");
+    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, version, type: "node.delete", payload: { nodeId }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
+  }
+  if (op.type === "document.meta.patch") {
+    if (version !== 2) throw new CanvasServiceError(400, "document.meta.patch requires operation version 2");
+    const patch = cleanRecord(op.payload.patch, "patch");
+    if (Object.keys(patch).length === 0) throw new CanvasServiceError(400, "document.meta.patch is empty");
+    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, version, type: "document.meta.patch", payload: { patch }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
+  }
+  throw new CanvasServiceError(400, "unsupported op type");
+}
+
+export function normalizeCanvasOps(ops: CanvasSemanticOp[]) {
+  if (!ops.length) throw new CanvasServiceError(400, "ops are required");
+  if (ops.length > MAX_CANVAS_OPS) throw new CanvasServiceError(413, "too many ops");
+  if (jsonBytes(ops) > MAX_TRANSACTION_BYTES) throw new CanvasServiceError(413, "transaction is too large");
+  const normalized = ops.map(normalizeOp);
+  if (jsonBytes(normalized) > MAX_TRANSACTION_BYTES) throw new CanvasServiceError(413, "transaction is too large");
+  return normalized;
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (isRecord(value)) {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+export function canvasRequestHash(ops: CanvasSemanticOp[]) {
+  return createHash("sha256").update(canonicalJson(ops)).digest("hex");
+}
+
+export function normalizeCanvasTransactionIdentity(input: { txId: string; baseVersion: number }) {
+  const txId = optionalString(input.txId, "txId", 120)?.trim();
+  if (!txId) throw new CanvasServiceError(400, "txId is required", "invalid_transaction");
+  if (!Number.isInteger(input.baseVersion) || input.baseVersion < 0) {
+    throw new CanvasServiceError(400, "baseVersion must be a non-negative integer", "invalid_base_version");
+  }
+  return { txId, baseVersion: input.baseVersion };
+}

--- a/apps/api/src/canvas-service.test.ts
+++ b/apps/api/src/canvas-service.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { CanvasServiceError, normalizeCanvasOps } from "./canvas-protocol.js";
+
+test("version 2 canvas operations keep merge and metadata semantics explicit", () => {
+  const operations = normalizeCanvasOps([
+    {
+      version: 2,
+      type: "node.data.merge",
+      payload: { nodeId: "text-1", data: { outputText: "new output" } },
+    },
+    {
+      version: 2,
+      type: "document.meta.patch",
+      payload: { patch: { openTap: { schema: 1 } } },
+    },
+  ]);
+
+  assert.deepEqual(operations, [
+    {
+      opId: undefined,
+      version: 2,
+      type: "node.data.merge",
+      payload: { nodeId: "text-1", data: { outputText: "new output" } },
+      inverse: undefined,
+    },
+    {
+      opId: undefined,
+      version: 2,
+      type: "document.meta.patch",
+      payload: { patch: { openTap: { schema: 1 } } },
+      inverse: undefined,
+    },
+  ]);
+});
+
+test("new canvas operation semantics reject unversioned clients", () => {
+  assert.throws(
+    () => normalizeCanvasOps([{
+      type: "node.data.merge",
+      payload: { nodeId: "text-1", data: { outputText: "new output" } },
+    }]),
+    (error) => error instanceof CanvasServiceError
+      && error.status === 400
+      && error.message.includes("version 2"),
+  );
+});
+
+test("legacy node.patch remains an explicit whole-field replacement", () => {
+  const [operation] = normalizeCanvasOps([{
+    type: "node.patch",
+    payload: { nodeId: "text-1", patch: { data: { outputText: "replacement" } } },
+  }]);
+
+  assert.equal(operation?.version, 1);
+  assert.deepEqual(operation?.payload, {
+    nodeId: "text-1",
+    patch: { data: { outputText: "replacement" } },
+  });
+});

--- a/apps/api/src/canvas-service.ts
+++ b/apps/api/src/canvas-service.ts
@@ -1,158 +1,62 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { canvasDocuments, canvasNodes, canvasUpdates } from "@cohub/db";
 import { db } from "./db/index.js";
 import { dispatchCanvasTransactionApplied } from "./canvas-events.js";
+import {
+  CanvasServiceError,
+  canvasRequestHash,
+  normalizeCanvasOps,
+  normalizeCanvasTransactionIdentity,
+  type normalizeNode,
+  type CanvasSemanticOp,
+  type NormalizedPatch,
+} from "./canvas-protocol.js";
 
-export type CanvasNodeInput = {
-  nodeId: string;
-  type: string;
-  parentId?: string | null;
-  orderKey?: string | null;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  rotation?: number;
-  refKind?: string | null;
-  refPath?: string | null;
-  refUrl?: string | null;
-  view?: Record<string, unknown>;
-  style?: Record<string, unknown>;
-  animation?: Record<string, unknown>;
-  data?: Record<string, unknown>;
+export { CanvasServiceError, normalizeNodes } from "./canvas-protocol.js";
+export type { CanvasNodeInput, CanvasSemanticOp } from "./canvas-protocol.js";
+
+export type CanvasTransactionResponse = {
+  transaction: {
+    txId: string;
+    baseVersion: number;
+    version: number;
+    replayed: boolean;
+  };
+  document: {
+    version: number;
+    meta: Record<string, unknown>;
+  };
+  changes: {
+    nodes: Array<typeof canvasNodes.$inferSelect>;
+    deletedNodeIds: string[];
+  };
 };
-
-export type CanvasSemanticOp = {
-  opId?: string;
-  type: "node.create" | "node.patch" | "node.delete";
-  payload: Record<string, unknown>;
-  inverse?: Record<string, unknown>;
-};
-
-export class CanvasServiceError extends Error {
-  constructor(
-    public status: number,
-    message: string,
-  ) {
-    super(message);
-  }
-}
-
-export const MAX_CANVAS_NODES = 2000;
-export const MAX_CANVAS_OPS = 100;
-export const MAX_NODE_ID_LENGTH = 120;
-export const MAX_NODE_TYPE_LENGTH = 40;
-export const MAX_REF_LENGTH = 4096;
-export const MAX_JSON_FIELD_BYTES = 16 * 1024;
-export const MAX_TRANSACTION_BYTES = 256 * 1024;
 
 const isRecord = (value: unknown): value is Record<string, unknown> => Boolean(value && typeof value === "object" && !Array.isArray(value));
-const jsonBytes = (value: unknown) => Buffer.byteLength(JSON.stringify(value ?? {}), "utf8");
-const cleanRecord = (value: unknown, fieldName: string) => {
-  if (value == null) return {};
-  if (!isRecord(value)) throw new CanvasServiceError(400, `${fieldName} must be an object`);
-  if (jsonBytes(value) > MAX_JSON_FIELD_BYTES) throw new CanvasServiceError(413, `${fieldName} is too large`);
-  return value;
-};
-const finiteNumber = (value: unknown, fallback: number) => typeof value === "number" && Number.isFinite(value) ? value : fallback;
-const optionalString = (value: unknown, fieldName: string, maxLength = MAX_REF_LENGTH) => {
-  if (value == null) return null;
-  if (typeof value !== "string") throw new CanvasServiceError(400, `${fieldName} must be a string`);
-  if (value.length > maxLength) throw new CanvasServiceError(400, `${fieldName} is too long`);
-  return value;
-};
 
-export function normalizeNode(input: CanvasNodeInput) {
-  if (!input || typeof input.nodeId !== "string" || !input.nodeId.trim()) throw new CanvasServiceError(400, "nodeId is required");
-  if (input.nodeId.length > MAX_NODE_ID_LENGTH) throw new CanvasServiceError(400, "nodeId is too long");
-  if (typeof input.type !== "string" || !input.type.trim()) throw new CanvasServiceError(400, "node type is required");
-  if (input.type.length > MAX_NODE_TYPE_LENGTH) throw new CanvasServiceError(400, "node type is too long");
+function readStoredTransactionResult(
+  value: Record<string, unknown>,
+  fallback: { txId: string; baseVersion: number; version: number; meta: Record<string, unknown> },
+): CanvasTransactionResponse {
+  const transaction = isRecord(value.transaction) ? value.transaction : {};
+  const document = isRecord(value.document) ? value.document : {};
+  const changes = isRecord(value.changes) ? value.changes : {};
   return {
-    nodeId: input.nodeId.trim(),
-    type: input.type.trim(),
-    parentId: optionalString(input.parentId, "parentId"),
-    orderKey: optionalString(input.orderKey, "orderKey"),
-    x: finiteNumber(input.x, 0),
-    y: finiteNumber(input.y, 0),
-    width: Math.max(1, finiteNumber(input.width, 240)),
-    height: Math.max(1, finiteNumber(input.height, 160)),
-    rotation: finiteNumber(input.rotation, 0),
-    refKind: optionalString(input.refKind, "refKind", 40),
-    refPath: optionalString(input.refPath, "refPath"),
-    refUrl: optionalString(input.refUrl, "refUrl"),
-    view: cleanRecord(input.view, "view"),
-    style: cleanRecord(input.style, "style"),
-    animation: cleanRecord(input.animation, "animation"),
-    data: cleanRecord(input.data, "data"),
+    transaction: {
+      txId: typeof transaction.txId === "string" ? transaction.txId : fallback.txId,
+      baseVersion: typeof transaction.baseVersion === "number" ? transaction.baseVersion : fallback.baseVersion,
+      version: typeof transaction.version === "number" ? transaction.version : fallback.version,
+      replayed: true,
+    },
+    document: {
+      version: typeof document.version === "number" ? document.version : fallback.version,
+      meta: isRecord(document.meta) ? document.meta : fallback.meta,
+    },
+    changes: {
+      nodes: Array.isArray(changes.nodes) ? changes.nodes as Array<typeof canvasNodes.$inferSelect> : [],
+      deletedNodeIds: Array.isArray(changes.deletedNodeIds) ? changes.deletedNodeIds.filter((id): id is string => typeof id === "string") : [],
+    },
   };
-}
-
-export function normalizeNodes(input: CanvasNodeInput[]) {
-  if (input.length > MAX_CANVAS_NODES) throw new CanvasServiceError(413, "Too many canvas nodes");
-  const nodes = input.map(normalizeNode);
-  const seen = new Set<string>();
-  for (const node of nodes) {
-    if (seen.has(node.nodeId)) throw new CanvasServiceError(400, "nodeId must be unique");
-    seen.add(node.nodeId);
-  }
-  return nodes;
-}
-
-type NormalizedPatch = Partial<ReturnType<typeof normalizeNode>>;
-
-function normalizePatch(input: Record<string, unknown>): NormalizedPatch {
-  const patch: NormalizedPatch = {};
-  if ("type" in input) {
-    if (typeof input.type !== "string" || !input.type.trim()) throw new CanvasServiceError(400, "type must be a non-empty string");
-    if (input.type.length > MAX_NODE_TYPE_LENGTH) throw new CanvasServiceError(400, "type is too long");
-    patch.type = input.type.trim();
-  }
-  if ("parentId" in input) patch.parentId = optionalString(input.parentId, "parentId");
-  if ("orderKey" in input) patch.orderKey = optionalString(input.orderKey, "orderKey");
-  if ("x" in input) patch.x = finiteNumber(input.x, 0);
-  if ("y" in input) patch.y = finiteNumber(input.y, 0);
-  if ("width" in input) patch.width = Math.max(1, finiteNumber(input.width, 240));
-  if ("height" in input) patch.height = Math.max(1, finiteNumber(input.height, 160));
-  if ("rotation" in input) patch.rotation = finiteNumber(input.rotation, 0);
-  if ("refKind" in input) patch.refKind = optionalString(input.refKind, "refKind", 40);
-  if ("refPath" in input) patch.refPath = optionalString(input.refPath, "refPath");
-  if ("refUrl" in input) patch.refUrl = optionalString(input.refUrl, "refUrl");
-  if ("view" in input) patch.view = cleanRecord(input.view, "view");
-  if ("style" in input) patch.style = cleanRecord(input.style, "style");
-  if ("animation" in input) patch.animation = cleanRecord(input.animation, "animation");
-  if ("data" in input) patch.data = cleanRecord(input.data, "data");
-  if (Object.keys(patch).length === 0) throw new CanvasServiceError(400, "node.patch is empty");
-  return patch;
-}
-
-function normalizeOp(op: CanvasSemanticOp): CanvasSemanticOp {
-  if (!op || typeof op.type !== "string" || !isRecord(op.payload)) throw new CanvasServiceError(400, "invalid op");
-  if (op.type === "node.create") {
-    const node = normalizeNode(op.payload.node as CanvasNodeInput);
-    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, type: "node.create", payload: { node }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
-  }
-  if (op.type === "node.patch") {
-    const nodeId = optionalString(op.payload.nodeId, "nodeId", MAX_NODE_ID_LENGTH);
-    if (!nodeId) throw new CanvasServiceError(400, "node.patch requires nodeId");
-    const patch = isRecord(op.payload.patch) ? normalizePatch(op.payload.patch) : null;
-    if (!patch) throw new CanvasServiceError(400, "node.patch requires patch");
-    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, type: "node.patch", payload: { nodeId, patch }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
-  }
-  if (op.type === "node.delete") {
-    const nodeId = optionalString(op.payload.nodeId, "nodeId", MAX_NODE_ID_LENGTH);
-    if (!nodeId) throw new CanvasServiceError(400, "node.delete requires nodeId");
-    return { opId: optionalString(op.opId, "opId", 120) ?? undefined, type: "node.delete", payload: { nodeId }, inverse: isRecord(op.inverse) ? op.inverse : undefined };
-  }
-  throw new CanvasServiceError(400, "unsupported op type");
-}
-
-export function normalizeCanvasOps(ops: CanvasSemanticOp[]) {
-  if (!ops.length) throw new CanvasServiceError(400, "ops are required");
-  if (ops.length > MAX_CANVAS_OPS) throw new CanvasServiceError(413, "too many ops");
-  if (jsonBytes(ops) > MAX_TRANSACTION_BYTES) throw new CanvasServiceError(413, "transaction is too large");
-  const normalized = ops.map(normalizeOp);
-  if (jsonBytes(normalized) > MAX_TRANSACTION_BYTES) throw new CanvasServiceError(413, "transaction is too large");
-  return normalized;
 }
 
 export async function applyCanvasTransaction(input: {
@@ -160,13 +64,15 @@ export async function applyCanvasTransaction(input: {
   documentId: string;
   actorId: string;
   txId: string;
-  baseVersion?: number | null;
+  baseVersion: number;
   clientId?: string | null;
   undoGroupId?: string | null;
   ops: CanvasSemanticOp[];
   broadcast?: boolean;
 }) {
+  const { txId } = normalizeCanvasTransactionIdentity(input);
   const normalizedOps = normalizeCanvasOps(input.ops);
+  const requestHash = canvasRequestHash(normalizedOps);
   const now = new Date();
   const result = await db.transaction(async (tx) => {
     const [document] = await tx
@@ -176,15 +82,38 @@ export async function applyCanvasTransaction(input: {
       .for("update")
       .limit(1);
     if (!document) throw new CanvasServiceError(404, "canvas not found");
-    if (input.baseVersion != null && input.baseVersion !== document.version) {
-      throw new CanvasServiceError(409, "canvas version conflict");
+    const [existingUpdate] = await tx
+      .select()
+      .from(canvasUpdates)
+      .where(and(eq(canvasUpdates.documentId, input.documentId), eq(canvasUpdates.txId, txId)))
+      .limit(1);
+    if (existingUpdate) {
+      if (existingUpdate.requestHash && existingUpdate.requestHash !== requestHash) {
+        throw new CanvasServiceError(409, "txId was already used for a different transaction", "tx_id_conflict", document.version);
+      }
+      return {
+        response: readStoredTransactionResult(existingUpdate.result, {
+          txId,
+          baseVersion: existingUpdate.baseVersion,
+          version: existingUpdate.version,
+          meta: document.meta,
+        }),
+        broadcast: false,
+        ops: normalizedOps,
+      };
+    }
+    if (input.baseVersion !== document.version) {
+      throw new CanvasServiceError(409, "canvas version conflict", "version_conflict", document.version);
     }
     const nextVersion = document.version + 1;
+    const changedNodeIds = new Set<string>();
+    const deletedNodeIds = new Set<string>();
+    let nextMeta = document.meta;
 
     for (const op of normalizedOps) {
       if (op.type === "node.create") {
         const node = (op.payload as { node: ReturnType<typeof normalizeNode> }).node;
-        await tx.insert(canvasNodes).values({
+        const values = {
           documentId: input.documentId,
           nodeId: node.nodeId,
           type: node.type,
@@ -206,29 +135,21 @@ export async function applyCanvasTransaction(input: {
           createdAt: now,
           updatedAt: now,
           deletedAt: null,
-        }).onConflictDoUpdate({
-          target: [canvasNodes.documentId, canvasNodes.nodeId],
-          set: {
-            type: node.type,
-            parentId: node.parentId,
-            orderKey: node.orderKey,
-            x: node.x,
-            y: node.y,
-            width: node.width,
-            height: node.height,
-            rotation: node.rotation,
-            refKind: node.refKind,
-            refPath: node.refPath,
-            refUrl: node.refUrl,
-            view: node.view,
-            style: node.style,
-            animation: node.animation,
-            data: node.data,
-            version: nextVersion,
-            updatedAt: now,
-            deletedAt: null,
-          },
-        });
+        };
+        const [existingNode] = await tx.select({ deletedAt: canvasNodes.deletedAt })
+          .from(canvasNodes)
+          .where(and(eq(canvasNodes.documentId, input.documentId), eq(canvasNodes.nodeId, node.nodeId)))
+          .limit(1);
+        if (existingNode && existingNode.deletedAt == null) {
+          throw new CanvasServiceError(409, "canvas node already exists", "node_exists", document.version);
+        }
+        if (existingNode) {
+          await tx.update(canvasNodes).set(values)
+            .where(and(eq(canvasNodes.documentId, input.documentId), eq(canvasNodes.nodeId, node.nodeId)));
+        } else {
+          await tx.insert(canvasNodes).values(values);
+        }
+        changedNodeIds.add(node.nodeId);
         continue;
       }
       if (op.type === "node.patch") {
@@ -238,6 +159,22 @@ export async function applyCanvasTransaction(input: {
           .where(and(eq(canvasNodes.documentId, input.documentId), eq(canvasNodes.nodeId, nodeId), isNull(canvasNodes.deletedAt)))
           .returning({ nodeId: canvasNodes.nodeId });
         if (updated.length === 0) throw new CanvasServiceError(404, "canvas node not found");
+        changedNodeIds.add(nodeId);
+        continue;
+      }
+      if (op.type === "node.data.merge") {
+        const { nodeId, data } = op.payload as { nodeId: string; data: Record<string, unknown> };
+        const updated = await tx.update(canvasNodes)
+          .set({ data: sql`${canvasNodes.data} || ${JSON.stringify(data)}::jsonb`, updatedAt: now, version: nextVersion })
+          .where(and(eq(canvasNodes.documentId, input.documentId), eq(canvasNodes.nodeId, nodeId), isNull(canvasNodes.deletedAt)))
+          .returning({ nodeId: canvasNodes.nodeId });
+        if (updated.length === 0) throw new CanvasServiceError(404, "canvas node not found");
+        changedNodeIds.add(nodeId);
+        continue;
+      }
+      if (op.type === "document.meta.patch") {
+        const { patch } = op.payload as { patch: Record<string, unknown> };
+        nextMeta = { ...nextMeta, ...patch };
         continue;
       }
       const nodeId = (op.payload as { nodeId: string }).nodeId;
@@ -246,32 +183,51 @@ export async function applyCanvasTransaction(input: {
         .where(and(eq(canvasNodes.documentId, input.documentId), eq(canvasNodes.nodeId, nodeId), isNull(canvasNodes.deletedAt)))
         .returning({ nodeId: canvasNodes.nodeId });
       if (deleted.length === 0) throw new CanvasServiceError(404, "canvas node not found");
+      changedNodeIds.delete(nodeId);
+      deletedNodeIds.add(nodeId);
     }
 
+    await tx.update(canvasDocuments)
+      .set({ version: nextVersion, meta: nextMeta, updatedAt: now })
+      .where(eq(canvasDocuments.id, input.documentId));
+    const nodes = changedNodeIds.size > 0
+      ? await tx.select().from(canvasNodes).where(and(
+          eq(canvasNodes.documentId, input.documentId),
+          inArray(canvasNodes.nodeId, [...changedNodeIds]),
+          isNull(canvasNodes.deletedAt),
+        ))
+      : [];
+    const response: CanvasTransactionResponse = {
+      transaction: { txId, baseVersion: input.baseVersion, version: nextVersion, replayed: false },
+      document: { version: nextVersion, meta: nextMeta },
+      changes: { nodes, deletedNodeIds: [...deletedNodeIds] },
+    };
     await tx.insert(canvasUpdates).values({
       documentId: input.documentId,
+      txId,
+      baseVersion: input.baseVersion,
+      requestHash,
       version: nextVersion,
       actorId: input.actorId,
       clientId: input.clientId ?? null,
       type: "canvas.tx",
-      payload: { txId: input.txId, baseVersion: input.baseVersion ?? null, ops: normalizedOps },
+      payload: { ops: normalizedOps },
+      result: response,
       undoGroupId: input.undoGroupId ?? null,
       createdAt: now,
     });
-    const [updated] = await tx.update(canvasDocuments).set({ version: nextVersion, updatedAt: now }).where(eq(canvasDocuments.id, input.documentId)).returning();
-    const nodes = await tx.select().from(canvasNodes).where(and(eq(canvasNodes.documentId, input.documentId), isNull(canvasNodes.deletedAt))).orderBy(canvasNodes.orderKey);
-    return { document: updated ?? { ...document, version: nextVersion, updatedAt: now }, nodes, version: nextVersion, ops: normalizedOps };
+    return { response, broadcast: true, ops: normalizedOps };
   });
 
-  if (input.broadcast !== false) {
+  if (input.broadcast !== false && result.broadcast) {
     await dispatchCanvasTransactionApplied({
       spaceId: input.spaceId,
       documentId: input.documentId,
       actorId: input.actorId,
-      txId: input.txId,
-      version: result.version,
+      txId,
+      version: result.response.transaction.version,
       ops: result.ops as Array<Record<string, unknown>>,
     }).catch(() => undefined);
   }
-  return { document: result.document, nodes: result.nodes, version: result.version };
+  return result.response;
 }

--- a/apps/api/src/channel-credentials.test.ts
+++ b/apps/api/src/channel-credentials.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  ChannelCredentialError,
+  decryptChannelCredentials,
+  encryptChannelCredentials,
+  parseChannelCredentialKeyring,
+  resolveChannelCredentials,
+  shouldRotateChannelCredentials,
+} from "./channel-credentials.js";
+
+const key = (byte: number) => Buffer.alloc(32, byte).toString("base64url");
+const context = { channelId: "channel-1", userUuid: "user-1", provider: "discord" };
+
+test("channel credential envelopes round-trip and bind ciphertext to its row", () => {
+  const keyring = parseChannelCredentialKeyring(JSON.stringify({ current: key(1) }), "current");
+  const envelope = encryptChannelCredentials({ token: "secret", nested: { enabled: true } }, context, keyring);
+
+  assert.deepEqual(decryptChannelCredentials(envelope, context, keyring), {
+    token: "secret",
+    nested: { enabled: true },
+  });
+  assert.throws(
+    () => decryptChannelCredentials(envelope, { ...context, channelId: "channel-2" }, keyring),
+    ChannelCredentialError,
+  );
+});
+
+test("legacy plaintext rows remain readable during backfill", () => {
+  const keyring = parseChannelCredentialKeyring(JSON.stringify({ current: key(1) }), "current");
+  assert.deepEqual(resolveChannelCredentials({
+    ...context,
+    credentials: { token: "legacy" },
+    credentialEnvelope: null,
+  }, keyring), { token: "legacy" });
+});
+
+test("key rotation decrypts old envelopes and writes with the primary key", () => {
+  const oldKeyring = parseChannelCredentialKeyring(JSON.stringify({ old: key(1) }), "old");
+  const rotatingKeyring = parseChannelCredentialKeyring(
+    JSON.stringify({ old: key(1), current: key(2) }),
+    "current",
+  );
+  const oldEnvelope = encryptChannelCredentials({ token: "secret" }, context, oldKeyring);
+
+  assert.equal(shouldRotateChannelCredentials(oldEnvelope, rotatingKeyring), true);
+  const credentials = decryptChannelCredentials(oldEnvelope, context, rotatingKeyring);
+  const newEnvelope = encryptChannelCredentials(credentials, context, rotatingKeyring);
+  assert.equal(newEnvelope.keyId, "current");
+  assert.equal(shouldRotateChannelCredentials(newEnvelope, rotatingKeyring), false);
+});
+
+test("keyring rejects malformed and missing primary keys", () => {
+  assert.throws(() => parseChannelCredentialKeyring("{}", "current"), ChannelCredentialError);
+  assert.throws(
+    () => parseChannelCredentialKeyring(JSON.stringify({ old: key(1) }), "current"),
+    ChannelCredentialError,
+  );
+});

--- a/apps/api/src/channel-credentials.ts
+++ b/apps/api/src/channel-credentials.ts
@@ -1,0 +1,180 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import type { UserChannelCredentialEnvelope } from "@cohub/db";
+
+const ALGORITHM = "aes-256-gcm";
+const NONCE_LENGTH = 12;
+const KEY_ID_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
+const BASE64URL_KEY_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+
+export type ChannelCredentialContext = {
+  channelId: string;
+  userUuid: string;
+  provider: string;
+};
+
+export type ChannelCredentialKeyring = {
+  primaryKeyId: string;
+  keys: ReadonlyMap<string, Buffer>;
+};
+
+export class ChannelCredentialError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ChannelCredentialError";
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const decodeKey = (keyId: string, encoded: unknown) => {
+  if (typeof encoded !== "string" || !BASE64URL_KEY_PATTERN.test(encoded)) {
+    throw new ChannelCredentialError(`Channel credential key ${keyId} must be an unpadded base64url 32-byte key`);
+  }
+  const key = Buffer.from(encoded, "base64url");
+  if (key.length !== 32) {
+    throw new ChannelCredentialError(`Channel credential key ${keyId} must decode to 32 bytes`);
+  }
+  return key;
+};
+
+export const parseChannelCredentialKeyring = (
+  keysJson: string,
+  primaryKeyId: string,
+): ChannelCredentialKeyring => {
+  const normalizedPrimaryKeyId = primaryKeyId.trim();
+  if (!KEY_ID_PATTERN.test(normalizedPrimaryKeyId)) {
+    throw new ChannelCredentialError("CHANNEL_CREDENTIAL_PRIMARY_KEY_ID is invalid");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(keysJson);
+  } catch (cause) {
+    throw new ChannelCredentialError("CHANNEL_CREDENTIAL_KEYS must be a JSON object", { cause });
+  }
+  if (!isRecord(parsed) || Object.keys(parsed).length === 0) {
+    throw new ChannelCredentialError("CHANNEL_CREDENTIAL_KEYS must contain at least one key");
+  }
+
+  const keys = new Map<string, Buffer>();
+  for (const [keyId, encoded] of Object.entries(parsed)) {
+    if (!KEY_ID_PATTERN.test(keyId)) {
+      throw new ChannelCredentialError(`Channel credential key id ${keyId} is invalid`);
+    }
+    keys.set(keyId, decodeKey(keyId, encoded));
+  }
+  if (!keys.has(normalizedPrimaryKeyId)) {
+    throw new ChannelCredentialError("CHANNEL_CREDENTIAL_PRIMARY_KEY_ID is not present in CHANNEL_CREDENTIAL_KEYS");
+  }
+  return { primaryKeyId: normalizedPrimaryKeyId, keys };
+};
+
+let configuredKeyring: ChannelCredentialKeyring | null = null;
+
+export const getChannelCredentialKeyring = () => {
+  configuredKeyring ??= parseChannelCredentialKeyring(
+    process.env.CHANNEL_CREDENTIAL_KEYS ?? "",
+    process.env.CHANNEL_CREDENTIAL_PRIMARY_KEY_ID ?? "",
+  );
+  return configuredKeyring;
+};
+
+const buildAdditionalAuthenticatedData = (context: ChannelCredentialContext) =>
+  Buffer.from(
+    ["cohub", "user-channel-credentials", "v1", context.channelId, context.userUuid, context.provider].join("\0"),
+    "utf8",
+  );
+
+const parseEnvelope = (value: unknown): UserChannelCredentialEnvelope => {
+  if (
+    !isRecord(value)
+    || value.version !== 1
+    || value.algorithm !== ALGORITHM
+    || typeof value.keyId !== "string"
+    || !KEY_ID_PATTERN.test(value.keyId)
+    || typeof value.nonce !== "string"
+    || typeof value.authTag !== "string"
+    || typeof value.ciphertext !== "string"
+  ) {
+    throw new ChannelCredentialError("Channel credential envelope is invalid");
+  }
+  return {
+    version: 1,
+    keyId: value.keyId,
+    algorithm: ALGORITHM,
+    nonce: value.nonce,
+    authTag: value.authTag,
+    ciphertext: value.ciphertext,
+  };
+};
+
+export const encryptChannelCredentials = (
+  credentials: Record<string, unknown>,
+  context: ChannelCredentialContext,
+  keyring: ChannelCredentialKeyring = getChannelCredentialKeyring(),
+): UserChannelCredentialEnvelope => {
+  const key = keyring.keys.get(keyring.primaryKeyId);
+  if (!key) throw new ChannelCredentialError(`Channel credential key ${keyring.primaryKeyId} is unavailable`);
+
+  const nonce = randomBytes(NONCE_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, nonce);
+  cipher.setAAD(buildAdditionalAuthenticatedData(context));
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(credentials), "utf8"),
+    cipher.final(),
+  ]);
+
+  return {
+    version: 1,
+    keyId: keyring.primaryKeyId,
+    algorithm: ALGORITHM,
+    nonce: nonce.toString("base64url"),
+    authTag: cipher.getAuthTag().toString("base64url"),
+    ciphertext: ciphertext.toString("base64url"),
+  };
+};
+
+export const decryptChannelCredentials = (
+  value: unknown,
+  context: ChannelCredentialContext,
+  keyring: ChannelCredentialKeyring = getChannelCredentialKeyring(),
+): Record<string, unknown> => {
+  const envelope = parseEnvelope(value);
+  const key = keyring.keys.get(envelope.keyId);
+  if (!key) throw new ChannelCredentialError(`Channel credential key ${envelope.keyId} is unavailable`);
+
+  try {
+    const decipher = createDecipheriv(ALGORITHM, key, Buffer.from(envelope.nonce, "base64url"));
+    decipher.setAAD(buildAdditionalAuthenticatedData(context));
+    decipher.setAuthTag(Buffer.from(envelope.authTag, "base64url"));
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(envelope.ciphertext, "base64url")),
+      decipher.final(),
+    ]).toString("utf8");
+    const credentials: unknown = JSON.parse(plaintext);
+    if (!isRecord(credentials)) throw new Error("credential payload is not an object");
+    return credentials;
+  } catch (cause) {
+    throw new ChannelCredentialError("Channel credential envelope could not be decrypted", { cause });
+  }
+};
+
+export const resolveChannelCredentials = (
+  channel: ChannelCredentialContext & {
+    credentials: unknown;
+    credentialEnvelope: unknown;
+  },
+  keyring: ChannelCredentialKeyring = getChannelCredentialKeyring(),
+) => {
+  if (channel.credentialEnvelope !== null && channel.credentialEnvelope !== undefined) {
+    return decryptChannelCredentials(channel.credentialEnvelope, channel, keyring);
+  }
+  if (isRecord(channel.credentials)) return channel.credentials;
+  throw new ChannelCredentialError(`Channel ${channel.channelId} has no readable credentials`);
+};
+
+export const shouldRotateChannelCredentials = (
+  value: unknown,
+  keyring: ChannelCredentialKeyring = getChannelCredentialKeyring(),
+) => parseEnvelope(value).keyId !== keyring.primaryKeyId;

--- a/apps/api/src/channels.ts
+++ b/apps/api/src/channels.ts
@@ -21,6 +21,7 @@ import { buildSessionSourceChannel } from "./lib/session-source-channel.js";
 import { assignSessionChannelSystemLabel } from "@cohub/core/labels/session-channel";
 import { assignSessionSourceSystemLabel } from "@cohub/core/labels/session-source";
 import { dispatchLabelAssignmentsUpdated } from "./realtime-events.js";
+import { resolveChannelCredentials } from "./channel-credentials.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -190,6 +191,48 @@ export async function getSpaceChannelRecord(spaceChannelId: string) {
   return channel ?? null;
 }
 
+export type GatewayChannelCredentialResolution =
+  | { kind: "not_found" }
+  | { kind: "revision_mismatch"; credentialRevision: number }
+  | {
+      kind: "ok";
+      provider: string;
+      credentials: Record<string, unknown>;
+      credentialRevision: number;
+    };
+
+export async function resolveGatewayChannelCredentials(
+  spaceChannelId: string,
+  expectedCredentialRevision: number,
+): Promise<GatewayChannelCredentialResolution> {
+  const [row] = await db
+    .select({
+      channelId: userChannels.id,
+      userUuid: userChannels.userUuid,
+      provider: userChannels.provider,
+      status: userChannels.status,
+      credentials: userChannels.credentials,
+      credentialEnvelope: userChannels.credentialEnvelope,
+      credentialRevision: userChannels.credentialRevision,
+    })
+    .from(spaceChannels)
+    .innerJoin(userChannels, eq(userChannels.id, spaceChannels.channelId))
+    .where(eq(spaceChannels.id, spaceChannelId))
+    .limit(1);
+
+  if (row?.status !== "active") return { kind: "not_found" };
+  if (row.credentialRevision !== expectedCredentialRevision) {
+    return { kind: "revision_mismatch", credentialRevision: row.credentialRevision };
+  }
+
+  return {
+    kind: "ok",
+    provider: row.provider,
+    credentials: resolveChannelCredentials(row),
+    credentialRevision: row.credentialRevision,
+  };
+}
+
 export async function bindSpaceChannelsToGateway(spaceId: string) {
   const channels = await db.select().from(spaceChannels).where(eq(spaceChannels.spaceId, spaceId));
   if (channels.length === 0) return;
@@ -238,6 +281,21 @@ export async function bindAllActiveSpaceChannelsToGateway() {
   return stats;
 }
 
+export async function refreshUserChannelGatewayBindings(userChannelId: string) {
+  const [userChannel] = await db
+    .select()
+    .from(userChannels)
+    .where(eq(userChannels.id, userChannelId))
+    .limit(1);
+  if (userChannel?.status !== "active") return;
+
+  const bindings = await db
+    .select()
+    .from(spaceChannels)
+    .where(eq(spaceChannels.channelId, userChannelId));
+  for (const binding of bindings) await bindSingleChannelToGateway(binding, userChannel);
+}
+
 async function bindSingleChannelToGateway(spaceChannel: typeof spaceChannels.$inferSelect, userChannel: typeof userChannels.$inferSelect | undefined) {
   if (userChannel?.status !== "active") return;
 
@@ -266,7 +324,7 @@ async function bindSingleChannelToGateway(spaceChannel: typeof spaceChannels.$in
     channelId: spaceChannel.id,
     spaceId: spaceChannel.spaceId,
     provider: userChannel.provider,
-    credentials: userChannel.credentials,
+    credentialRevision: userChannel.credentialRevision,
   });
 
   const pipeline = redisCommandClient.multi()

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,4 +1,5 @@
 import { resolveLogtoEndpoint } from "@cohub/identity";
+import { parseChannelCredentialKeyring } from "./channel-credentials.js";
 
 export type AppConfig = {
   logtoEndpoint: string;
@@ -10,11 +11,14 @@ export type AppConfig = {
   talesofaiBillingAdminApiKey?: string;
   env: "dev" | "prod";
   appEncryptionKey: string;
+  channelCredentialKeys: string;
+  channelCredentialPrimaryKeyId: string;
   sandboxImage: string;
   sandboxNodeSelector: Record<string, string>;
   sandboxTolerations: SandboxToleration[];
   bullmqRedisUrl: string;
   workerSecret: string;
+  gatewayInternalSecret: string;
   spaceStorageRoot: string;
   spaceStoragePvc: string;
   checkpointCachePvc: string;
@@ -119,6 +123,7 @@ const parseSandboxTolerations = (value: string | undefined): SandboxToleration[]
 
 export const config: AppConfig = {
   workerSecret: process.env.WORKER_SECRET ?? "",
+  gatewayInternalSecret: process.env.GATEWAY_INTERNAL_SECRET ?? "",
   logtoEndpoint: resolveLogtoEndpoint({ endpoint: process.env.LOGTO_ENDPOINT, env }),
   webOrigin: process.env.WEB_ORIGIN,
   redisUrl: process.env.REDIS_URL ?? "redis://localhost:6379",
@@ -128,6 +133,8 @@ export const config: AppConfig = {
   talesofaiBillingAdminApiKey: process.env.TALESOFAI_BILLING_ADMIN_API_KEY,
   env,
   appEncryptionKey: process.env.APP_ENCRYPTION_KEY ?? "",
+  channelCredentialKeys: process.env.CHANNEL_CREDENTIAL_KEYS ?? "",
+  channelCredentialPrimaryKeyId: process.env.CHANNEL_CREDENTIAL_PRIMARY_KEY_ID ?? "",
   sandboxImage:
     process.env.SANDBOX_IMAGE ?? getDefaultSandboxImage(env),
   sandboxNodeSelector: parseSandboxNodeSelector(process.env.SANDBOX_NODE_SELECTOR),
@@ -175,8 +182,21 @@ export const assertRequiredConfig = () => {
   if (!config.appEncryptionKey) {
     throw new Error("Missing required env: APP_ENCRYPTION_KEY");
   }
+  if (!config.channelCredentialKeys) {
+    throw new Error("Missing required env: CHANNEL_CREDENTIAL_KEYS");
+  }
+  if (!config.channelCredentialPrimaryKeyId) {
+    throw new Error("Missing required env: CHANNEL_CREDENTIAL_PRIMARY_KEY_ID");
+  }
+  parseChannelCredentialKeyring(
+    config.channelCredentialKeys,
+    config.channelCredentialPrimaryKeyId,
+  );
   if (!config.workerSecret) {
     throw new Error("Missing required env: WORKER_SECRET");
+  }
+  if (!config.gatewayInternalSecret) {
+    throw new Error("Missing required env: GATEWAY_INTERNAL_SECRET");
   }
   if (!config.bullmqRedisUrl) {
     throw new Error("Missing required env: BULLMQ_REDIS_URL");

--- a/apps/api/src/db/migrate-channel-credentials.ts
+++ b/apps/api/src/db/migrate-channel-credentials.ts
@@ -1,0 +1,203 @@
+import "dotenv/config";
+import { config as loadDotenv } from "dotenv";
+loadDotenv({ path: "apps/api/.env", override: false });
+
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as schema from "@cohub/db";
+import {
+  encryptChannelCredentials,
+  parseChannelCredentialKeyring,
+  resolveChannelCredentials,
+  shouldRotateChannelCredentials,
+  type ChannelCredentialContext,
+} from "../channel-credentials.js";
+
+const DEFAULT_BATCH_SIZE = 100;
+const MAX_BATCH_SIZE = 1_000;
+
+type MigrationMode = "backfill" | "rotate";
+
+type Args = {
+  apply: boolean;
+  batchSize: number;
+  mode: MigrationMode;
+};
+
+type ChannelRow = {
+  id: string;
+  user_uuid: string;
+  provider: string;
+  credentials: unknown;
+  credential_envelope: unknown;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const readCount = (value: unknown) => {
+  if (!isRecord(value)) return 0;
+  const count = Number(value.count ?? 0);
+  if (!Number.isSafeInteger(count) || count < 0) throw new Error("database returned an invalid count");
+  return count;
+};
+
+const parseChannelRow = (value: unknown): ChannelRow => {
+  if (
+    !isRecord(value)
+    || typeof value.id !== "string"
+    || typeof value.user_uuid !== "string"
+    || typeof value.provider !== "string"
+  ) {
+    throw new Error("database returned an invalid user channel row");
+  }
+  return {
+    id: value.id,
+    user_uuid: value.user_uuid,
+    provider: value.provider,
+    credentials: value.credentials,
+    credential_envelope: value.credential_envelope,
+  };
+};
+
+const readKeyId = (value: unknown) => {
+  if (!isRecord(value) || typeof value.key_id !== "string" || !value.key_id) {
+    throw new Error("database contains a channel credential envelope without a key id");
+  }
+  return value.key_id;
+};
+
+function parseArgs(rawArgv: string[]): Args {
+  const argv = rawArgv.filter((arg) => arg !== "--");
+  const readValue = (name: string) => {
+    const index = argv.indexOf(name);
+    return index >= 0 ? argv[index + 1] : undefined;
+  };
+  const mode = readValue("--mode") ?? "backfill";
+  if (mode !== "backfill" && mode !== "rotate") {
+    throw new Error("--mode must be backfill or rotate");
+  }
+  const rawBatchSize = Number(readValue("--batch-size") ?? DEFAULT_BATCH_SIZE);
+  if (!Number.isInteger(rawBatchSize) || rawBatchSize <= 0) {
+    throw new Error("--batch-size must be a positive integer");
+  }
+  return {
+    apply: argv.includes("--apply"),
+    batchSize: Math.min(rawBatchSize, MAX_BATCH_SIZE),
+    mode,
+  };
+}
+
+const contextFor = (row: ChannelRow): ChannelCredentialContext => ({
+  channelId: row.id,
+  userUuid: row.user_uuid,
+  provider: row.provider,
+});
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const keysJson = process.env.CHANNEL_CREDENTIAL_KEYS ?? "";
+  const primaryKeyId = process.env.CHANNEL_CREDENTIAL_PRIMARY_KEY_ID ?? "";
+  const keyring = parseChannelCredentialKeyring(keysJson, primaryKeyId);
+  const connectionString = process.env.DATABASE_URL || "postgres://postgres:postgres@localhost:5432/cohub";
+  const client = postgres(connectionString, { prepare: false, max: 1 });
+  const db = drizzle(client, { schema });
+
+  try {
+    const where = args.mode === "backfill"
+      ? sql`credential_envelope is null and credentials is not null`
+      : sql`credential_envelope is not null and credential_envelope ->> 'keyId' is distinct from ${keyring.primaryKeyId}`;
+    if (args.mode === "backfill") {
+      const invalidRows = await db.execute(sql`
+        select count(*)::int as count
+        from v2.user_channels
+        where ${where} and jsonb_typeof(credentials) is distinct from 'object'
+      `);
+      const invalidCount = readCount(invalidRows[0]);
+      if (invalidCount > 0) {
+        throw new Error(`${invalidCount} legacy channel credential rows are not JSON objects`);
+      }
+    } else {
+      const keyRows = await db.execute(sql`
+        select distinct credential_envelope ->> 'keyId' as key_id
+        from v2.user_channels
+        where ${where}
+      `);
+      const missingKeyIds = keyRows
+        .map(readKeyId)
+        .filter((keyId) => !keyring.keys.has(keyId));
+      if (missingKeyIds.length > 0) {
+        throw new Error(`CHANNEL_CREDENTIAL_KEYS is missing: ${missingKeyIds.join(", ")}`);
+      }
+    }
+    const countRows = await db.execute(sql`
+      select count(*)::int as count
+      from v2.user_channels
+      where ${where}
+    `);
+    const candidateCount = readCount(countRows[0]);
+    console.log(
+      `[channel-credentials] mode=${args.mode} candidates=${candidateCount} primaryKeyId=${keyring.primaryKeyId} apply=${args.apply}`,
+    );
+    if (!args.apply || candidateCount === 0) return;
+
+    let processed = 0;
+    for (;;) {
+      const batchCount = await db.transaction(async (tx) => {
+        const result = await tx.execute(sql`
+          select id, user_uuid, provider, credentials, credential_envelope
+          from v2.user_channels
+          where ${where}
+          order by id
+          for update skip locked
+          limit ${args.batchSize}
+        `);
+        const rows = result.map(parseChannelRow);
+
+        for (const row of rows) {
+          const context = contextFor(row);
+          const credentials = resolveChannelCredentials({
+            ...context,
+            credentials: row.credentials,
+            credentialEnvelope: row.credential_envelope,
+          }, keyring);
+          if (
+            args.mode === "rotate"
+            && !shouldRotateChannelCredentials(row.credential_envelope, keyring)
+          ) {
+            continue;
+          }
+          const envelope = encryptChannelCredentials(credentials, context, keyring);
+          await tx.execute(sql`
+            update v2.user_channels
+            set credential_envelope = ${JSON.stringify(envelope)}::jsonb,
+                credentials = null
+            where id = ${row.id}
+          `);
+        }
+        return rows.length;
+      });
+
+      processed += batchCount;
+      console.log(`[channel-credentials] processed=${processed}/${candidateCount}`);
+      if (batchCount < args.batchSize) break;
+    }
+
+    const remainingRows = await db.execute(sql`
+      select count(*)::int as count
+      from v2.user_channels
+      where ${where}
+    `);
+    const remaining = readCount(remainingRows[0]);
+    if (remaining !== 0) throw new Error(`${remaining} channel credentials still require ${args.mode}`);
+    console.log(`[channel-credentials] ${args.mode} complete`);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error) => {
+  console.error("[channel-credentials] failed", error);
+  process.exit(1);
+});

--- a/apps/api/src/db/session-message-sequence.test.ts
+++ b/apps/api/src/db/session-message-sequence.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { test } from "node:test";
+import postgres from "postgres";
+
+const databaseUrl = process.env.TEST_DATABASE_URL;
+
+test("session message sequence allocation is atomic and idempotency-safe", {
+  skip: databaseUrl ? false : "TEST_DATABASE_URL is not configured",
+}, async () => {
+  if (!databaseUrl) return;
+
+  const sql = postgres(databaseUrl, { prepare: false, max: 12 });
+  const sessionId = randomUUID();
+  const spaceId = randomUUID();
+  try {
+    await sql`
+      insert into v2.space_sessions (id, space_id, title)
+      values (${sessionId}, ${spaceId}, 'sequence test')
+    `;
+
+    const append = (idempotencyKey: string) => sql`
+      insert into v2.session_messages (
+        session_id,
+        role,
+        content,
+        sequence,
+        idempotency_key
+      ) values (
+        ${sessionId},
+        'user',
+        '[]'::jsonb,
+        v2.allocate_session_message_sequence(${sessionId}::uuid),
+        ${idempotencyKey}
+      )
+      on conflict (session_id, idempotency_key) do nothing
+      returning sequence
+    `;
+
+    await Promise.all(Array.from({ length: 32 }, (_, index) => append(`unique-${index}`)));
+    const initial = await sql<{ sequence: number }[]>`
+      select sequence
+      from v2.session_messages
+      where session_id = ${sessionId}
+      order by sequence
+    `;
+    assert.deepEqual(initial.map((row) => row.sequence), Array.from({ length: 32 }, (_, index) => index + 1));
+
+    await Promise.all(Array.from({ length: 16 }, () => append("same-request")));
+    const duplicateRows = await sql<{ sequence: number }[]>`
+      select sequence
+      from v2.session_messages
+      where session_id = ${sessionId} and idempotency_key = 'same-request'
+    `;
+    assert.equal(duplicateRows.length, 1);
+    assert.equal(duplicateRows[0]?.sequence, 33);
+
+    const [next] = await append("after-duplicates");
+    assert.equal(next?.sequence, 34);
+  } finally {
+    await sql`delete from v2.session_messages where session_id = ${sessionId}`;
+    await sql`delete from v2.space_sessions where id = ${sessionId}`;
+    await sql.end();
+  }
+});

--- a/apps/api/src/db/token-usage-hourly-integrity.test.ts
+++ b/apps/api/src/db/token-usage-hourly-integrity.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { test } from "node:test";
+import postgres from "postgres";
+
+const databaseUrl = process.env.TEST_DATABASE_URL;
+
+test("nullable token usage dimensions upsert into one hourly row", {
+  skip: databaseUrl ? false : "TEST_DATABASE_URL is not configured",
+}, async () => {
+  if (!databaseUrl) return;
+
+  const sql = postgres(databaseUrl, { prepare: false, max: 12 });
+  const spaceId = randomUUID();
+  const sessionId = randomUUID();
+  const bucketStartAt = new Date("2026-07-16T00:00:00.000Z");
+  try {
+    const upsert = () => sql`
+      insert into v2.token_usage_stats_hourly (
+        bucket_start_at,
+        user_id,
+        space_id,
+        session_id,
+        provider,
+        model,
+        request_count,
+        success_count,
+        input_tokens,
+        total_tokens,
+        cost_total
+      ) values (
+        ${bucketStartAt},
+        null,
+        ${spaceId},
+        ${sessionId},
+        null,
+        null,
+        1,
+        1,
+        2,
+        2,
+        0.25
+      )
+      on conflict (bucket_start_at, user_id, space_id, session_id, provider, model)
+      do update set
+        request_count = token_usage_stats_hourly.request_count + excluded.request_count,
+        success_count = token_usage_stats_hourly.success_count + excluded.success_count,
+        input_tokens = token_usage_stats_hourly.input_tokens + excluded.input_tokens,
+        total_tokens = token_usage_stats_hourly.total_tokens + excluded.total_tokens,
+        cost_total = token_usage_stats_hourly.cost_total + excluded.cost_total
+    `;
+
+    await Promise.all(Array.from({ length: 32 }, upsert));
+    const rows = await sql<{
+      request_count: number;
+      success_count: number;
+      input_tokens: number;
+      total_tokens: number;
+      cost_total: string;
+    }[]>`
+      select request_count, success_count, input_tokens, total_tokens, cost_total
+      from v2.token_usage_stats_hourly
+      where space_id = ${spaceId} and session_id = ${sessionId}
+    `;
+
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]?.request_count, 32);
+    assert.equal(rows[0]?.success_count, 32);
+    assert.equal(rows[0]?.input_tokens, 64);
+    assert.equal(rows[0]?.total_tokens, 64);
+    assert.equal(rows[0]?.cost_total, "8.00000000");
+  } finally {
+    await sql`
+      delete from v2.token_usage_stats_hourly
+      where space_id = ${spaceId} and session_id = ${sessionId}
+    `;
+    await sql.end();
+  }
+});

--- a/apps/api/src/lib/middleware.ts
+++ b/apps/api/src/lib/middleware.ts
@@ -142,9 +142,8 @@ export const isPrivateNetworkAddress = (value: string | null | undefined) => {
   return false;
 };
 
-export const ensureInternalRequest = (c: Context) => {
-  const secret = c.req.header("x-worker-secret");
-  const expectedSecret = config.workerSecret;
+const ensureSharedSecretRequest = (c: Context, header: string, expectedSecret: string) => {
+  const secret = c.req.header(header);
   if (!secret || !expectedSecret) return c.json({ message: "forbidden" }, 403);
   const provided = new TextEncoder().encode(secret);
   const expected = new TextEncoder().encode(expectedSecret);
@@ -153,6 +152,12 @@ export const ensureInternalRequest = (c: Context) => {
   }
   return null;
 };
+
+export const ensureInternalRequest = (c: Context) =>
+  ensureSharedSecretRequest(c, "x-worker-secret", config.workerSecret);
+
+export const ensureGatewayRequest = (c: Context) =>
+  ensureSharedSecretRequest(c, "x-gateway-secret", config.gatewayInternalSecret);
 
 // ── Space helpers ────────────────────────────────────────────────────────────
 

--- a/apps/api/src/routes/channels.route.ts
+++ b/apps/api/src/routes/channels.route.ts
@@ -2,11 +2,13 @@ import { randomUUID } from "node:crypto";
 import { Hono } from "hono";
 import { db } from "../db/index.js";
 import { userChannels, spaceChannels, spaces } from "@cohub/db";
-import { eq, and, desc, inArray } from "drizzle-orm";
+import { eq, and, desc, inArray, sql } from "drizzle-orm";
 import { useAuth, requireValidId } from "../lib/middleware.js";
 import { redisCommandClient } from "../redis.js";
 import { deleteChannelResponse, type DeleteChannelResult } from "./channel-delete.js";
 import { fallbackBoundChannelHealth, getChannelHealthMap } from "../channel-health.js";
+import { encryptChannelCredentials, resolveChannelCredentials } from "../channel-credentials.js";
+import { refreshUserChannelGatewayBindings } from "../channels.js";
 
 const WECHAT_LOGIN_BASE_URL = "https://ilinkai.weixin.qq.com";
 const WECHAT_CDN_BASE_URL = "https://novac2c.cdn.weixin.qq.com/c2c";
@@ -20,8 +22,17 @@ const WECHAT_CONFIRM_LOCK_TTL_SECONDS = 60;
 
 const router = new Hono();
 
-const serializeChannel = <T extends { credentials?: unknown }>(channel: T) => {
-  const { credentials: _credentials, ...safeChannel } = channel;
+const serializeChannel = <T extends {
+  credentials?: unknown;
+  credentialEnvelope?: unknown;
+  credentialRevision?: unknown;
+}>(channel: T) => {
+  const {
+    credentials: _credentials,
+    credentialEnvelope: _credentialEnvelope,
+    credentialRevision: _credentialRevision,
+    ...safeChannel
+  } = channel;
   return safeChannel;
 };
 
@@ -93,11 +104,24 @@ async function listUserWeChatChannels(userUuid: string) {
     .orderBy(desc(userChannels.updatedAt), desc(userChannels.createdAt));
 }
 
-function getWeChatCredentials(channel: { credentials: unknown }) {
-  return (channel.credentials && typeof channel.credentials === "object" ? channel.credentials : {}) as WeChatChannelCredentials;
+function getWeChatCredentials(channel: typeof userChannels.$inferSelect) {
+  const credentials = resolveChannelCredentials({
+    channelId: channel.id,
+    userUuid: channel.userUuid,
+    provider: channel.provider,
+    credentials: channel.credentials,
+    credentialEnvelope: channel.credentialEnvelope,
+  });
+  return {
+    token: typeof credentials.token === "string" ? credentials.token : undefined,
+    accountId: typeof credentials.accountId === "string" ? credentials.accountId : undefined,
+    userId: typeof credentials.userId === "string" ? credentials.userId : undefined,
+    baseUrl: typeof credentials.baseUrl === "string" ? credentials.baseUrl : undefined,
+    cdnBaseUrl: typeof credentials.cdnBaseUrl === "string" ? credentials.cdnBaseUrl : undefined,
+  } satisfies WeChatChannelCredentials;
 }
 
-function findWeChatChannelByAccountId<T extends { credentials: unknown }>(channels: T[], accountId: string | undefined) {
+function findWeChatChannelByAccountId(channels: Array<typeof userChannels.$inferSelect>, accountId: string | undefined) {
   const normalized = accountId?.trim();
   if (!normalized) return null;
   return channels.find((channel) => getWeChatCredentials(channel).accountId?.trim() === normalized) ?? null;
@@ -250,19 +274,38 @@ router.post("/wechat/login/wait", async (c) => {
     };
     const existingChannel = findWeChatChannelByAccountId(await listUserWeChatChannels(user.uuid), status.ilink_bot_id);
     if (existingChannel) {
+      const credentialEnvelope = encryptChannelCredentials(credentials, {
+        channelId: existingChannel.id,
+        userUuid: existingChannel.userUuid,
+        provider: existingChannel.provider,
+      });
       const [channel] = await db.update(userChannels)
-        .set({ credentials, status: "active", updatedAt: new Date() })
+        .set({
+          credentials: null,
+          credentialEnvelope,
+          credentialRevision: sql`${userChannels.credentialRevision} + 1`,
+          status: "active",
+          updatedAt: new Date(),
+        })
         .where(and(eq(userChannels.id, existingChannel.id), eq(userChannels.userUuid, user.uuid)))
         .returning();
+      if (channel) await refreshUserChannelGatewayBindings(channel.id);
       await redisCommandClient.del(wechatLoginKey(sessionKey));
       return c.json({ connected: true, alreadyConnected: true, message: "WeChat is already connected.", channel: channel ? serializeChannel(channel) : null });
     }
 
+    const channelId = randomUUID();
     const [channel] = await db.insert(userChannels).values({
+      id: channelId,
       userUuid: user.uuid,
       provider: "wechat",
       name: state.name,
-      credentials,
+      credentials: null,
+      credentialEnvelope: encryptChannelCredentials(credentials, {
+        channelId,
+        userUuid: user.uuid,
+        provider: "wechat",
+      }),
       status: "active",
     }).returning();
 
@@ -334,13 +377,20 @@ router.post("/", async (c) => {
     return c.json({ message: "Create WeChat channels through the QR login flow." }, 400);
   }
 
+  const channelId = randomUUID();
   const [channel] = await db
     .insert(userChannels)
     .values({
+      id: channelId,
       userUuid: user.uuid,
       provider,
       name,
-      credentials: body.credentials,
+      credentials: null,
+      credentialEnvelope: encryptChannelCredentials(body.credentials, {
+        channelId,
+        userUuid: user.uuid,
+        provider,
+      }),
       status: "active",
     })
     .returning();

--- a/apps/api/src/routes/internal/canvas.route.ts
+++ b/apps/api/src/routes/internal/canvas.route.ts
@@ -14,12 +14,12 @@ router.post("/:spaceId/:documentId/tx", async (c) => {
   const body = await c.req.json<{
     actorId?: string;
     txId?: string;
-    baseVersion?: number | null;
+    baseVersion?: number;
     clientId?: string | null;
     undoGroupId?: string | null;
     ops?: CanvasSemanticOp[];
   }>().catch(() => null);
-  if (!body?.actorId || !body.txId || !Array.isArray(body.ops)) return c.json({ message: "invalid canvas transaction" }, 400);
+  if (!body?.actorId || !body.txId || typeof body.baseVersion !== "number" || !Number.isInteger(body.baseVersion) || !Array.isArray(body.ops)) return c.json({ message: "invalid canvas transaction" }, 400);
   try {
     const actor = { uuid: body.actorId } as AuthUser;
     if (!(await hasPermission(actor, "file.edit", { spaceId }))) return c.json({ message: "forbidden" }, 403);
@@ -28,7 +28,7 @@ router.post("/:spaceId/:documentId/tx", async (c) => {
       documentId,
       actorId: body.actorId,
       txId: body.txId,
-      baseVersion: body.baseVersion ?? null,
+      baseVersion: body.baseVersion,
       clientId: body.clientId ?? null,
       undoGroupId: body.undoGroupId ?? null,
       ops: body.ops,
@@ -37,7 +37,11 @@ router.post("/:spaceId/:documentId/tx", async (c) => {
   } catch (error) {
     const status = typeof (error as { status?: unknown })?.status === "number" ? (error as { status: number }).status : 500;
     const message = error instanceof Error ? error.message : "Canvas operation failed";
-    return c.json({ message }, status as never);
+    const code = typeof (error as { code?: unknown })?.code === "string" ? (error as { code: string }).code : "canvas_error";
+    const currentVersion = typeof (error as { currentVersion?: unknown })?.currentVersion === "number"
+      ? (error as { currentVersion: number }).currentVersion
+      : undefined;
+    return c.json({ message, code, currentVersion }, status as never);
   }
 });
 

--- a/apps/api/src/routes/internal/gateway.route.ts
+++ b/apps/api/src/routes/internal/gateway.route.ts
@@ -6,9 +6,19 @@ import { parseRealtimeRoom } from "@cohub/protocol/realtime";
 import { dispatchSpacePresenceUpdated } from "../../realtime-events.js";
 import { getSpacePresenceSnapshot } from "../../space-presence.js";
 import { Hono } from "hono";
-import { bindAllActiveSpaceChannelsToGateway, handleInboundEvent, resolveChannelInboundForEventWithLock } from "../../channels.js";
+import {
+  bindAllActiveSpaceChannelsToGateway,
+  handleInboundEvent,
+  resolveChannelInboundForEventWithLock,
+  resolveGatewayChannelCredentials,
+} from "../../channels.js";
 import { hasPermission } from "../../permissions.js";
-import { ensureInternalRequest, getOptionalAuth, requireValidId } from "../../lib/middleware.js";
+import {
+  ensureGatewayRequest,
+  ensureInternalRequest,
+  getOptionalAuth,
+  requireValidId,
+} from "../../lib/middleware.js";
 import { getSpaceById } from "../../space-sessions.js";
 import { getSpaceSandboxBySpaceId, updateSpaceSandbox } from "../../space-sandboxes.js";
 import { normalizeSandboxLifecycleStatus, normalizeSandboxRuntimeStatus } from "@cohub/sandbox-controller";
@@ -35,7 +45,7 @@ import {
   type SpaceUploadManifestEntry,
 } from "../../space-upload-storage.js";
 import { enqueueSandboxUploadFilesJob } from "../../sandbox-bash-queue.js";
-import { config } from "../../config.js";
+import { redisCommandClient } from "../../redis.js";
 
 const logger = createLogger({ serviceName: "cohub-api" });
 const tracer = getTracer("cohub-api");
@@ -89,6 +99,35 @@ router.post("/reconcile-channels", async (c) => {
   } finally {
     span.end();
   }
+});
+
+router.post("/channels/:id/credentials", async (c) => {
+  const forbidden = ensureGatewayRequest(c);
+  if (forbidden) return forbidden;
+
+  const spaceChannelId = c.req.param("id");
+  if (!requireValidId(spaceChannelId)) return c.json({ message: "channel not found" }, 404);
+  const gatewayNodeId = c.req.header("x-gateway-node-id")?.trim();
+  if (!gatewayNodeId || gatewayNodeId.length > 255) return c.json({ message: "forbidden" }, 403);
+  const routedNodeId = await redisCommandClient.hget("gateway:channel_routing", spaceChannelId);
+  if (routedNodeId !== gatewayNodeId) return c.json({ message: "forbidden" }, 403);
+  const body = await c.req.json<{ credentialRevision?: number }>().catch(() => null);
+  const credentialRevision = body?.credentialRevision;
+  if (typeof credentialRevision !== "number" || !Number.isInteger(credentialRevision) || credentialRevision <= 0) {
+    return c.json({ message: "credentialRevision must be a positive integer" }, 400);
+  }
+
+  const result = await resolveGatewayChannelCredentials(spaceChannelId, credentialRevision);
+  c.header("cache-control", "no-store");
+  c.header("pragma", "no-cache");
+  if (result.kind === "not_found") return c.json({ message: "channel not found" }, 404);
+  if (result.kind === "revision_mismatch") {
+    return c.json({
+      message: "channel credential revision changed",
+      credentialRevision: result.credentialRevision,
+    }, 409);
+  }
+  return c.json(result);
 });
 
 router.post("/space-presence-updated", async (c) => {

--- a/apps/api/src/routes/spaces/canvas.route.ts
+++ b/apps/api/src/routes/spaces/canvas.route.ts
@@ -1,6 +1,6 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, gt, isNull } from "drizzle-orm";
 import { Hono } from "hono";
-import { canvasDocuments, canvasNodes } from "@cohub/db";
+import { canvasDocuments, canvasNodes, canvasUpdates } from "@cohub/db";
 import { applyCanvasTransaction, CanvasServiceError, normalizeNodes, type CanvasNodeInput, type CanvasSemanticOp } from "../../canvas-service.js";
 import { db } from "../../db/index.js";
 import { authzDenied, getOptionalAuth, requireValidId, useAuth } from "../../lib/middleware.js";
@@ -21,9 +21,11 @@ const serializeManifest = (input: { documentId: string; title: string }) => `${J
 }, null, 2)}\n`;
 
 function canvasErrorResponse(error: unknown) {
-  if (error instanceof CanvasServiceError) return { status: error.status, message: error.message };
-  if (error instanceof SpaceFsError) return { status: error.status, message: error.message };
-  return { status: 500, message: "Canvas operation failed" };
+  if (error instanceof CanvasServiceError) {
+    return { status: error.status, message: error.message, code: error.code, currentVersion: error.currentVersion };
+  }
+  if (error instanceof SpaceFsError) return { status: error.status, message: error.message, code: "space_fs_error" };
+  return { status: 500, message: "Canvas operation failed", code: "canvas_error" };
 }
 
 async function loadDocumentForSpace(spaceId: string, documentId: string) {
@@ -140,6 +142,39 @@ router.get("/:documentId/bootstrap", async (c) => {
   return c.json({ document, nodes });
 });
 
+router.get("/:documentId/updates", async (c) => {
+  const user = getOptionalAuth(c);
+  const spaceId = c.req.param("id");
+  const documentId = c.req.param("documentId");
+  if (!spaceId || !documentId || !requireValidId(spaceId) || !requireValidId(documentId)) return c.json({ message: "canvas not found" }, 404);
+  if (!(await hasPermission(user, "file.view", { spaceId }))) return authzDenied(c);
+  const afterVersion = Number(c.req.query("afterVersion") ?? "0");
+  const requestedLimit = Number(c.req.query("limit") ?? "100");
+  if (!Number.isInteger(afterVersion) || afterVersion < 0) return c.json({ message: "afterVersion must be a non-negative integer" }, 400);
+  const limit = Number.isInteger(requestedLimit) ? Math.min(Math.max(requestedLimit, 1), 500) : 100;
+  const document = await loadDocumentForSpace(spaceId, documentId);
+  if (!document) return c.json({ message: "canvas not found" }, 404);
+  const updates = await db.select({
+    txId: canvasUpdates.txId,
+    baseVersion: canvasUpdates.baseVersion,
+    version: canvasUpdates.version,
+    actorId: canvasUpdates.actorId,
+    clientId: canvasUpdates.clientId,
+    payload: canvasUpdates.payload,
+    createdAt: canvasUpdates.createdAt,
+  }).from(canvasUpdates)
+    .where(and(eq(canvasUpdates.documentId, documentId), gt(canvasUpdates.version, afterVersion)))
+    .orderBy(canvasUpdates.version)
+    .limit(limit);
+  const lastVersion = updates.at(-1)?.version;
+  return c.json({
+    documentVersion: document.version,
+    updates,
+    hasMore: updates.length === limit && lastVersion !== document.version,
+    requiresBootstrap: afterVersion < document.version && updates[0]?.version !== afterVersion + 1,
+  });
+});
+
 router.post("/:documentId/ops", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
@@ -149,14 +184,14 @@ router.post("/:documentId/ops", async (c) => {
   if (!(await hasPermission(user, "file.edit", { spaceId }))) return authzDenied(c);
 
   const body = await c.req.json<{ txId?: string; baseVersion?: number; clientId?: string; undoGroupId?: string; ops?: CanvasSemanticOp[] }>().catch(() => null);
-  if (!Array.isArray(body?.ops)) return c.json({ message: "ops are required" }, 400);
+  if (!body?.txId || typeof body.baseVersion !== "number" || !Number.isInteger(body.baseVersion) || !Array.isArray(body.ops)) return c.json({ message: "txId, baseVersion and ops are required" }, 400);
   try {
     const result = await applyCanvasTransaction({
       spaceId,
       documentId,
       actorId: user.uuid,
-      txId: body.txId || crypto.randomUUID(),
-      baseVersion: body.baseVersion ?? null,
+      txId: body.txId,
+      baseVersion: body.baseVersion,
       clientId: body.clientId ?? null,
       undoGroupId: body.undoGroupId ?? null,
       ops: body.ops,
@@ -164,7 +199,7 @@ router.post("/:documentId/ops", async (c) => {
     return c.json(result);
   } catch (error) {
     const response = canvasErrorResponse(error);
-    return c.json({ message: response.message }, response.status as never);
+    return c.json({ message: response.message, code: response.code, currentVersion: response.currentVersion }, response.status as never);
   }
 });
 

--- a/apps/api/src/routes/spaces/spaces.route.ts
+++ b/apps/api/src/routes/spaces/spaces.route.ts
@@ -2150,7 +2150,12 @@ router.get("/:id/channels", async (c) => {
     channels.map((channel) => {
       const userChannel = userChannelById.get(channel.channelId) ?? null;
       const safeChannel = userChannel
-        ? (({ credentials: _credentials, ...rest }) => rest)(userChannel)
+        ? (({
+            credentials: _credentials,
+            credentialEnvelope: _credentialEnvelope,
+            credentialRevision: _credentialRevision,
+            ...rest
+          }) => rest)(userChannel)
         : null;
       return {
         ...channel,

--- a/apps/api/src/space-sessions.ts
+++ b/apps/api/src/space-sessions.ts
@@ -11,6 +11,7 @@ import { assignSessionParticipantSystemLabels } from "@cohub/core/labels/session
 import { initializeSessionParticipantsMeta, readSessionParticipantUserUuids } from "@cohub/core/sessions";
 import { db } from "./db/index.js";
 import {
+  allocateSessionMessageSequence,
   sessionMessages,
   sessionTurnSegments,
   sessionTurns,
@@ -427,11 +428,6 @@ export const listUserSessions = async (
   return mergeUserSessionListBranches([creatorRows, participantRows], limit);
 };
 
-const getNextSessionSequence = async (sessionId: string) => {
-  const [row] = await db.select({ max: sql<number>`coalesce(max(${sessionMessages.sequence}), 0)::int` }).from(sessionMessages).where(eq(sessionMessages.sessionId, sessionId));
-  return (row?.max ?? 0) + 1;
-};
-
 const updateSessionAfterAppend = async (session: Pick<typeof spaceSessions.$inferSelect, "id" | "spaceId">, message: typeof sessionMessages.$inferSelect) => {
   const activityAt = message.createdAt ?? new Date();
   await db.update(spaceSessions).set({
@@ -474,7 +470,6 @@ export const persistMessageNode = async (input: PersistMessageInput & { message:
     if (!previous) throw new Error("Previous message not found");
   }
 
-  const sequence = await getNextSessionSequence(input.sessionId);
   const content = sanitizeContentBlocksForPostgresJson(input.message.content);
   const text = deriveMessagePreviewText({ content }) || null;
   const messageRole = input.message.role ?? "assistant";
@@ -500,7 +495,7 @@ export const persistMessageNode = async (input: PersistMessageInput & { message:
   const startedAt = toDateOrNull(input.message.startedAt) ?? completedAt;
   const durationMs = normalizeDurationMs(input.message.durationMs, durationBetweenMs(startedAt, completedAt));
 
-  const [messageNode] = await db.insert(sessionMessages).values({
+  const [insertedMessage] = await db.insert(sessionMessages).values({
     id: input.message.id?.trim() || undefined,
     sessionId: input.sessionId,
     role: messageRole,
@@ -514,7 +509,7 @@ export const persistMessageNode = async (input: PersistMessageInput & { message:
       providerResponseId: ((input.message.meta as Record<string, unknown> | null)?.responseId as string | undefined) ?? null,
     }),
     idempotencyKey: input.idempotencyKey,
-    sequence,
+    sequence: allocateSessionMessageSequence(input.sessionId),
     provider: input.message.provider ?? null,
     model: input.message.model ?? null,
     stopReason: input.message.stopReason ?? null,
@@ -523,8 +518,24 @@ export const persistMessageNode = async (input: PersistMessageInput & { message:
     startedAt,
     completedAt,
     durationMs,
+  }).onConflictDoNothing({
+    target: [sessionMessages.sessionId, sessionMessages.idempotencyKey],
   }).returning();
-  if (!messageNode) throw new Error("Failed to persist message");
+  if (!insertedMessage) {
+    const [existingAfterConflict] = await db.select().from(sessionMessages).where(and(
+      eq(sessionMessages.sessionId, input.sessionId),
+      eq(sessionMessages.idempotencyKey, input.idempotencyKey),
+    )).limit(1);
+    if (!existingAfterConflict) throw new Error("Failed to resolve idempotent message conflict");
+    if (existingAfterConflict.role === "assistant") {
+      await enqueueSessionMessagePostprocess({
+        sessionId: input.sessionId,
+        messageId: existingAfterConflict.id,
+      });
+    }
+    return existingAfterConflict;
+  }
+  const messageNode = insertedMessage;
 
   if (messageRole === "user" && !session.title?.trim()) {
     const titleText = (text ?? extractPlainText(content)).replace(/\s+/g, " ").replace(/^[:\-\s]+/, "").trim().slice(0, 60);

--- a/apps/gateway/src/api-client.ts
+++ b/apps/gateway/src/api-client.ts
@@ -165,11 +165,11 @@ export const submitCanvasTransaction = async (input: {
   spaceId: string;
   documentId: string;
   txId: string;
-  baseVersion?: number | null;
+  baseVersion: number;
   clientId?: string | null;
   undoGroupId?: string | null;
   ops: Array<Record<string, unknown>>;
-}): Promise<{ document: { version: number }; nodes: unknown[] }> => {
+}): Promise<{ document: { version: number }; transaction: { txId: string; version: number; replayed: boolean } }> => {
   const response = await fetch(`${gatewayConfig.apiBaseUrl}/internal/canvas/${input.spaceId}/${input.documentId}/tx`, {
     method: "POST",
     headers: {
@@ -180,22 +180,49 @@ export const submitCanvasTransaction = async (input: {
     body: JSON.stringify({
       actorId: input.userId,
       txId: input.txId,
-      baseVersion: input.baseVersion ?? null,
+      baseVersion: input.baseVersion,
       clientId: input.clientId ?? null,
       undoGroupId: input.undoGroupId ?? null,
       ops: input.ops,
     }),
   });
   if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    throw new Error(`Internal canvas transaction failed ${response.status}: ${text}`);
+    const data = await parseJson<{ message?: string; code?: string; currentVersion?: number }>(response);
+    throw new InternalCanvasTransactionError(
+      data?.message || `Internal canvas transaction failed ${response.status}`,
+      response.status,
+      data?.code,
+      data?.currentVersion,
+    );
   }
-  const data = await parseJson<{ document?: { version?: number }; nodes?: unknown[] }>(response);
-  if (!data?.document || typeof data.document.version !== "number" || !Array.isArray(data.nodes)) {
+  const data = await parseJson<{
+    document?: { version?: number };
+    transaction?: { txId?: string; version?: number; replayed?: boolean };
+  }>(response);
+  if (!data?.document || typeof data.document.version !== "number" || !data.transaction || typeof data.transaction.version !== "number" || typeof data.transaction.txId !== "string") {
     throw new Error("Internal canvas transaction returned an invalid response");
   }
-  return { document: { version: data.document.version }, nodes: data.nodes };
+  return {
+    document: { version: data.document.version },
+    transaction: {
+      txId: data.transaction.txId,
+      version: data.transaction.version,
+      replayed: data.transaction.replayed === true,
+    },
+  };
 };
+
+export class InternalCanvasTransactionError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code?: string,
+    readonly currentVersion?: number,
+  ) {
+    super(message);
+    this.name = "InternalCanvasTransactionError";
+  }
+}
 
 /** Carries a standard billing error body from the internal prompt API. */
 export class InternalPromptError extends Error {

--- a/apps/gateway/src/api-client.ts
+++ b/apps/gateway/src/api-client.ts
@@ -118,6 +118,53 @@ export const requestGatewayChannelReconcile = async (): Promise<{ stats: unknown
   return { stats: data.stats };
 };
 
+export type GatewayChannelCredentials = {
+  provider: string;
+  credentials: Record<string, unknown>;
+  credentialRevision: number;
+};
+
+export const requestGatewayChannelCredentials = async (input: {
+  channelId: string;
+  credentialRevision: number;
+  gatewayNodeId: string;
+}): Promise<GatewayChannelCredentials> => {
+  const response = await fetch(
+    `${gatewayConfig.apiBaseUrl}/internal/gateway/channels/${encodeURIComponent(input.channelId)}/credentials`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-gateway-secret": gatewayConfig.gatewayInternalSecret,
+        "x-gateway-node-id": input.gatewayNodeId,
+        ...buildTraceHeaders(),
+      },
+      body: JSON.stringify({ credentialRevision: input.credentialRevision }),
+    },
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Gateway channel credentials request failed ${response.status}: ${text}`);
+  }
+  const data = await parseJson<unknown>(response);
+  if (
+    !isRecord(data)
+    || data.kind !== "ok"
+    || typeof data.provider !== "string"
+    || !isRecord(data.credentials)
+    || typeof data.credentialRevision !== "number"
+    || !Number.isInteger(data.credentialRevision)
+    || data.credentialRevision <= 0
+  ) {
+    throw new Error("Gateway channel credentials response is invalid");
+  }
+  return {
+    provider: data.provider,
+    credentials: data.credentials,
+    credentialRevision: data.credentialRevision,
+  };
+};
+
 export const notifySpacePresenceUpdated = async (spaceId: string): Promise<void> => {
   const response = await fetch(`${gatewayConfig.apiBaseUrl}/internal/gateway/space-presence-updated`, {
     method: "POST",

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -7,6 +7,7 @@ const env = process.env.ENV === "prod" ? "prod" : "dev";
 export const gatewayConfig = {
   apiBaseUrl: normalizeBaseUrl(process.env.API_BASE_URL ?? "http://localhost:8787"),
   workerSecret: process.env.WORKER_SECRET ?? "",
+  gatewayInternalSecret: process.env.GATEWAY_INTERNAL_SECRET ?? "",
   logtoEndpoint: resolveLogtoEndpoint({ endpoint: process.env.LOGTO_ENDPOINT, env }),
   port: Number(process.env.PORT ?? 8788),
   // Pod IP used to build the cluster-internal relay endpoint advertised to
@@ -18,6 +19,11 @@ export const gatewayConfig = {
     resourceId: "volc.seedasr.sauc.duration",
     url: "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async",
   },
+};
+
+export const assertGatewayConfig = () => {
+  if (!gatewayConfig.workerSecret) throw new Error("Missing required env: WORKER_SECRET");
+  if (!gatewayConfig.gatewayInternalSecret) throw new Error("Missing required env: GATEWAY_INTERNAL_SECRET");
 };
 
 export type GatewayAuthUser = {

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -31,7 +31,7 @@ import {
   wsClientEventSchema,
 } from "@cohub/protocol/realtime";
 import { getOrCreateRequestId } from "@cohub/infra/tracing";
-import { authenticateRealtimeToken, authorizeRealtimeRooms, notifySpacePresenceUpdated, requestGatewayChannelReconcile, submitCanvasTransaction, submitInternalSessionPrompt, InternalPromptError, type RealtimeAuthResult } from "./api-client.js";
+import { authenticateRealtimeToken, authorizeRealtimeRooms, notifySpacePresenceUpdated, requestGatewayChannelReconcile, submitCanvasTransaction, submitInternalSessionPrompt, InternalCanvasTransactionError, InternalPromptError, type RealtimeAuthResult } from "./api-client.js";
 import { listenOutboundCommands, initOutboundConsumerGroup } from "./bus.js";
 import { summarizeRedisUrl } from "./logging.js";
 import { gatewayConfig } from "./config.js";
@@ -932,13 +932,13 @@ async function main() {
             const documentId = typeof payload.documentId === "string" ? payload.documentId : "";
             const txId = typeof payload.txId === "string" ? payload.txId : "";
             const ops = Array.isArray(payload.ops) ? payload.ops.filter((op): op is Record<string, unknown> => Boolean(op && typeof op === "object" && !Array.isArray(op))) : [];
-            if (!spaceId || !documentId || !txId || ops.length === 0) throw new WsClientInputError("invalid canvas transaction");
+            if (!spaceId || !documentId || !txId || !Number.isInteger(payload.baseVersion) || payload.baseVersion < 0 || ops.length === 0) throw new WsClientInputError("invalid canvas transaction");
             const result = await submitCanvasTransaction({
               userId: ctx.userId,
               spaceId,
               documentId,
               txId,
-              baseVersion: typeof payload.baseVersion === "number" ? payload.baseVersion : null,
+              baseVersion: payload.baseVersion,
               clientId: typeof payload.clientId === "string" ? payload.clientId : null,
               undoGroupId: typeof payload.undoGroupId === "string" ? payload.undoGroupId : null,
               ops,
@@ -949,7 +949,12 @@ async function main() {
               requestId: requestId ?? null,
               spaceId,
               sessionId: null,
-              payload: { documentId, txId, version: result.document.version },
+              payload: {
+                documentId,
+                txId,
+                version: result.document.version,
+                replayed: result.transaction.replayed,
+              },
             }));
           } catch (error) {
             if (error instanceof WsClientInputError) throw error;
@@ -964,6 +969,9 @@ async function main() {
                 documentId: typeof payload.documentId === "string" ? payload.documentId : null,
                 txId: typeof payload.txId === "string" ? payload.txId : null,
                 message: error instanceof Error ? error.message : String(error),
+                code: error instanceof InternalCanvasTransactionError ? error.code : undefined,
+                status: error instanceof InternalCanvasTransactionError ? error.status : undefined,
+                currentVersion: error instanceof InternalCanvasTransactionError ? error.currentVersion : undefined,
               },
             }));
           }

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -34,7 +34,7 @@ import { getOrCreateRequestId } from "@cohub/infra/tracing";
 import { authenticateRealtimeToken, authorizeRealtimeRooms, notifySpacePresenceUpdated, requestGatewayChannelReconcile, submitCanvasTransaction, submitInternalSessionPrompt, InternalCanvasTransactionError, InternalPromptError, type RealtimeAuthResult } from "./api-client.js";
 import { listenOutboundCommands, initOutboundConsumerGroup } from "./bus.js";
 import { summarizeRedisUrl } from "./logging.js";
-import { gatewayConfig } from "./config.js";
+import { assertGatewayConfig, gatewayConfig } from "./config.js";
 import { GatewayManager } from "./manager/index.js";
 import { markChannelDegraded, touchChannelOutbound } from "./channel-health.js";
 import { handleAsrWebSocketConnection } from "./asr/session.js";
@@ -561,6 +561,7 @@ const submitWebsocketSessionMessage = async (ctx: WsConnectionContext, requestId
 };
 
 async function main() {
+  assertGatewayConfig();
   logStartupInfo();
 
   startWsConnectionSweeper();

--- a/apps/gateway/src/manager/index.ts
+++ b/apps/gateway/src/manager/index.ts
@@ -11,17 +11,43 @@ import {
   markChannelError,
   markChannelStopped,
 } from "../channel-health.js";
+import { requestGatewayChannelCredentials } from "../api-client.js";
 
 
 const logger = createLogger({ serviceName: "cohub-gateway" });
 const GATEWAY_NODE_TTL_MS = 15_000;
 
-interface ChannelConfig {
+interface ChannelAssignment {
   provider: string;
-  credentials: Record<string, unknown>;
+  credentialRevision: number;
   spaceId?: string;
   externalChatId?: string;
 }
+
+interface ChannelConfig extends ChannelAssignment {
+  credentials: Record<string, unknown>;
+}
+
+const parseChannelAssignment = (value: unknown): ChannelAssignment => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("assignment is invalid");
+  }
+  const record = Object.fromEntries(Object.entries(value));
+  if (
+    typeof record.provider !== "string"
+    || typeof record.credentialRevision !== "number"
+    || !Number.isInteger(record.credentialRevision)
+    || record.credentialRevision <= 0
+  ) {
+    throw new Error("assignment is invalid");
+  }
+  return {
+    provider: record.provider,
+    credentialRevision: record.credentialRevision,
+    spaceId: typeof record.spaceId === "string" ? record.spaceId : undefined,
+    externalChatId: typeof record.externalChatId === "string" ? record.externalChatId : undefined,
+  };
+};
 
 type ProviderFactory = (channelId: string, credentials: Record<string, unknown>) => GatewayProvider;
 
@@ -62,6 +88,7 @@ export class GatewayManager {
 
   // 本地维持的实例集合 Map<ChannelId, ProviderInstance>
   private providers = new Map<string, GatewayProvider>();
+  private providerCredentialRevisions = new Map<string, number>();
 
   constructor(options: GatewayManagerOptions = {}) {
     // 优先使用 k8s 的 pod name (如 gateway-0)，回退到 hostname，再回退到随机生成的 id
@@ -111,6 +138,7 @@ export class GatewayManager {
       }
     }
     this.providers.clear();
+    this.providerCredentialRevisions.clear();
 
     logger.info("[Manager] Leaving task assignments intact for stable restart handoff");
 
@@ -147,10 +175,19 @@ export class GatewayManager {
       const syncStart = Date.now();
       // 获取分配给本节点的专属任务
       // 数据结构: HASH gateway:node:<nodeId>:channels
-      // Field: channelId, Value: JSON string of ChannelConfig
+      // Field: channelId, Value: JSON string of ChannelAssignment (never credentials)
       const tasksStr = await redisCommandClient.hgetall(`gateway:node:${this.nodeId}:channels`);
 
-      const expectedChannelIds = new Set(Object.keys(tasksStr));
+      const assignments = new Map<string, ChannelAssignment>();
+      for (const [channelId, assignmentJson] of Object.entries(tasksStr)) {
+        try {
+          assignments.set(channelId, parseChannelAssignment(JSON.parse(assignmentJson)));
+        } catch (error) {
+          logger.error("[Manager] Ignoring invalid channel assignment", { channelId, error });
+        }
+      }
+
+      const expectedChannelIds = new Set(assignments.keys());
       const currentChannelIds = new Set(this.providers.keys());
 
       logger.info(`[Manager] Sync tasks: expected=${expectedChannelIds.size}, current=${currentChannelIds.size}`);
@@ -162,24 +199,39 @@ export class GatewayManager {
       }
 
       // 1. 需要新增或更新的连接
-      const toAdd = Array.from(expectedChannelIds).filter(id => !currentChannelIds.has(id));
+      const toSync = Array.from(expectedChannelIds).filter((id) => {
+        const assignment = assignments.get(id);
+        return !currentChannelIds.has(id)
+          || this.providerCredentialRevisions.get(id) !== assignment?.credentialRevision;
+      });
       const toRemove = Array.from(currentChannelIds).filter(id => !expectedChannelIds.has(id));
 
-      if (toAdd.length > 0) {
-        logger.info(`[Manager] Channels to add: [${toAdd.join(", ")}]`);
+      if (toSync.length > 0) {
+        logger.info(`[Manager] Channels to start or refresh: [${toSync.join(", ")}]`);
       }
       if (toRemove.length > 0) {
         logger.info(`[Manager] Channels to remove: [${toRemove.join(", ")}]`);
       }
 
-      for (const channelId of toAdd) {
-        const configStr = tasksStr[channelId];
-        if (configStr) {
-          const config = JSON.parse(configStr);
-          this.startProvider(channelId, config);
+      for (const channelId of toSync) {
+        const assignment = assignments.get(channelId);
+        if (!assignment) continue;
+        try {
+          const resolved = await requestGatewayChannelCredentials({
+            channelId,
+            credentialRevision: assignment.credentialRevision,
+            gatewayNodeId: this.nodeId,
+          });
+          if (resolved.provider !== assignment.provider) {
+            throw new Error("channel provider changed during credential resolution");
+          }
+          if (this.providers.has(channelId)) await this.stopProvider(channelId);
+          this.startProvider(channelId, { ...assignment, ...resolved });
+        } catch (error) {
+          logger.error("[Manager] Failed to resolve channel credentials", { channelId, error });
+          void markChannelError(channelId, error, { nodeId: this.nodeId }).catch(() => undefined);
         }
       }
-      // TODO: 如果配置变了(比如 token 变了)，可能需要重启 provider
 
       // 2. 需要断开的连接 (本地有，但 Redis 里没有了)
       for (const channelId of toRemove) {
@@ -210,6 +262,7 @@ export class GatewayManager {
       }
       const provider = factory(channelId, config.credentials);
       this.providers.set(channelId, provider);
+      this.providerCredentialRevisions.set(channelId, config.credentialRevision);
       logger.info(`[Manager] Provider for ${channelId} created and added to active providers`);
     } catch (error) {
       logger.error(`[Manager] Error starting provider for ${channelId}:`, error);
@@ -228,6 +281,7 @@ export class GatewayManager {
         logger.error(`[Manager] Error destroying provider for ${channelId}:`, error);
       }
       this.providers.delete(channelId);
+      this.providerCredentialRevisions.delete(channelId);
     }
     await markChannelStopped(channelId).catch((error) => {
       logger.warn("[Manager] failed to mark channel stopped", { channelId, error });

--- a/apps/web/src/lib/cache/repositories/canvas-pending-tx-repo.ts
+++ b/apps/web/src/lib/cache/repositories/canvas-pending-tx-repo.ts
@@ -81,3 +81,16 @@ export async function markCanvasPendingTransactionAttempt(
 		updatedAt: Date.now(),
 	});
 }
+
+export async function rebaseCanvasPendingTransaction(
+	record: CanvasPendingTransactionCacheRecord,
+	baseVersion: number,
+) {
+	const rebased = {
+		...record,
+		baseVersion,
+		updatedAt: Date.now(),
+	};
+	await idbPut("canvas_pending_txs", rebased);
+	return rebased;
+}

--- a/apps/web/src/lib/canvas/canvas-document.ts
+++ b/apps/web/src/lib/canvas/canvas-document.ts
@@ -257,6 +257,22 @@ export function invertCanvasOps(ops: CanvasSemanticOp[]): CanvasSemanticOp[] {
 				inverse: op.payload,
 			};
 		}
+		if (op.type === "node.data.merge") {
+			return {
+				version: 2,
+				type: "node.data.merge",
+				payload: { nodeId: op.payload.nodeId, data: op.inverse ?? {} },
+				inverse: op.payload.data as Record<string, unknown>,
+			};
+		}
+		if (op.type === "document.meta.patch") {
+			return {
+				version: 2,
+				type: "document.meta.patch",
+				payload: { patch: op.inverse ?? {} },
+				inverse: op.payload.patch as Record<string, unknown>,
+			};
+		}
 		return {
 			type: "node.patch",
 			payload: { nodeId: op.payload.nodeId, patch: op.inverse ?? {} },
@@ -283,14 +299,23 @@ export function applyCanvasOps(
 				items = items.filter((item) => item.id !== nodeId);
 			continue;
 		}
+		if (op.type === "document.meta.patch") continue;
 		const nodeId = op.payload.nodeId;
-		const patch = op.payload.patch as Partial<CanvasNodeInput> | undefined;
+		const patch =
+			op.type === "node.data.merge"
+				? { data: op.payload.data as Record<string, unknown> }
+				: (op.payload.patch as Partial<CanvasNodeInput> | undefined);
 		if (typeof nodeId !== "string" || !patch) continue;
 		items = items.map((item, index) => {
 			if (item.id !== nodeId) return item;
+			const current = canvasItemToNode(item, index);
 			return nodeInputToItem({
-				...canvasItemToNode(item, index),
+				...current,
 				...patch,
+				data:
+					op.type === "node.data.merge"
+						? { ...current.data, ...(patch.data ?? {}) }
+						: (patch.data ?? current.data),
 				nodeId,
 			});
 		});

--- a/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
+++ b/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
@@ -1688,22 +1688,22 @@ onMount(() => {
 				documentId?: unknown;
 				version?: unknown;
 				actorId?: unknown;
+				ops?: unknown;
 			};
 			if (
 				typeof payload.documentId !== "string" ||
+				typeof payload.version !== "number" ||
+				!Array.isArray(payload.ops) ||
 				payload.documentId !== inlineCanvas?.documentId
 			)
 				return;
 			if (inlineCanvas?.saving) return;
-			void sdk
-				.space(spaceId)
-				.canvas.bootstrap(payload.documentId)
-				.then((bootstrap) => {
-					canvasPreview.applyBootstrap(payload.documentId as string, bootstrap);
-				})
+			const documentId = payload.documentId;
+			void canvasPreview
+				.applyRemoteTransaction(documentId, payload.version, payload.ops)
 				.catch((error) => {
 					canvasPreview.setError(
-						payload.documentId as string,
+						documentId,
 						error instanceof Error ? error.message : "Failed to sync canvas",
 					);
 				});

--- a/apps/web/src/lib/features/space/modules/canvas-preview-controller.svelte.ts
+++ b/apps/web/src/lib/features/space/modules/canvas-preview-controller.svelte.ts
@@ -3,9 +3,11 @@ import {
 	deleteCanvasPendingTransaction,
 	listCanvasPendingTransactions,
 	markCanvasPendingTransactionAttempt,
+	rebaseCanvasPendingTransaction,
 	writeCanvasPendingTransaction,
 } from "$lib/cache/repositories/canvas-pending-tx-repo";
 import {
+	applyCanvasOps,
 	canvasBootstrapToDocument,
 	parseCovasManifest,
 } from "$lib/canvas/canvas-document";
@@ -13,6 +15,24 @@ import type { CovasDocument } from "$lib/canvas/canvas-schema";
 import { sdk } from "$lib/sdk";
 
 type CanvasFileResponse = unknown;
+
+function isCanvasSemanticOp(value: unknown): value is CanvasSemanticOp {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const operation = value as Record<string, unknown>;
+	return (
+		typeof operation.type === "string" &&
+		[
+			"node.create",
+			"node.patch",
+			"node.data.merge",
+			"node.delete",
+			"document.meta.patch",
+		].includes(operation.type) &&
+		Boolean(operation.payload) &&
+		typeof operation.payload === "object" &&
+		!Array.isArray(operation.payload)
+	);
+}
 
 export type InlineCanvasPanelState = {
 	path: string;
@@ -97,12 +117,22 @@ export function createCanvasPreviewController(
 				...syncVersionByDocumentId,
 				[bootstrap.document.id]: bootstrap.document.version,
 			};
+			const pending = options.getReadonly?.()
+				? []
+				: await listCanvasPendingTransactions(
+						options.getSpaceId(),
+						bootstrap.document.id,
+					);
+			const restoredDocument = pending.reduce(
+				(document, transaction) => applyCanvasOps(document, transaction.ops),
+				canvasBootstrapToDocument(bootstrap),
+			);
 			canvases = canvases.map((item) =>
 				item.path === path
 					? {
 							path,
 							documentId: bootstrap.document.id,
-							document: canvasBootstrapToDocument(bootstrap),
+							document: restoredDocument,
 							loading: false,
 							saving: false,
 							error: null,
@@ -169,6 +199,7 @@ export function createCanvasPreviewController(
 		}
 		pendingFlush = true;
 		try {
+			let rebaseAttempted = false;
 			do {
 				pendingFlushRequested = false;
 				while (true) {
@@ -177,16 +208,30 @@ export function createCanvasPreviewController(
 						documentId,
 					);
 					if (pending.length === 0) break;
-					const tx = pending[0];
+					let tx = pending[0];
 					if (!tx) break;
+					let baseVersion = syncVersionByDocumentId[documentId];
+					if (typeof baseVersion !== "number") {
+						baseVersion = await reloadCanvasWithPendingTransactions(documentId);
+					}
+					if (tx.baseVersion !== baseVersion) {
+						tx = await rebaseCanvasPendingTransaction(tx, baseVersion);
+					}
 					await markCanvasPendingTransactionAttempt(tx);
 					const result = await sdk
 						.space(options.getSpaceId())
 						.sendCanvasTransactionRealtime(documentId, {
 							txId: tx.txId,
-							baseVersion: tx.baseVersion,
+							baseVersion,
 							ops: tx.ops,
+						})
+						.catch(async (error) => {
+							if (rebaseAttempted) throw error;
+							await reloadCanvasWithPendingTransactions(documentId);
+							rebaseAttempted = true;
+							return null;
 						});
+					if (!result) continue;
 					syncVersionByDocumentId = {
 						...syncVersionByDocumentId,
 						[documentId]: result.document.version,
@@ -196,11 +241,36 @@ export function createCanvasPreviewController(
 						documentId,
 						txId: tx.txId,
 					});
+					rebaseAttempted = false;
 				}
 			} while (pendingFlushRequested);
 		} finally {
 			pendingFlush = false;
 		}
+	}
+
+	async function reloadCanvasWithPendingTransactions(documentId: string) {
+		const bootstrap = await sdk
+			.space(options.getSpaceId())
+			.canvas.bootstrap(documentId);
+		const pending = await listCanvasPendingTransactions(
+			options.getSpaceId(),
+			documentId,
+		);
+		const document = pending.reduce(
+			(current, transaction) => applyCanvasOps(current, transaction.ops),
+			canvasBootstrapToDocument(bootstrap),
+		);
+		syncVersionByDocumentId = {
+			...syncVersionByDocumentId,
+			[documentId]: bootstrap.document.version,
+		};
+		canvases = canvases.map((canvas) =>
+			canvas.documentId === documentId
+				? { ...canvas, document, error: null }
+				: canvas,
+		);
+		return bootstrap.document.version;
 	}
 
 	async function commitCanvas(
@@ -221,7 +291,7 @@ export function createCanvasPreviewController(
 			spaceId: options.getSpaceId(),
 			documentId,
 			txId,
-			baseVersion: syncVersionByDocumentId[documentId] ?? null,
+			baseVersion: syncVersionByDocumentId[documentId] ?? 0,
 			ops,
 		});
 		canvases = canvases.map((item) =>
@@ -279,21 +349,36 @@ export function createCanvasPreviewController(
 		setCanvasError(documentId, error);
 	}
 
-	function applyBootstrap(
+	async function applyRemoteTransaction(
 		documentId: string,
-		bootstrap: Parameters<typeof canvasBootstrapToDocument>[0],
+		version: number,
+		ops: unknown[],
 	) {
 		const canvas = canvases.find((item) => item.documentId === documentId);
-		if (!canvas || canvas.saving) return;
+		if (!canvas?.document || canvas.saving) return;
+		const currentDocument = canvas.document;
+		const currentVersion = syncVersionByDocumentId[documentId];
+		if (typeof currentVersion !== "number" || version !== currentVersion + 1) {
+			await reloadCanvasWithPendingTransactions(documentId);
+			return;
+		}
+		const parsedOps = ops.filter(isCanvasSemanticOp);
+		if (parsedOps.length !== ops.length) {
+			await reloadCanvasWithPendingTransactions(documentId);
+			return;
+		}
 		syncVersionByDocumentId = {
 			...syncVersionByDocumentId,
-			[documentId]: bootstrap.document.version,
+			[documentId]: version,
 		};
 		canvases = canvases.map((item) =>
 			item.documentId === documentId
 				? {
 						...item,
-						document: canvasBootstrapToDocument(bootstrap),
+						document: applyCanvasOps(
+							item.document ?? currentDocument,
+							parsedOps,
+						),
 						error: null,
 					}
 				: item,
@@ -317,6 +402,6 @@ export function createCanvasPreviewController(
 		flushPendingTransactions,
 		renamePath,
 		setError,
-		applyBootstrap,
+		applyRemoteTransaction,
 	};
 }

--- a/deploy/api/dev/deploy.sh
+++ b/deploy/api/dev/deploy.sh
@@ -91,7 +91,12 @@ if [ ! -f "secrets.yaml" ]; then
   echo -e "${RED}✗ 缺少 secrets.yaml${NC}"
   exit 1
 fi
+if [ ! -f "private-secrets.yaml" ]; then
+  echo -e "${RED}✗ 缺少 private-secrets.yaml${NC}"
+  exit 1
+fi
 kubectl apply -f secrets.yaml
+kubectl apply -f private-secrets.yaml
 
 mkdir -p rendered
 

--- a/deploy/api/dev/private-secrets.template.yaml
+++ b/deploy/api/dev/private-secrets.template.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cohub-api-dev-private-secrets
+  namespace: cohub-dev
+stringData:
+  # JSON object of key-id to unpadded base64url 32-byte key.
+  CHANNEL_CREDENTIAL_PRIMARY_KEY_ID: "dev-v1"
+  CHANNEL_CREDENTIAL_KEYS: '{"dev-v1":"CHANGE_ME_TO_A_43_CHAR_BASE64URL_KEY"}'
+  # Shared only with Cohub Gateway; do not reuse WORKER_SECRET.
+  GATEWAY_INTERNAL_SECRET: "CHANGE_ME_TO_A_SEPARATE_RANDOM_SECRET"

--- a/deploy/api/manifests/channel-credential-job.tmpl.yaml
+++ b/deploy/api/manifests/channel-credential-job.tmpl.yaml
@@ -1,25 +1,29 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: __APP_NAME__-migrate
+  name: __APP_NAME__-channel-credentials
   namespace: __NAMESPACE__
   labels:
-    app.kubernetes.io/name: __APP_NAME__-migrate
+    app.kubernetes.io/name: __APP_NAME__-channel-credentials
 spec:
-  ttlSecondsAfterFinished: 300
-  activeDeadlineSeconds: 180
-  backoffLimit: 0
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: __APP_NAME__-migrate
+        app.kubernetes.io/name: __APP_NAME__-channel-credentials
     spec:
       restartPolicy: Never
+__IMAGE_PULL_SECRETS_BLOCK__
       containers:
-        - name: migrate
+        - name: migrate-channel-credentials
           image: __IMAGE_REPOSITORY__:__IMAGE_TAG__
           imagePullPolicy: __IMAGE_PULL_POLICY__
-          command: ["node", "dist/db/migrate.js"]
+          command: ["node", "dist/db/migrate-channel-credentials.js"]
+          args:
+            - "--mode"
+            - "__MODE__"
+__APPLY_ARG_BLOCK__
           envFrom:
             - secretRef:
                 name: __APP_NAME__-secrets
@@ -30,5 +34,5 @@ spec:
               cpu: "50m"
               memory: "64Mi"
             limits:
-              cpu: "200m"
-              memory: "128Mi"
+              cpu: "500m"
+              memory: "256Mi"

--- a/deploy/api/manifests/deployment.tmpl.yaml
+++ b/deploy/api/manifests/deployment.tmpl.yaml
@@ -38,6 +38,8 @@ __IMAGE_PULL_SECRETS_BLOCK__
                 name: __APP_NAME__-config
             - secretRef:
                 name: __APP_NAME__-secrets
+            - secretRef:
+                name: __APP_NAME__-private-secrets
           volumeMounts:
             - name: space-storage
               mountPath: /space-storage

--- a/deploy/api/prod/deploy.sh
+++ b/deploy/api/prod/deploy.sh
@@ -91,7 +91,12 @@ if [ ! -f "secrets.yaml" ]; then
   echo -e "${RED}✗ 缺少 secrets.yaml${NC}"
   exit 1
 fi
+if [ ! -f "private-secrets.yaml" ]; then
+  echo -e "${RED}✗ 缺少 private-secrets.yaml${NC}"
+  exit 1
+fi
 kubectl apply -f secrets.yaml
+kubectl apply -f private-secrets.yaml
 
 mkdir -p rendered
 

--- a/deploy/api/prod/private-secrets.template.yaml
+++ b/deploy/api/prod/private-secrets.template.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cohub-api-private-secrets
+  namespace: cohub
+stringData:
+  # Keep old entries during rotation until the rotate job reports zero remaining rows.
+  CHANNEL_CREDENTIAL_PRIMARY_KEY_ID: "prod-v1"
+  CHANNEL_CREDENTIAL_KEYS: '{"prod-v1":"CHANGE_ME_TO_A_43_CHAR_BASE64URL_KEY"}'
+  # Shared only with Cohub Gateway; do not reuse WORKER_SECRET.
+  GATEWAY_INTERNAL_SECRET: "CHANGE_ME_TO_A_SEPARATE_RANDOM_SECRET"

--- a/deploy/api/run-channel-credential-migration.sh
+++ b/deploy/api/run-channel-credential-migration.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENVIRONMENT="${1:-}"
+MODE="${2:-}"
+APPLY="${3:-}"
+
+if [[ "$ENVIRONMENT" != "dev" && "$ENVIRONMENT" != "prod" ]]; then
+  echo "Usage: $0 <dev|prod> <backfill|rotate> [--apply]" >&2
+  exit 1
+fi
+if [[ "$MODE" != "backfill" && "$MODE" != "rotate" ]]; then
+  echo "Usage: $0 <dev|prod> <backfill|rotate> [--apply]" >&2
+  exit 1
+fi
+if [[ -n "$APPLY" && "$APPLY" != "--apply" ]]; then
+  echo "Third argument must be --apply when provided" >&2
+  exit 1
+fi
+
+ENV_DIR="$SCRIPT_DIR/$ENVIRONMENT"
+VALUES_FILE="$ENV_DIR/values.yaml"
+if [[ ! -f "$VALUES_FILE" ]]; then
+  echo "Missing $VALUES_FILE" >&2
+  exit 1
+fi
+
+get_value() {
+  local key="$1"
+  grep -E "^${key}:" "$VALUES_FILE" | head -1 | sed 's/^[^:]*:[[:space:]]*//' | sed 's/^"//' | sed 's/"$//'
+}
+
+NAMESPACE="$(get_value NAMESPACE)"
+APP_NAME="$(get_value APP_NAME)"
+IMAGE_REPOSITORY="$(get_value IMAGE_REPOSITORY)"
+IMAGE_TAG="${OVERRIDE_IMAGE_TAG:-$(get_value IMAGE_TAG)}"
+IMAGE_PULL_POLICY="$(get_value IMAGE_PULL_POLICY)"
+IMAGE_PULL_SECRET="$(get_value IMAGE_PULL_SECRET)"
+JOB_NAME="${APP_NAME}-channel-credentials"
+RENDERED_DIR="$ENV_DIR/rendered"
+RENDERED_FILE="$RENDERED_DIR/channel-credential-job.yaml"
+
+mkdir -p "$RENDERED_DIR"
+cp "$SCRIPT_DIR/manifests/channel-credential-job.tmpl.yaml" "$RENDERED_FILE"
+
+python3 - "$RENDERED_FILE" "$IMAGE_PULL_SECRET" "$APPLY" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+image_pull_secret = sys.argv[2]
+apply = sys.argv[3]
+text = path.read_text()
+pull_block = ""
+if image_pull_secret:
+    pull_block = f"      imagePullSecrets:\n        - name: {image_pull_secret}\n"
+apply_block = '            - "--apply"\n' if apply == "--apply" else ""
+text = text.replace("__IMAGE_PULL_SECRETS_BLOCK__\n", pull_block)
+text = text.replace("__APPLY_ARG_BLOCK__\n", apply_block)
+path.write_text(text)
+PY
+
+sed -i.bak \
+  -e "s|__NAMESPACE__|${NAMESPACE}|g" \
+  -e "s|__APP_NAME__|${APP_NAME}|g" \
+  -e "s|__IMAGE_REPOSITORY__|${IMAGE_REPOSITORY}|g" \
+  -e "s|__IMAGE_TAG__|${IMAGE_TAG}|g" \
+  -e "s|__IMAGE_PULL_POLICY__|${IMAGE_PULL_POLICY}|g" \
+  -e "s|__MODE__|${MODE}|g" \
+  "$RENDERED_FILE"
+rm -f "$RENDERED_FILE.bak"
+
+kubectl delete job "$JOB_NAME" -n "$NAMESPACE" --ignore-not-found
+kubectl apply -f "$RENDERED_FILE"
+if ! kubectl wait --for=condition=complete "job/$JOB_NAME" -n "$NAMESPACE" --timeout=1800s; then
+  kubectl logs "job/$JOB_NAME" -n "$NAMESPACE" --tail=200 || true
+  exit 1
+fi
+kubectl logs "job/$JOB_NAME" -n "$NAMESPACE"

--- a/deploy/gateway/dev/secrets.template.yaml
+++ b/deploy/gateway/dev/secrets.template.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cohub-gateway-dev-secrets
+  namespace: cohub-dev
+stringData:
+  REDIS_URL: "redis://..."
+  # Must match cohub-api-dev-secrets.WORKER_SECRET.
+  WORKER_SECRET: "..."
+  # Must match cohub-api-dev-private-secrets.GATEWAY_INTERNAL_SECRET.
+  GATEWAY_INTERNAL_SECRET: "..."

--- a/deploy/gateway/prod/secrets.template.yaml
+++ b/deploy/gateway/prod/secrets.template.yaml
@@ -12,3 +12,5 @@ stringData:
   REDIS_URL: "redis://..."
   # Must match cohub-api-secrets.WORKER_SECRET
   WORKER_SECRET: "..."
+  # Must match cohub-api-private-secrets.GATEWAY_INTERNAL_SECRET.
+  GATEWAY_INTERNAL_SECRET: "..."

--- a/docs/channel-credential-encryption.md
+++ b/docs/channel-credential-encryption.md
@@ -1,0 +1,85 @@
+# Channel credential encryption
+
+`v2.user_channels.credential_envelope` is the source of truth for new channel credentials. The API is the only service with the encryption keyring. Gateway assignments in Redis contain a credential revision, not credentials; a Gateway fetches credentials from the authenticated internal API only when it starts or refreshes a provider.
+
+The credential endpoint uses a dedicated `GATEWAY_INTERNAL_SECRET` and verifies that the requesting Gateway node currently owns the channel route. Do not reuse `WORKER_SECRET`; agents and workers do not need access to channel credentials.
+
+## Keyring
+
+Configure the API and migration job with:
+
+```text
+CHANNEL_CREDENTIAL_PRIMARY_KEY_ID=prod-v1
+CHANNEL_CREDENTIAL_KEYS={"prod-v1":"<unpadded base64url 32-byte key>"}
+```
+
+Generate a key with Node.js 24:
+
+```bash
+node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("base64url"))'
+```
+
+Key ids may contain letters, digits, `.`, `_`, and `-`. Never remove an old key while an envelope still references it.
+
+## Rollout
+
+1. Create the API-only `private-secrets.yaml` from `deploy/api/<env>/private-secrets.template.yaml`. The Worker must not mount this Secret. Add the same `GATEWAY_INTERNAL_SECRET` to the Gateway Secret before deploying either new image.
+2. Run database migrations. The expand migration keeps legacy `credentials` rows readable.
+3. Roll out API, then Gateway. Avoid channel create/update requests while old and new API pods overlap because old code cannot read newly encrypted rows.
+4. Preview the legacy backfill:
+
+   ```bash
+   pnpm --filter @cohub/api db:migrate:channel-credentials -- --mode backfill
+   ```
+
+   In Kubernetes, run the equivalent isolated Job:
+
+   ```bash
+   ./deploy/api/run-channel-credential-migration.sh prod backfill
+   ```
+
+5. Apply the backfill after every API pod is on the new version:
+
+   ```bash
+   pnpm --filter @cohub/api db:migrate:channel-credentials -- --mode backfill --apply
+   ```
+
+   ```bash
+   ./deploy/api/run-channel-credential-migration.sh prod backfill --apply
+   ```
+
+6. Verify that no plaintext rows remain:
+
+   ```sql
+   SELECT count(*) AS plaintext_rows
+   FROM v2.user_channels
+   WHERE credentials IS NOT NULL;
+   ```
+
+7. Validate the online constraints after the database is quiet enough for the scan:
+
+   ```sql
+   ALTER TABLE v2.user_channels
+     VALIDATE CONSTRAINT v2_chk_user_channels_credentials_storage;
+   ALTER TABLE v2.user_channels
+     VALIDATE CONSTRAINT v2_chk_user_channels_credential_envelope;
+   ALTER TABLE v2.user_channels
+     VALIDATE CONSTRAINT v2_chk_user_channels_credential_revision;
+   ```
+
+The script locks small batches with `FOR UPDATE SKIP LOCKED`, is safe to rerun, and never changes the logical credential revision during a storage-only backfill.
+
+The nullable legacy `credentials` column is deliberately retained for this expand release. After the backfill, constraint validation, and rollback window are complete, remove the dual-read path and drop the legacy column in a separate contract release. Combining expand, data rewrite, and contract into one deployment would make rollback unsafe.
+
+## Rotation
+
+Add a new key while retaining every old key, set it as primary, deploy the API, then run:
+
+```bash
+pnpm --filter @cohub/api db:migrate:channel-credentials -- --mode rotate
+pnpm --filter @cohub/api db:migrate:channel-credentials -- --mode rotate --apply
+```
+
+For production Kubernetes, use `./deploy/api/run-channel-credential-migration.sh prod rotate` first, then rerun it with `--apply`.
+
+After the apply run reports zero remaining rows and every API pod has the new keyring, remove retired keys in a later deployment. A rollback across a completed backfill requires the new API code and the old keys; the legacy application cannot read encrypted-only rows.

--- a/docs/session-message-sequence.md
+++ b/docs/session-message-sequence.md
@@ -1,0 +1,25 @@
+# Session message sequence allocation
+
+`v2.session_messages.sequence` is ordered within one `space_sessions` row. Every runtime append calls `v2.allocate_session_message_sequence(session_id)` instead of calculating `max(sequence) + 1` in application code.
+
+The allocator locks the parent Session row, reads the current maximum after acquiring that lock, and holds the lock until the caller transaction finishes. This gives API, Agent, and compaction one database serialization point without maintaining a second counter that can drift from message data.
+
+Message idempotency remains `(session_id, idempotency_key)`. Concurrent retries use `ON CONFLICT DO NOTHING` and return the committed message. Since allocation has no persistent counter, a rejected retry does not create a sequence gap.
+
+## Rollout
+
+1. Apply migration `0046` before deploying API or Agent.
+2. Deploy API and Agent in the same release window. Old instances still calculate sequences in application code and do not participate in the Session row lock.
+3. Validate the online constraints after checking for invalid legacy rows:
+
+   ```sql
+   SELECT count(*) FROM v2.session_messages WHERE sequence <= 0;
+   SELECT count(*) FROM v2.session_turns WHERE sequence <= 0;
+
+   ALTER TABLE v2.session_messages
+     VALIDATE CONSTRAINT v2_chk_session_messages_sequence;
+   ALTER TABLE v2.session_turns
+     VALIDATE CONSTRAINT v2_chk_session_turns_sequence;
+   ```
+
+The allocator function is backward-compatible with explicit historical sequence inserts. Data migrations and fork reconstruction may keep supplying their own sequence values; only live append paths use the allocator.

--- a/docs/token-usage-hourly-integrity.md
+++ b/docs/token-usage-hourly-integrity.md
@@ -1,0 +1,43 @@
+# Token usage hourly integrity
+
+`v2.token_usage_stats_hourly` preserves nullable `user_id`, `provider`, and `model` dimensions. Its unique key uses PostgreSQL `NULLS NOT DISTINCT`, so a missing dimension still participates in `ON CONFLICT` and one logical hourly bucket has exactly one row.
+
+Migration `0047` takes a `SHARE ROW EXCLUSIVE` table lock, aggregates only duplicate dimension groups, replaces those rows without losing counters or costs, then replaces the legacy unique index with the null-aware unique constraint. Reads remain available while the migration holds the lock; token usage writes wait. Lock acquisition has a 30-second timeout, so a busy deployment fails cleanly instead of waiting indefinitely.
+
+## Preflight
+
+Run these read-only queries before scheduling the migration:
+
+```sql
+SELECT count(*) AS duplicate_groups,
+       coalesce(sum(row_count - 1), 0) AS redundant_rows
+FROM (
+  SELECT count(*) AS row_count
+  FROM v2.token_usage_stats_hourly
+  GROUP BY bucket_start_at, user_id, space_id, session_id, provider, model
+  HAVING count(*) > 1
+) duplicates;
+
+SELECT pg_size_pretty(pg_total_relation_size('v2.token_usage_stats_hourly')) AS total_size;
+```
+
+Do not infer lock duration without these production values. Pause the session-message postprocess Worker if the measured table size or duplicate count makes a short write pause unacceptable.
+
+## Verification
+
+```sql
+SELECT count(*)
+FROM (
+  SELECT 1
+  FROM v2.token_usage_stats_hourly
+  GROUP BY bucket_start_at, user_id, space_id, session_id, provider, model
+  HAVING count(*) > 1
+) duplicates;
+
+SELECT conname, convalidated
+FROM pg_constraint
+WHERE conrelid = 'v2.token_usage_stats_hourly'::regclass
+  AND conname = 'v2_uq_token_usage_stats_hourly_bucket_dims';
+```
+
+Both checks must report one valid constraint and zero duplicate groups. The generation usage table is not part of this migration: its dimensions are already `NOT NULL` and normalized to explicit sentinels before upsert.

--- a/packages/db/src/schema-v2.ts
+++ b/packages/db/src/schema-v2.ts
@@ -31,6 +31,15 @@ export type AccessPolicyResourceType = "space" | "session";
 export type ReferralCodeStatus = "active" | "revoked";
 export type ReferralStatus = "pending" | "qualified" | "rewarded";
 
+export type UserChannelCredentialEnvelope = {
+  version: 1;
+  keyId: string;
+  algorithm: "aes-256-gcm";
+  nonce: string;
+  authTag: string;
+  ciphertext: string;
+};
+
 /** Endpoints of a reference: the kinds of resources that can point or be pointed at. */
 export type ReferenceResourceType =
   | "space"
@@ -111,7 +120,9 @@ export const userChannels = v2.table(
     userUuid: varchar("user_uuid", { length: 255 }).notNull(),
     provider: varchar("provider", { length: 50 }).notNull(),
     name: varchar("name", { length: 255 }),
-    credentials: jsonb("credentials").notNull(),
+    credentials: jsonb("credentials"),
+    credentialEnvelope: jsonb("credential_envelope").$type<UserChannelCredentialEnvelope>(),
+    credentialRevision: integer("credential_revision").default(1).notNull(),
     status: varchar("status", { length: 20 }).default("active"),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
@@ -119,6 +130,27 @@ export const userChannels = v2.table(
   (table) => ({
     userUuidIdx: index("v2_idx_user_channels_user_uuid").on(table.userUuid),
     providerIdx: index("v2_idx_user_channels_provider").on(table.provider),
+    credentialsStorageCheck: check(
+      "v2_chk_user_channels_credentials_storage",
+      sql`num_nonnulls(${table.credentials}, ${table.credentialEnvelope}) = 1`,
+    ),
+    credentialEnvelopeCheck: check(
+      "v2_chk_user_channels_credential_envelope",
+      sql`${table.credentialEnvelope} is null or coalesce(
+        jsonb_typeof(${table.credentialEnvelope}) = 'object'
+        and ${table.credentialEnvelope}->'version' = '1'::jsonb
+        and ${table.credentialEnvelope}->>'algorithm' = 'aes-256-gcm'
+        and ${table.credentialEnvelope}->>'keyId' ~ '^[A-Za-z0-9._-]{1,64}$'
+        and ${table.credentialEnvelope}->>'nonce' ~ '^[A-Za-z0-9_-]{16}$'
+        and ${table.credentialEnvelope}->>'authTag' ~ '^[A-Za-z0-9_-]{22}$'
+        and ${table.credentialEnvelope}->>'ciphertext' ~ '^[A-Za-z0-9_-]{3,}$',
+        false
+      )`,
+    ),
+    credentialRevisionCheck: check(
+      "v2_chk_user_channels_credential_revision",
+      sql`${table.credentialRevision} > 0`,
+    ),
   }),
 );
 

--- a/packages/db/src/schema-v2.ts
+++ b/packages/db/src/schema-v2.ts
@@ -772,14 +772,14 @@ export const tokenUsageStatsHourly = v2.table(
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
   },
   (table) => ({
-    pk: uniqueIndex("v2_uq_token_usage_stats_hourly_bucket_dims").on(
+    pk: unique("v2_uq_token_usage_stats_hourly_bucket_dims").on(
       table.bucketStartAt,
       table.userId,
       table.spaceId,
       table.sessionId,
       table.provider,
       table.model,
-    ),
+    ).nullsNotDistinct(),
     bucketIdx: index("v2_idx_token_usage_stats_hourly_bucket").on(table.bucketStartAt),
     userBucketIdx: index("v2_idx_token_usage_stats_hourly_user_bucket").on(table.userId, table.bucketStartAt),
     spaceBucketIdx: index("v2_idx_token_usage_stats_hourly_space_bucket").on(table.spaceId, table.bucketStartAt),

--- a/packages/db/src/schema-v2.ts
+++ b/packages/db/src/schema-v2.ts
@@ -343,11 +343,11 @@ export const canvasDocuments = v2.table(
   "canvas_documents",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    spaceId: uuid("space_id").notNull(),
+    spaceId: uuid("space_id").notNull().references(() => spaces.id, { onDelete: "cascade" }),
     filePath: text("file_path").notNull(),
     title: text("title").notNull(),
     version: integer("version").notNull().default(0),
-    meta: jsonb("meta").$type<Record<string, unknown>>(),
+    meta: jsonb("meta").$type<Record<string, unknown>>().notNull().default({}),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
@@ -355,13 +355,14 @@ export const canvasDocuments = v2.table(
   (table) => ({
     spaceIdx: index("v2_idx_canvas_documents_space_id").on(table.spaceId),
     spacePathUniqueIdx: uniqueIndex("v2_uq_canvas_documents_space_path").on(table.spaceId, table.filePath),
+    versionCheck: check("v2_chk_canvas_documents_version", sql`${table.version} >= 0`),
   }),
 );
 
 export const canvasNodes = v2.table(
   "canvas_nodes",
   {
-    documentId: uuid("document_id").notNull(),
+    documentId: uuid("document_id").notNull().references(() => canvasDocuments.id, { onDelete: "cascade" }),
     nodeId: text("node_id").notNull(),
     type: varchar("type", { length: 40 }).notNull(),
     parentId: text("parent_id"),
@@ -385,9 +386,10 @@ export const canvasNodes = v2.table(
   },
   (table) => ({
     primary: uniqueIndex("v2_uq_canvas_nodes_document_node").on(table.documentId, table.nodeId),
-    documentIdx: index("v2_idx_canvas_nodes_document_id").on(table.documentId),
     viewportIdx: index("v2_idx_canvas_nodes_viewport").on(table.documentId, table.x, table.y, table.width, table.height),
     refPathIdx: index("v2_idx_canvas_nodes_ref_path").on(table.documentId, table.refPath),
+    dimensionsCheck: check("v2_chk_canvas_nodes_dimensions", sql`${table.width} > 0 AND ${table.height} > 0`),
+    versionCheck: check("v2_chk_canvas_nodes_version", sql`${table.version} >= 0`),
   }),
 );
 
@@ -395,18 +397,24 @@ export const canvasUpdates = v2.table(
   "canvas_updates",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    documentId: uuid("document_id").notNull(),
+    documentId: uuid("document_id").notNull().references(() => canvasDocuments.id, { onDelete: "cascade" }),
+    txId: text("tx_id").notNull(),
+    baseVersion: integer("base_version").notNull(),
+    requestHash: varchar("request_hash", { length: 64 }),
     version: integer("version").notNull(),
     actorId: varchar("actor_id", { length: 255 }).notNull(),
     clientId: text("client_id"),
     type: varchar("type", { length: 80 }).notNull(),
     payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
+    result: jsonb("result").$type<Record<string, unknown>>().notNull().default({}),
     undoGroupId: text("undo_group_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
   },
   (table) => ({
     documentVersionUniqueIdx: uniqueIndex("v2_uq_canvas_updates_document_version").on(table.documentId, table.version),
-    documentIdx: index("v2_idx_canvas_updates_document_id").on(table.documentId),
+    documentTxUniqueIdx: uniqueIndex("v2_uq_canvas_updates_document_tx").on(table.documentId, table.txId),
+    baseVersionCheck: check("v2_chk_canvas_updates_base_version", sql`${table.baseVersion} >= 0`),
+    versionCheck: check("v2_chk_canvas_updates_version", sql`${table.version} > ${table.baseVersion}`),
   }),
 );
 

--- a/packages/db/src/schema-v2.ts
+++ b/packages/db/src/schema-v2.ts
@@ -703,8 +703,12 @@ export const sessionTurns = v2.table(
     userUuidIdx: index("v2_idx_session_turns_user_uuid").on(table.userUuid),
     createdAtIdx: index("v2_idx_session_turns_created_at").on(table.createdAt),
     userTextSearchIdx: index("v2_idx_session_turns_user_text_trgm").using("gin", table.userText.op("gin_trgm_ops")),
+    sequenceCheck: check("v2_chk_session_turns_sequence", sql`${table.sequence} > 0`),
   }),
 );
+
+export const allocateSessionMessageSequence = (sessionId: string) =>
+  sql<number>`v2.allocate_session_message_sequence(${sessionId}::uuid)`;
 
 export const sessionMessages = v2.table(
   "session_messages",
@@ -738,6 +742,7 @@ export const sessionMessages = v2.table(
       table.sessionId,
       table.idempotencyKey,
     ),
+    sequenceCheck: check("v2_chk_session_messages_sequence", sql`${table.sequence} > 0`),
   }),
 );
 

--- a/packages/protocol/src/realtime/schema.ts
+++ b/packages/protocol/src/realtime/schema.ts
@@ -96,7 +96,7 @@ export const wsClientEventSchema = z.discriminatedUnion("type", [
       spaceId: z.string().uuid(),
       documentId: z.string().min(1),
       txId: z.string().min(1),
-      baseVersion: z.number().nullable().optional(),
+      baseVersion: z.number().int().nonnegative(),
       clientId: z.string().nullable().optional(),
       undoGroupId: z.string().nullable().optional(),
       ops: z.array(z.record(z.string(), z.unknown())).min(1),

--- a/packages/protocol/src/realtime/types.ts
+++ b/packages/protocol/src/realtime/types.ts
@@ -42,7 +42,7 @@ export type WsClientEvent =
   | { type: "subscribe"; requestId?: string; payload: { rooms: string[] } }
   | { type: "unsubscribe"; requestId?: string; payload: { rooms: string[] } }
   | { type: "session.message.create"; requestId?: string; payload: { spaceId: string; sessionId: string; clientMessageId?: string; content: ContentBlock[]; model?: string; provider?: string } }
-  | { type: "canvas.tx"; requestId?: string; payload: { spaceId: string; documentId: string; txId: string; baseVersion?: number | null; clientId?: string | null; undoGroupId?: string | null; ops: Array<Record<string, unknown>> } }
+  | { type: "canvas.tx"; requestId?: string; payload: { spaceId: string; documentId: string; txId: string; baseVersion: number; clientId?: string | null; undoGroupId?: string | null; ops: Array<Record<string, unknown>> } }
   | { type: "presence.update"; requestId?: string; payload: { spaceId: string; meta?: Record<string, unknown> | null } }
   | { type: "ping"; requestId?: string; payload?: Record<string, unknown> }
   | { type: "ack"; requestId?: string; payload?: { eventId?: string } };
@@ -495,6 +495,7 @@ export type CanvasTransactionAckEvent = {
     documentId: string;
     txId: string;
     version: number;
+    replayed?: boolean;
   };
 };
 
@@ -510,6 +511,9 @@ export type CanvasTransactionErrorEvent = {
     documentId?: string | null;
     txId?: string | null;
     message: string;
+    code?: string;
+    status?: number;
+    currentVersion?: number;
   };
 };
 

--- a/packages/sdk/src/apis/spaces.ts
+++ b/packages/sdk/src/apis/spaces.ts
@@ -76,6 +76,8 @@ import type {
   ChannelHealth,
   CanvasDocumentRecord,
   CanvasTransactionInput,
+  CanvasTransactionResponse,
+  CanvasUpdatesResponse,
 } from "../types.js";
 import { SpaceInvitationsApi } from "./invitations.js";
 
@@ -1412,8 +1414,17 @@ export class SpaceCanvasApi {
     );
   }
 
+  updates(documentId: string, input: { afterVersion: number; limit?: number }, customFetch?: Fetch) {
+    const params = new URLSearchParams({ afterVersion: String(input.afterVersion) });
+    if (input.limit !== undefined) params.set("limit", String(input.limit));
+    return this.transport.request<CanvasUpdatesResponse>(
+      `/api/spaces/${this.spaceId}/canvas/${documentId}/updates?${params.toString()}`,
+      { fetch: customFetch },
+    );
+  }
+
   sendTransaction(documentId: string, input: CanvasTransactionInput) {
-    return this.transport.request<CanvasBootstrapResponse>(
+    return this.transport.request<CanvasTransactionResponse>(
       `/api/spaces/${this.spaceId}/canvas/${documentId}/ops`,
       {
         method: "POST",
@@ -1817,7 +1828,7 @@ export class SpaceClient {
   async sendCanvasTransactionRealtime(documentId: string, input: CanvasTransactionInput) {
     if (!this.websocketClient) return this.canvas.sendTransaction(documentId, input);
     const requestId = `canvas-${input.txId}`;
-    const result = new Promise<{ document: { version: number } }>((resolve, reject) => {
+    const result = new Promise<{ document: { version: number }; transaction: { txId: string; version: number; replayed: boolean } }>((resolve, reject) => {
       let settled = false;
       let timeout: ReturnType<typeof setTimeout> | null = null;
       const settle = (fn: () => void) => {
@@ -1831,8 +1842,16 @@ export class SpaceClient {
       const cleanupAck = this.websocketClient?.on("event", (event) => {
         if (event.type !== "canvas.tx.ack" || event.requestId !== requestId) return;
         const version = event.payload.version;
+        const txId = event.payload.txId;
         settle(() => {
-          if (typeof version === "number") resolve({ document: { version } });
+          if (typeof version === "number" && typeof txId === "string") resolve({
+            document: { version },
+            transaction: {
+              txId,
+              version,
+              replayed: event.payload.replayed === true,
+            },
+          });
           else reject(new Error("Invalid canvas ack"));
         });
       });
@@ -1846,7 +1865,7 @@ export class SpaceClient {
       spaceId: this.id,
       documentId,
       txId: input.txId,
-      baseVersion: input.baseVersion ?? null,
+      baseVersion: input.baseVersion,
       clientId: input.clientId ?? null,
       undoGroupId: input.undoGroupId ?? null,
       ops: input.ops,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -748,7 +748,7 @@ export type CanvasDocumentRecord = {
   filePath: string;
   title: string;
   version: number;
-  meta?: Record<string, unknown> | null;
+  meta: Record<string, unknown>;
   createdAt: string | null;
   updatedAt: string | null;
   deletedAt?: string | null;
@@ -782,17 +782,52 @@ export type CanvasNodeInput = Omit<CanvasNodeRecord, "documentId" | "version" | 
 
 export type CanvasSemanticOp = {
   opId?: string;
-  type: "node.create" | "node.patch" | "node.delete";
+  version?: 1 | 2;
+  type: "node.create" | "node.patch" | "node.data.merge" | "node.delete" | "document.meta.patch";
   payload: Record<string, unknown>;
   inverse?: Record<string, unknown>;
 };
 
 export type CanvasTransactionInput = {
   txId: string;
-  baseVersion?: number | null;
+  baseVersion: number;
   clientId?: string | null;
   undoGroupId?: string | null;
   ops: CanvasSemanticOp[];
+};
+
+export type CanvasTransactionResponse = {
+  transaction: {
+    txId: string;
+    baseVersion: number;
+    version: number;
+    replayed: boolean;
+  };
+  document: {
+    version: number;
+    meta: Record<string, unknown>;
+  };
+  changes: {
+    nodes: CanvasNodeRecord[];
+    deletedNodeIds: string[];
+  };
+};
+
+export type CanvasUpdateRecord = {
+  txId: string;
+  baseVersion: number;
+  version: number;
+  actorId: string;
+  clientId: string | null;
+  payload: { ops?: CanvasSemanticOp[] } & Record<string, unknown>;
+  createdAt: string | null;
+};
+
+export type CanvasUpdatesResponse = {
+  documentVersion: number;
+  updates: CanvasUpdateRecord[];
+  hasMore: boolean;
+  requiresBootstrap: boolean;
 };
 
 export type CanvasCreateInput = {

--- a/packages/sdk/src/websocket.ts
+++ b/packages/sdk/src/websocket.ts
@@ -383,7 +383,7 @@ export class WebsocketClient {
     documentId: string;
     txId: string;
     ops: Array<Record<string, unknown>>;
-    baseVersion?: number | null;
+    baseVersion: number;
     clientId?: string | null;
     undoGroupId?: string | null;
     requestId?: string;
@@ -396,7 +396,7 @@ export class WebsocketClient {
         spaceId: input.spaceId,
         documentId: input.documentId,
         txId: input.txId,
-        baseVersion: input.baseVersion ?? null,
+        baseVersion: input.baseVersion,
         clientId: input.clientId ?? null,
         undoGroupId: input.undoGroupId ?? null,
         ops: input.ops,


### PR DESCRIPTION
## Summary

- make the hourly token-usage dimension key use PostgreSQL `UNIQUE NULLS NOT DISTINCT`
- preserve nullable business dimensions instead of introducing sentinel values
- aggregate existing duplicate dimension groups without losing counters, token totals, costs, or timestamps
- document read-only production preflight and post-migration verification

## Root cause

The previous unique index treated `NULL` values as distinct. `ON CONFLICT` therefore did not match rows when `user_id`, `provider`, or `model` was missing, allowing multiple rows for one logical hourly bucket and corrupting rollups.

## Migration behavior

Migration `0047` uses a 30-second lock timeout and a `SHARE ROW EXCLUSIVE` lock. Reads remain available while usage writes wait. It aggregates only duplicate groups, keeps `created_at = min(created_at)` and `updated_at = max(updated_at)`, then replaces the old index with a null-aware unique constraint.

## Validation

- migrated a fresh PostgreSQL 15 database through `0046`, seeded three duplicate nullable-dimension rows, and applied `0047`
- verified one resulting row with request/success/error counts `6/4/2`, total tokens `114`, total cost `6.00000000`, earliest creation time, and latest update time
- verified zero duplicate groups and a valid `NULLS NOT DISTINCT` unique constraint
- verified 32 concurrent nullable-dimension upserts produce one row with correct accumulated values
- `pnpm --filter @cohub/api... build`
- `pnpm -r typecheck` with required public environment variables
- `pnpm -r lint` (passes; existing unrelated warnings remain)
- 9 stacked API/database tests

## Dependency

Stacked on #104. Merge order: #102, #103, #104, then this PR. Rebase each stacked branch after its dependency merges.
