### PR TITLE
feat(model-status): prefer online heartbeats over probe history for hover chart

### DIFF
--- a/apps/api/src/routes/models-status.route.ts
+++ b/apps/api/src/routes/models-status.route.ts
@@ -56,6 +56,7 @@ type RawCheck = {
 type RawOnlineHeartbeat = {
 	start?: string;
 	success_rate?: number;
+	sample_count?: number;
 };
 
 type RawOnlineModel = {
@@ -102,7 +103,11 @@ function uptime24h(history: RawCheck["history"]): number | null {
 	return total > 0 ? (op / total) * 100 : null;
 }
 
-function slimCheck(c: RawCheck, heartbeats8h: number[] | null): ModelStatusEntry {
+function slimCheck(
+	c: RawCheck,
+	heartbeats8h: Array<number | null> | null,
+	heartbeatsWindowMinutes: number | null,
+): ModelStatusEntry {
 	const windows = c.windows ?? {};
 	const l = c.latency_1h;
 	return {
@@ -116,6 +121,7 @@ function slimCheck(c: RawCheck, heartbeats8h: number[] | null): ModelStatusEntry
 		checkedAt: c.checked_at ?? null,
 		probeIntervalSeconds: c.probe_interval_seconds ?? null,
 		heartbeats8h,
+		heartbeatsWindowMinutes,
 		history: c.history?.length
 			? c.history.map((b) => ({
 					t: b.started_at ?? "",
@@ -145,23 +151,67 @@ async function fetchUpstream(): Promise<ModelStatusResponse> {
 		}
 	}
 
-	// 8h/2min heartbeats from the online section (fine-grained bar chart data).
+	// 8h online heartbeats arrive as 2-min buckets (~240) — too dense for the
+	// 288px hover card (gaps alone would overflow). Resample to 5-min buckets
+	// (96 bars over 8h), matching the validated bar density. Each 5-min bucket
+	// is the sample-weighted mean success rate of the 2-min buckets it covers;
+	// empty buckets stay null (rendered gray).
+	const HEARTBEAT_BUCKET_MS = 5 * 60 * 1000;
+	const windowStartMs = raw.online?.window?.start
+		? Date.parse(raw.online.window.start)
+		: Number.NaN;
+	const windowMinutes = raw.online?.window?.minutes ?? 480;
+	const heartbeatBucketCount = Math.max(1, Math.round(windowMinutes / 5));
+
+	function resampleHeartbeats(heartbeats: RawOnlineHeartbeat[]): Array<number | null> | null {
+		if (!Number.isFinite(windowStartMs) || !heartbeats.length) return null;
+		const acc = new Map<number, { sum: number; weight: number }>();
+		for (const hb of heartbeats) {
+			const t = hb.start ? Date.parse(hb.start) : Number.NaN;
+			if (!Number.isFinite(t) || typeof hb.success_rate !== "number") continue;
+			const idx = Math.floor((t - windowStartMs) / HEARTBEAT_BUCKET_MS);
+			if (idx < 0 || idx >= heartbeatBucketCount) continue;
+			const w = hb.sample_count && hb.sample_count > 0 ? hb.sample_count : 1;
+			const slot = acc.get(idx) ?? { sum: 0, weight: 0 };
+			slot.sum += hb.success_rate * w;
+			slot.weight += w;
+			acc.set(idx, slot);
+		}
+		const out: Array<number | null> = [];
+		for (let i = 0; i < heartbeatBucketCount; i++) {
+			const slot = acc.get(i);
+			out.push(slot && slot.weight > 0 ? Math.round((slot.sum / slot.weight) * 10) / 10 : null);
+		}
+		return out;
+	}
+
 	const onlineModels = raw.online?.models ?? [];
-	const heartbeatsByModel = new Map<string, number[]>();
+	const onlineHeartbeatsByModel = new Map<string, Array<number | null> | null>();
 	for (const m of onlineModels) {
-		if (!m.heartbeats?.length) continue;
-		heartbeatsByModel.set(
-			m.model,
-			m.heartbeats.map((hb) =>
-				typeof hb.success_rate === "number" ? Math.round(hb.success_rate * 10) / 10 : 0,
-			),
+		onlineHeartbeatsByModel.set(m.model, m.heartbeats ? resampleHeartbeats(m.heartbeats) : null);
+	}
+	const onlineWindowMinutes = windowMinutes;
+	const HISTORY_WINDOW_MINUTES = 24 * 60;
+
+	// Per-model bar series: real observed traffic (online) first; fall back to
+	// the probe self-test history for models not yet covered by online (new
+	// models, or a stale/missing online snapshot). Each branch yields 96
+	// buckets; windowMinutes tags the source so the axis label stays honest.
+	function historyRates(c: RawCheck): Array<number | null> {
+		return (c.history ?? []).map((b) =>
+			b.sample_count ? Math.round(((b.operational_samples ?? 0) / b.sample_count) * 100) : null,
 		);
 	}
-	const heartbeats8hStart = raw.online?.window?.start ?? null;
 
 	const models: Record<string, ModelStatusEntry> = {};
-	for (const [id, c] of byModel)
-		models[id] = slimCheck(c, heartbeatsByModel.get(id) ?? null);
+	for (const [id, c] of byModel) {
+		const online = onlineHeartbeatsByModel.get(id) ?? null;
+		if (online?.some((r) => r != null)) {
+			models[id] = slimCheck(c, online, onlineWindowMinutes);
+		} else {
+			models[id] = slimCheck(c, historyRates(c), HISTORY_WINDOW_MINUTES);
+		}
+	}
 
 	const overall = raw.overall_status;
 	const response: ModelStatusResponse = {
@@ -170,7 +220,6 @@ async function fetchUpstream(): Promise<ModelStatusResponse> {
 			overall === "operational" || overall === "degraded" || overall === "outage"
 				? overall
 				: "unknown",
-		heartbeats8hStart,
 		models,
 	};
 

--- a/apps/web/src/lib/components/ModelSelector.svelte
+++ b/apps/web/src/lib/components/ModelSelector.svelte
@@ -5,6 +5,11 @@ import { Brain, Check, ChevronDown, Image } from "lucide-svelte";
 import Dialog from "$lib/components/Dialog.svelte";
 import { isComposingKeyboardEvent } from "$lib/keyboard";
 import {
+	AVAILABILITY_LABEL,
+	type AvailabilityLevel,
+	availabilityLevel,
+} from "$lib/model-availability";
+import {
 	clampThinkingLevel,
 	formatThinkingLevelFull,
 	formatThinkingLevelShort,
@@ -12,11 +17,6 @@ import {
 	getSupportedThinkingLevels,
 	type ModelThinkingLevel,
 } from "$lib/model-catalog";
-import {
-	availabilityLevel,
-	AVAILABILITY_LABEL,
-	type AvailabilityLevel,
-} from "$lib/model-availability";
 
 type ModelItem = {
 	provider: string;
@@ -723,13 +723,21 @@ function fmtMs(ms: number | null | undefined): string {
 	return `${m}m${rs}s`;
 }
 
-function fmtAgo(iso: string | null | undefined): string {
-	if (!iso) return "—";
-	const s = Math.max(0, Math.round((Date.now() - new Date(iso).getTime()) / 1000));
+function fmtAgoSec(s: number): string {
+	s = Math.max(0, Math.round(s));
 	if (s < 60) return `${s}s ago`;
 	const m = Math.floor(s / 60);
 	if (m < 60) return `${m}m ago`;
 	return `${Math.floor(m / 60)}h ago`;
+}
+
+function fmtAgo(iso: string | null | undefined): string {
+	if (!iso) return "—";
+	return fmtAgoSec((Date.now() - new Date(iso).getTime()) / 1000);
+}
+
+function fmtAgoMs(ms: number): string {
+	return fmtAgoSec(ms / 1000);
 }
 
 function fmtRate(rate: number | null | undefined): string {
@@ -763,7 +771,7 @@ function onDotMouseEnter(modelId: string, e: MouseEvent) {
 		hoverShowTimer = setTimeout(() => {
 			hoveredModelId = modelId;
 			hoverAnchorRect = target.getBoundingClientRect();
-		}, 220);
+		}, 120);
 	}
 }
 
@@ -801,8 +809,20 @@ const hoveredLevel = $derived(
 	hoveredModelId ? getAvailabilityLevel(hoveredModelId) : "available",
 );
 
-/** 24h history (96 × 15-min buckets) for the bar chart. */
-const hoveredHistory = $derived(hoveredEntry?.history ?? []);
+/** Bar-chart series (96 buckets): online traffic first, probe history fallback. */
+const hoveredHeartbeats = $derived(hoveredEntry?.heartbeats8h ?? []);
+/** Total minutes the bar series spans (online 480 / history fallback 1440). */
+const hoveredHeartbeatWindowMin = $derived(
+	hoveredEntry?.heartbeatsWindowMinutes ?? 480,
+);
+const hoveredHeartbeatHours = $derived(
+	Math.round(hoveredHeartbeatWindowMin / 60),
+);
+const hoveredHeartbeatPerBucketMin = $derived(
+	hoveredHeartbeats.length
+		? hoveredHeartbeatWindowMin / hoveredHeartbeats.length
+		: 5,
+);
 
 // Card width is fixed at 288px (see .model-avail-card). Estimate height for
 // flip-above calculation; we don't depend on hoverCardEl here to avoid a
@@ -907,11 +927,13 @@ const hoverCardPos = $derived.by(() => {
 									{/if}
 									{#if modelStatus}
 										<span
-											class={`avail-dot avail-dot--${getAvailabilityLevel(item.id)}`}
+											class="avail-dot-target"
 											onmouseenter={(e) => onDotMouseEnter(item.id, e)}
 											onmouseleave={onDotMouseLeave}
 											role="presentation"
-										></span>
+										>
+											<span class={`avail-dot avail-dot--${getAvailabilityLevel(item.id)}`}></span>
+										</span>
 									{/if}
 								</div>
 								{#if costText}
@@ -1152,19 +1174,19 @@ const hoverCardPos = $derived.by(() => {
 		</div>
 		<div class="mt-0.5 font-mono text-[10px] text-text-tertiary">{hoveredModelId}</div>
 		<div class="my-2 h-px bg-border-subtle"></div>
-		<div class="mb-1 text-[10px] font-semibold uppercase tracking-wider text-text-tertiary">Past 24 hours</div>
-		{#if hoveredHistory.length}
+		<div class="mb-1 text-[10px] font-semibold uppercase tracking-wider text-text-tertiary">Past {hoveredHeartbeatHours} hours</div>
+		{#if hoveredHeartbeats.length}
 			<div class="flex items-stretch gap-px h-[26px]">
-				{#each hoveredHistory as bucket}
+				{#each hoveredHeartbeats as rate, i}
 					<i
 						class="avail-bar"
-						style={`background:${rateToBarColor(bucket.rate)}`}
-						title={`${new Date(bucket.t).toLocaleString([], {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'})} · ${fmtRate(bucket.rate)}${bucket.samples ? ` (${bucket.samples})` : ''}`}
+						style={`background:${rateToBarColor(rate)}`}
+						title={`${fmtAgoMs((hoveredHeartbeats.length - 1 - i) * hoveredHeartbeatPerBucketMin * 60 * 1000)} · ${fmtRate(rate)}`}
 					></i>
 				{/each}
 			</div>
 			<div class="mt-1 flex justify-between text-[9px] text-text-tertiary">
-				<span>24h ago</span><span>now</span>
+				<span>{hoveredHeartbeatHours}h ago</span><span>now</span>
 			</div>
 		{:else}
 			<div class="text-[11px] text-text-tertiary">No history</div>
@@ -1194,6 +1216,19 @@ const hoverCardPos = $derived.by(() => {
 {/if}
 
 <style>
+	.avail-dot-target {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex: 0 0 18px;
+		width: 18px;
+		height: 18px;
+		margin: -6px;
+		cursor: help;
+	}
+	.avail-dot-target .avail-dot {
+		margin-left: 0;
+	}
 	.avail-dot {
 		display: inline-block;
 		flex: 0 0 auto;

--- a/packages/protocol/src/model/status.ts
+++ b/packages/protocol/src/model/status.ts
@@ -26,18 +26,24 @@ export type ModelStatusEntry = {
 		samples: number;
 	}> | null;
 	/**
-	 * 8-hour heartbeat rates in 2-minute buckets (oldest → newest), or null.
-	 * Parallel to `heartbeats8hStart`. Drives the fine-grained hover card
-	 * bar chart, matching router-status.neta.art's 8h/2min visualization.
+	 * Bar-chart series (oldest → newest), always 96 buckets. Source is real
+	 * observed traffic (`online` heartbeats resampled to 5-min buckets) when
+	 * available, else the probe self-test `history` (15-min buckets) as a
+	 * fallback for models not yet covered by online. Drives the hover card
+	 * bar chart; color each bucket via the 6-tier success-rate scale.
 	 */
-	heartbeats8h: number[] | null;
+	heartbeats8h: Array<number | null> | null;
+	/**
+	 * Total minutes spanned by `heartbeats8h` (online → 480, history fallback
+	 * → 1440). The frontend divides by bucket count for the per-bar age and
+	 * the axis label, so the window reads honestly regardless of source.
+	 */
+	heartbeatsWindowMinutes: number | null;
 };
 
 export type ModelStatusResponse = {
 	generatedAt: string;
 	overallStatus: ModelAvailabilityStatus | "unknown";
-	/** Start of the 8h heartbeat window (ISO). Buckets are 2 minutes apart. */
-	heartbeats8hStart: string | null;
 	/** Keyed by model id. */
 	models: Record<string, ModelStatusEntry>;
 };


### PR DESCRIPTION
## Problem

The model selector hover card bar chart was drawn from `checks[].history` (probe self-test). A probe's small ping can miss a real-traffic fault, so the chart stayed all-green while the official router-status page (which plots observed traffic) showed a clear fault band.

Concrete case — **gpt-5.5**, same upstream snapshot:

| Source | Meaning | Non-green buckets |
|---|---|---|
| `checks[].history` | probe self-test | **0/32** |
| `online.models[].heartbeats` | real observed traffic | **37/96** |

This is a data-source mismatch, not a cache issue: at the same moment `grok-4.5`'s history already reported `outage 0%`, proving history was fresh — the gpt-5.5 fault simply never tripped the probe.

## Fix

**Online heartbeats first, probe history as fallback**, with the window label tracking the source so the axis stays honest:

- Resample `online.models[].heartbeats` (2-min buckets) into **96 × 5-min** sample-weighted buckets → `Past 8 hours`.
- If a model has no online coverage yet (new model / stale snapshot), fall back to probe `history` (**96 × 15-min**) → `Past 24 hours`.
- Add per-model `heartbeatsWindowMinutes` (480 online / 1440 fallback); the frontend derives per-bar age and the axis label from it. Drop the unused top-level `heartbeats8hStart`.

## Hover UX

- Enlarge the status dot hit area to **18×18px** (visual dot stays 6px) — the 6px target was nearly impossible to hit.
- Cut show delay 220ms → 120ms.
- Card now accepts the pointer (`pointer-events: auto` when open) so moving from dot to card keeps it open; leaving closes it.

## Verification

Replicated the API slimming logic against live `router-status.newapi` data:

```
gpt-5.5            ONLINE   winMin=480   nonGreen=38   ← fault band restored
grok-4.5           ONLINE   winMin=480   nonGreen=50
claude-sonnet-5    ONLINE   winMin=480   nonGreen=11
deepseek-v4-pro    ONLINE   winMin=480   nonGreen=0
gpt-5.5 (no online) HISTORY winMin=1440  nonGreen=0    ← fallback works
```

Standalone prototype validated in-browser (96 bars, fault band matches official, hover open/stay/close all pass).

## Checks

- `@cohub/protocol` + SDK build ✅
- `api` lint ✅
- `web` typecheck ✅ (only pre-existing errors remain: missing local `.env` vars + an untracked WIP vitest test — none in the files touched here)
- `web` lint ✅ (3 pre-existing warnings)