### PR TITLE
[codex] fix(agent): continue incomplete assistant turns

### DIFF
--- a/apps/agent/src/assistant-message-normalizer.ts
+++ b/apps/agent/src/assistant-message-normalizer.ts
@@ -19,6 +19,18 @@ const summarizeThinking = (thinking: string): string => {
   return lines.slice(0, 3).join("\n").slice(0, 600);
 };
 
+export const hasAssistantOutcomeContent = (content: unknown): boolean => {
+  if (!Array.isArray(content)) return false;
+  return content.some((item) => {
+    if (!item || typeof item !== "object") return false;
+    const block = item as Record<string, unknown>;
+    const type = typeof block.type === "string" ? block.type : "";
+    if (type === "text") return typeof block.text === "string" && block.text.trim().length > 0;
+    if (type === "thinking" || type === "redacted_thinking" || type === "reasoning" || type === "reasoning_content") return false;
+    return type.length > 0;
+  });
+};
+
 const summarizeToolArgs = (toolName: string, args: unknown): string => {
   if (!args || typeof args !== "object") return "";
   const record = args as Record<string, unknown>;

--- a/apps/agent/src/persistence.ts
+++ b/apps/agent/src/persistence.ts
@@ -10,7 +10,7 @@ import { sanitizeContentBlocksForPostgresJson, sanitizePostgresJsonValue } from 
 import { countToolCallsInContent, deriveMessagePreviewText, extractPlainText } from "@cohub/core/sessions";
 import { buildTraceHeaders, getCurrentRequestId } from "@cohub/infra/tracing";
 import { enqueueSessionMessagePostprocess } from "./session-message-postprocess-queue.js";
-import { normalizeAssistantTurn } from "./assistant-message-normalizer.js";
+import { hasAssistantOutcomeContent, normalizeAssistantTurn } from "./assistant-message-normalizer.js";
 import { indexTurnReferences } from "./reference-index.js";
 import { db } from "./db.js";
 import { env } from "./env.js";
@@ -623,7 +623,7 @@ export async function persistUserMessage(input: { spaceId: string; sessionId: st
   return { ok: true, message: record };
 }
 
-const EMPTY_ASSISTANT_MESSAGE_ERROR = "LLM returned an empty assistant message after streaming completed.";
+const INCOMPLETE_ASSISTANT_MESSAGE_ERROR = "LLM returned no final assistant output after streaming completed.";
 
 export async function persistAssistantMessage(input: { spaceId: string; spaceSessionId: string; userMessageId: string; event: Record<string, unknown>; userId?: string | null; turnId?: string | null; startedAt?: string | null; completedAt?: string | null; messageOrdinal?: number | null; thinkingLevel?: string | null }) {
   const assistantMessage = input.event.message;
@@ -637,9 +637,9 @@ export async function persistAssistantMessage(input: { spaceId: string; spaceSes
   const stopReason = typeof assistant.stopReason === "string" ? assistant.stopReason : null;
   const errorMessage = typeof assistant.errorMessage === "string" ? assistant.errorMessage : null;
   const hasAssistantError = stopReason === "error" || stopReason === "aborted" || Boolean(errorMessage);
-  const isEmptySuccessfulAssistant = normalized.content.length === 0 && !hasAssistantError;
-  const effectiveStopReason = isEmptySuccessfulAssistant ? "error" : stopReason;
-  const effectiveErrorMessage = isEmptySuccessfulAssistant ? EMPTY_ASSISTANT_MESSAGE_ERROR : errorMessage;
+  const isIncompleteSuccessfulAssistant = !hasAssistantOutcomeContent(normalized.content) && !hasAssistantError;
+  const effectiveStopReason = isIncompleteSuccessfulAssistant ? "error" : stopReason;
+  const effectiveErrorMessage = isIncompleteSuccessfulAssistant ? INCOMPLETE_ASSISTANT_MESSAGE_ERROR : errorMessage;
   const timing = completeMessageTiming({ startedAt: input.startedAt, completedAt: input.completedAt });
 
   const message: PersistMessageInput["message"] = {
@@ -657,7 +657,7 @@ export async function persistAssistantMessage(input: { spaceId: string; spaceSes
     // 与 stream-snapshot API 重新编号的 ordinal:N 不在同一套去重 key 体系里，
     // 导致同一条中间消息在快照恢复与实时事件两条路径里无法合并，最终在
     // ProcessCard/ToolCallList 的 {#each ... (id)} 产生重复 key(each_key_duplicate)。
-    meta: { ...(normalizeRecord(assistant.meta) ?? {}), turnId: input.turnId ?? null, spaceId: input.spaceId, sessionId: input.spaceSessionId, rawStopReason: stopReason, messageOrdinal: input.messageOrdinal ?? null, ...(isEmptySuccessfulAssistant ? { emptyAssistantMessageConvertedToError: true } : {}), thinking: normalized.thinking, thinkingSummary: normalized.thinkingSummary, toolCallRenderStates: normalized.toolCallRenderStates, agentSessionEntryId: typeof assistant.sessionEntryId === "string" ? assistant.sessionEntryId : null },
+    meta: { ...(normalizeRecord(assistant.meta) ?? {}), turnId: input.turnId ?? null, spaceId: input.spaceId, sessionId: input.spaceSessionId, rawStopReason: stopReason, messageOrdinal: input.messageOrdinal ?? null, ...(isIncompleteSuccessfulAssistant ? { incompleteAssistantMessageConvertedToError: true } : {}), thinking: normalized.thinking, thinkingSummary: normalized.thinkingSummary, toolCallRenderStates: normalized.toolCallRenderStates, agentSessionEntryId: typeof assistant.sessionEntryId === "string" ? assistant.sessionEntryId : null },
     usage: normalizeUsage(assistant.usage as PersistMessageInput["message"]["usage"]),
     ...timing,
   };

--- a/apps/agent/src/runtime/session-runtime.ts
+++ b/apps/agent/src/runtime/session-runtime.ts
@@ -13,6 +13,7 @@ import { getCurrentToolExecutionContext, runWithToolExecutionContext, type ToolE
 import { isToolFailureDetails } from "./tools/index.js";
 import { applyRequestProfile } from "./request-profile.js";
 import { mergeHeaders } from "@cohub/infra/config-runtime/models";
+import { hasAssistantOutcomeContent } from "../assistant-message-normalizer.js";
 
 import type { SpaceModListItem } from "@cohub/core/space-mods";
 
@@ -87,15 +88,10 @@ function isRetryableProviderError(message: AssistantMessage | undefined): boolea
   return isRetryableAssistantError(message) || COHUB_RETRYABLE_ERROR_PATTERN.test(message.errorMessage);
 }
 
-function hasAssistantContent(message: AssistantMessage): boolean {
-  const content = Array.isArray(message.content) ? message.content : [];
-  return content.length > 0;
-}
-
-function isEmptySuccessfulAssistantMessage(message: AssistantMessage | undefined): boolean {
+function isIncompleteSuccessfulAssistantMessage(message: AssistantMessage | undefined): boolean {
   if (!message) return false;
   if (message.stopReason === "error" || message.stopReason === "aborted") return false;
-  return !hasAssistantContent(message);
+  return !hasAssistantOutcomeContent(message.content);
 }
 
 /**
@@ -119,7 +115,7 @@ export function isContextOverflowFailure(message: AssistantMessage | undefined):
 
 export function isRetryableAssistantFailure(message: AssistantMessage | undefined): boolean {
   return isRetryableProviderError(message)
-    || isEmptySuccessfulAssistantMessage(message)
+    || isIncompleteSuccessfulAssistantMessage(message)
     || isContextOverflowFailure(message);
 }
 
@@ -149,7 +145,7 @@ function getAssistantRetryOutcome(message: AssistantMessage | undefined, retryAt
       ? "context_overflow"
       : message?.stopReason === "error"
         ? (message?.errorMessage ?? "assistant_error")
-        : "empty_assistant_message",
+        : "missing_assistant_outcome",
     forceCompaction: overflow,
   };
 }

--- a/apps/agent/src/tests/session-retry.test.ts
+++ b/apps/agent/src/tests/session-retry.test.ts
@@ -44,13 +44,18 @@ const emptyUsage: AssistantMessage["usage"] = {
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
 
-type MockOutcome = { error: string } | { text: string };
+type MockOutcome = { error: string } | { text: string } | { thinking: string };
 
 function createAssistantMessage(outcome: MockOutcome): AssistantMessage {
   const failed = "error" in outcome;
+  const content = failed
+    ? []
+    : "thinking" in outcome
+      ? [{ type: "thinking" as const, thinking: outcome.thinking }]
+      : [{ type: "text" as const, text: outcome.text }];
   return {
     role: "assistant",
-    content: failed ? [] : [{ type: "text", text: outcome.text }],
+    content,
     api: "openai-responses",
     provider: "test",
     model: "plain",
@@ -155,6 +160,19 @@ for (const errorMessage of [
 ]) {
   assert.equal(isRetryableAssistantFailure(createAssistantMessage({ error: errorMessage })), false, errorMessage);
 }
+assert.equal(
+  isRetryableAssistantFailure(createAssistantMessage({ thinking: "unfinished reasoning" })),
+  true,
+  "thinking-only completion must be continued",
+);
+assert.equal(
+  isRetryableAssistantFailure({
+    ...createAssistantMessage({ text: "" }),
+    content: [{ type: "text", text: "   " }],
+  }),
+  true,
+  "empty text blocks must be continued",
+);
 
 async function* createThrowingPartialStream(): AsyncGenerator<import("@earendil-works/pi-ai").AssistantMessageEvent> {
   const partial: AssistantMessage = {
@@ -197,6 +215,19 @@ await withSession(
     const assistants = sessionManager.buildSessionContext().messages.filter((message) => message.role === "assistant");
     assert.equal(assistants.length, 1);
     assert.deepEqual(assistants[0]?.content, [{ type: "text", text: "recovered" }]);
+  },
+);
+
+await withSession(
+  [{ thinking: "unfinished reasoning" }, { text: "continued result" }],
+  async ({ session, sessionManager, calls }) => {
+    await session.promptMessages([
+      { role: "user", content: [{ type: "text", text: "continue incomplete reasoning" }], timestamp: Date.now() } as AgentMessage,
+    ]);
+    assert.equal(calls.count, 2);
+    const assistants = sessionManager.buildSessionContext().messages.filter((message) => message.role === "assistant");
+    assert.equal(assistants.length, 1);
+    assert.deepEqual(assistants[0]?.content, [{ type: "text", text: "continued result" }]);
   },
 );
 


### PR DESCRIPTION
## Summary
- treat thinking-only and empty-text assistant completions as incomplete
- reuse the bounded agent continuation path to retry the current LLM round
- persist an error instead of a successful stop if recovery is exhausted

## Root cause
Cohub considered any content block successful, including an unfinished thinking block or an empty text block. That allowed clipped streams normalized as stop to finalize a turn without a usable assistant result.

## Validation
- pnpm --filter @cohub/agent typecheck
- pnpm --filter @cohub/agent lint
- pnpm build:agent
- pnpm --filter @cohub/agent exec tsx src/tests/session-retry.test.ts
- repository pre-commit full typecheck