### PR TITLE
[codex] Fix generation platform contracts

### DIFF
--- a/.changeset/calm-generation-media.md
+++ b/.changeset/calm-generation-media.md
@@ -1,0 +1,5 @@
+---
+"@neta-art/cohub-cli": patch
+---
+
+Upload local generation media as durable public URLs and allow media-only generation commands.

--- a/apps/api/src/lib/middleware.ts
+++ b/apps/api/src/lib/middleware.ts
@@ -17,6 +17,7 @@ export type RequestPrincipal =
 
 import { config } from "../config.js";
 import { getProfilesByUuids } from "../user-profiles.js";
+import { sanitizeSpaceMeta } from "../space-response-sanitize.js";
 import { getSpaceSandboxBySpaceId } from "../space-sandboxes.js";
 import { spaceSandboxes } from "@cohub/db";
 import { db } from "../db/index.js";
@@ -184,6 +185,7 @@ export const buildSpaceListItem = async (space: typeof spaces.$inferSelect) => {
   const sandbox = await getSpaceSandboxBySpaceId(space.id);
   return {
     ...space,
+    meta: sanitizeSpaceMeta(space.meta),
     publicProfile: getSpacePublicProfile(space),
     sandboxStatus: sandbox?.status ?? null,
   };
@@ -206,6 +208,7 @@ export const buildSpaceListItems = async (spaceList: typeof spaces.$inferSelect[
 
   return spaceList.map((space) => ({
     ...space,
+    meta: sanitizeSpaceMeta(space.meta),
     publicProfile: getSpacePublicProfile(space),
     sandboxStatus: statusBySpaceId.get(space.id) ?? null,
     ownerProfile: profileByUserUuid.get(space.userUuid) ?? null,

--- a/apps/api/src/routes/spaces/spaces.route.ts
+++ b/apps/api/src/routes/spaces/spaces.route.ts
@@ -70,6 +70,7 @@ import { parseChannelConfigPatch, mergeChannelConfig, validateChannelModelConfig
 import { redisCommandClient } from "../../redis.js";
 import { featureGateResponse } from "../../lib/feature-gate.js";
 import { billingBlockedResponse } from "../../lib/billing-blocked.js";
+import { sanitizeSpaceMeta } from "../../space-response-sanitize.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -1011,55 +1012,6 @@ async function serializeSpaceForResponse(space: typeof spaces.$inferSelect, user
     access,
     ownerProfile,
   };
-}
-
-function sanitizeRepoUrl(url: string): string {
-  try {
-    const parsed = new URL(url);
-    parsed.username = "";
-    parsed.password = "";
-    return parsed.toString();
-  } catch {
-    return url;
-  }
-}
-
-function sanitizeSpaceMeta(meta: unknown): Record<string, unknown> | null {
-  if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
-    return meta as null;
-  }
-  const metaObj = meta as Record<string, unknown>;
-  const bootstrap = metaObj.bootstrap;
-  if (
-    !bootstrap ||
-    typeof bootstrap !== "object" ||
-    Array.isArray(bootstrap)
-  ) {
-    return metaObj;
-  }
-  const bootstrapObj = bootstrap as Record<string, unknown>;
-  const source = bootstrapObj.source;
-  if (
-    !source ||
-    typeof source !== "object" ||
-    Array.isArray(source)
-  ) {
-    return metaObj;
-  }
-  const sourceObj = source as Record<string, unknown>;
-  if (sourceObj.type === "git_repo" && typeof sourceObj.repoUrl === "string") {
-    return {
-      ...metaObj,
-      bootstrap: {
-        ...bootstrapObj,
-        source: {
-          ...sourceObj,
-          repoUrl: sanitizeRepoUrl(sourceObj.repoUrl as string),
-        },
-      },
-    };
-  }
-  return metaObj;
 }
 
 router.get("/:id", async (c) => {

--- a/apps/api/src/space-response-sanitize.test.ts
+++ b/apps/api/src/space-response-sanitize.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { sanitizeSpaceMeta } from "./space-response-sanitize.js";
+
+describe("sanitizeSpaceMeta", () => {
+  it("removes environment values and bootstrap credentials", () => {
+    assert.deepEqual(
+      sanitizeSpaceMeta({
+        extraEnv: [{ name: "GITHUB_TOKEN", value: "secret" }],
+        config: { sandbox: { spec: "standard" } },
+        bootstrap: {
+          status: "ready",
+          source: {
+            type: "git_repo",
+            repoUrl: "https://user:password@example.com/org/repo.git",
+            gitToken: "secret-token",
+            ref: "main",
+          },
+        },
+      }),
+      {
+        config: { sandbox: { spec: "standard" } },
+        bootstrap: {
+          status: "ready",
+          source: {
+            type: "git_repo",
+            repoUrl: "https://example.com/org/repo.git",
+            ref: "main",
+          },
+        },
+      },
+    );
+  });
+
+  it("normalizes absent metadata", () => {
+    assert.equal(sanitizeSpaceMeta(null), null);
+  });
+});

--- a/apps/api/src/space-response-sanitize.ts
+++ b/apps/api/src/space-response-sanitize.ts
@@ -1,0 +1,36 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sanitizeRepoUrl(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    const url = new URL(value);
+    url.username = "";
+    url.password = "";
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
+function sanitizeBootstrap(value: unknown): unknown {
+  if (!isRecord(value) || !isRecord(value.source)) return value;
+  const { gitToken: _gitToken, ...source } = value.source;
+  return {
+    ...value,
+    source: {
+      ...source,
+      ...(source.repoUrl === undefined ? {} : { repoUrl: sanitizeRepoUrl(source.repoUrl) }),
+    },
+  };
+}
+
+export function sanitizeSpaceMeta(meta: unknown): Record<string, unknown> | null {
+  if (!isRecord(meta)) return null;
+  const { extraEnv: _extraEnv, ...safeMeta } = meta;
+  return {
+    ...safeMeta,
+    ...(safeMeta.bootstrap === undefined ? {} : { bootstrap: sanitizeBootstrap(safeMeta.bootstrap) }),
+  };
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint-staged": "^17.0.8",
     "tsx": "4.23.1",
     "typescript": "7.0.2",
+    "unrun": "^0.3.1",
     "zod": "^4.4.3"
   },
   "license": "Apache-2.0",

--- a/packages/cli/src/commands/generations.ts
+++ b/packages/cli/src/commands/generations.ts
@@ -5,6 +5,7 @@ import {
   GenerationPolicyError,
   assertGenerationRequestAllowedByPolicy,
   parseGenerationPolicyFromEnv,
+  type CohubHttpClient,
   type GenerationContentBlock,
 } from "@neta-art/cohub";
 import { createClient } from "../client.js";
@@ -87,7 +88,13 @@ async function parseMediaInput(type: MediaInputType, rawValue: string): Promise<
   return { value, role };
 }
 
-async function contentFromPathOrUrl(type: MediaInputType, rawValue: string): Promise<GenerationContentBlock> {
+async function contentFromPathOrUrl(
+  client: CohubHttpClient,
+  spaceId: string,
+  sessionId: string | undefined,
+  type: MediaInputType,
+  rawValue: string,
+): Promise<GenerationContentBlock> {
   const { value, role } = await parseMediaInput(type, rawValue);
   const meta = role ? { role } : undefined;
   if (/^https?:\/\//.test(value)) {
@@ -95,9 +102,16 @@ async function contentFromPathOrUrl(type: MediaInputType, rawValue: string): Pro
   }
   const data = await readFile(value);
   const mediaType = mimeByExt[extname(value).toLowerCase()] ?? "application/octet-stream";
+  const asset = await client.publicAssets.uploadChatAttachment({
+    spaceId,
+    sessionId,
+    file: new Blob([new Uint8Array(data)], { type: mediaType }),
+    mimeType: mediaType,
+    filename: basename(value),
+  });
   return {
     type,
-    source: { type: "base64", mediaType, data: data.toString("base64") },
+    source: { type: "url", url: asset.publicUrl },
     ...(meta ? { meta } : {}),
   } as GenerationContentBlock;
 }
@@ -275,7 +289,7 @@ export function registerGenerations(program: Command): void {
   program
     .command("generate")
     .description("Generate multimodal outputs")
-    .argument("<prompt>", "Prompt text")
+    .argument("[prompt]", "Prompt text")
     .requiredOption("-m, --model <model>", "Multimodal model ID from `cohub models ls --model-type multimodal`")
     .option(
       "--image <path-or-url>",
@@ -302,12 +316,13 @@ export function registerGenerations(program: Command): void {
 Examples:
   cohub models ls --model-type multimodal
   cohub -s <space-id> generate "A calm lake at sunrise" -m <model> -o lake.png
+  cohub -s <space-id> generate -m birefnet-general --image portrait.png -o cutout.png
   COHUB_SPACE_ID=<space-id> cohub generate "Restyle this image" -m <model> --image input.png
   cohub -s <space-id> generate "Smooth transition" -m seedance-2-0-fast --image first_frame=https://example.com/first.png --image last_frame=https://example.com/last.png
   cohub -s <space-id> generate "Use these references" -m seedance-2-0-fast --image reference_image=https://example.com/a.png --image reference_image=https://example.com/b.png
   cohub -s <space-id> generate "A calm lake" -m <model> --async
 `)
-    .action(async (prompt: string, opts: {
+    .action(async (prompt: string | undefined, opts: {
       model: string;
       image: string[];
       video: string[];
@@ -322,10 +337,26 @@ Examples:
     }) => {
       try {
         const spaceId = resolveSpace(program);
-        const content: GenerationContentBlock[] = [{ type: "text", text: prompt }];
-        content.push(...await Promise.all(opts.image.map((value) => contentFromPathOrUrl("image", value))));
-        content.push(...await Promise.all(opts.video.map((value) => contentFromPathOrUrl("video", value))));
-        content.push(...await Promise.all(opts.audio.map((value) => contentFromPathOrUrl("audio", value))));
+        const sessionId = envValue("COHUB_SESSION_ID");
+        const client = createClient();
+        const content: GenerationContentBlock[] = [];
+        if (prompt?.trim()) content.push({ type: "text", text: prompt });
+        content.push(
+          ...await Promise.all(
+            opts.image.map((value) => contentFromPathOrUrl(client, spaceId, sessionId, "image", value)),
+          ),
+        );
+        content.push(
+          ...await Promise.all(
+            opts.video.map((value) => contentFromPathOrUrl(client, spaceId, sessionId, "video", value)),
+          ),
+        );
+        content.push(
+          ...await Promise.all(
+            opts.audio.map((value) => contentFromPathOrUrl(client, spaceId, sessionId, "audio", value)),
+          ),
+        );
+        if (content.length === 0) return error("Missing generation input", "Provide a prompt or media input.");
         validateMediaRoleModes(content);
 
         const parameters = parseParams(opts.param, opts.parameters);
@@ -341,10 +372,9 @@ Examples:
         }
 
         const meta = mergeCohubMeta(parseMeta(opts.meta));
-        const client = createClient();
         const created = await client.generations.create({
           spaceId,
-          sessionId: envValue("COHUB_SESSION_ID"),
+          sessionId,
           turnId: envValue("COHUB_TURN_ID"),
           model: opts.model,
           content,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       typescript:
         specifier: 7.0.2
         version: 7.0.2
+      unrun:
+        specifier: ^0.3.1
+        version: 0.3.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -795,7 +798,7 @@ importers:
         version: link:../protocol
       tsdown:
         specifier: ^0.22.7
-        version: 0.22.7(tsx@4.23.1)(typescript@7.0.2)
+        version: 0.22.7(tsx@4.23.1)(typescript@7.0.2)(unrun@0.3.1)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -6606,6 +6609,16 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unrun@0.3.1:
+    resolution: {integrity: sha512-onIck/oNnCaytwths1ZVp1LK2Gq2hPoyFhiHebObuUXqR3S0uHuLLaBK8K6mRRgV7Ptip8AnNvaUsgzwWwBZuA==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      synckit: ^0.11.11
+    peerDependenciesMeta:
+      synckit:
+        optional: true
 
   upath@1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
@@ -12689,7 +12702,7 @@ snapshots:
 
   ts-mixer@6.0.4: {}
 
-  tsdown@0.22.7(tsx@4.23.1)(typescript@7.0.2):
+  tsdown@0.22.7(tsx@4.23.1)(typescript@7.0.2)(unrun@0.3.1):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -12709,6 +12722,7 @@ snapshots:
     optionalDependencies:
       tsx: 4.23.1
       typescript: 7.0.2
+      unrun: 0.3.1
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -12854,6 +12868,10 @@ snapshots:
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
+
+  unrun@0.3.1:
+    dependencies:
+      rolldown: 1.1.5
 
   upath@1.2.0: {}
 


### PR DESCRIPTION
## Summary

- upload local CLI generation media as durable public URLs instead of Base64 payloads
- allow media-only generation commands for models such as BiRefNet
- strip environment values and bootstrap Git credentials from space list/detail responses
- add the missing `unrun` build dependency required by the SDK build configuration

## Why

Platform generation declarations are moving to URL-only media inputs because the downstream providers do not reliably accept Base64. The CLI previously converted local files to Base64, so it needs to upload them before those declarations can be switched safely. Space API responses also exposed raw environment and bootstrap credential values through ordinary list calls.

## Validation

- CLI dependency build and typecheck
- API dependency build, typecheck, and lint
- focused space metadata sanitization tests
- frozen-lockfile install on Node 24
