### PR TITLE
fix: correlate LLM disconnects

### DIFF
--- a/apps/agent/src/runtime/session-runtime.ts
+++ b/apps/agent/src/runtime/session-runtime.ts
@@ -564,6 +564,8 @@ function createStreamFn(getRuntime: () => { modelRegistry: CohubModelRegistry; u
                   user_uuid: runtime.userId,
                   cohub_space_uuid: toolCtx?.spaceId ?? null,
                   cohub_session_uuid: toolCtx?.sessionId ?? null,
+                  cohub_turn_uuid: toolCtx?.turnId ?? null,
+                  cohub_llm_round: round,
                 }),
               }
             : streamHeaders,


### PR DESCRIPTION
## Summary

- include `cohub_turn_uuid` in the existing authenticated LLM tracking metadata
- include `cohub_llm_round` so retries and tool-loop calls remain distinguishable

## Why

New API can only observe that its HTTP caller disconnected. That includes an explicit Stop, a Steer interruption, a page close, a timeout, or a network/proxy break; the socket signal cannot prove which one happened.

Cohub already owns the business reason:

- Stop records `abortRequestedAt` / `abortActorUserId`, then finalizes the turn with `stopReason=aborted` and `summary.reason=abort`
- Steer records `continuedByTurnId`, then finalizes the turn with `stopReason=interrupted` and `summary.reason=steer`

The turn UUID lets operators join New API's neutral `caller_disconnected` event to that authoritative Cohub turn. The LLM round distinguishes multiple upstream calls within one turn.

This intentionally adds no cancellation callback endpoint and no duplicate termination model.

## Behavior

Normal request and response behavior is unchanged. The existing tracking header only gains two correlation dimensions.

## Validation

- `pnpm --filter @cohub/agent... build`
- `pnpm --filter @cohub/agent... typecheck`
- `pnpm --filter @cohub/agent... lint`
- `git diff --check`

Companion New API PR: https://git.talesofai.com/talesofai/new-api/pulls/181
