### PR TITLE
fix(agent): count base64 images when deciding to compact

### DIFF
--- a/apps/agent/src/runtime/compaction-policy.ts
+++ b/apps/agent/src/runtime/compaction-policy.ts
@@ -1,0 +1,71 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+
+/**
+ * Pure compaction policy: context-token accounting.
+ * Deliberately free of db/redis/env imports so it can be unit-tested without
+ * booting the agent's side-effectful module graph.
+ */
+
+// Cap above pi default (16k). Scaled down for small windows so we never
+// reserve more than the whole context (which would compact on every turn).
+const RESERVE_TOKENS_CAP = 32_768;
+const RESERVE_TOKENS_RATIO = 0.25;
+
+// Some provider proxies tokenize inline base64 image payloads as raw text
+// instead of charging vision tokens. Observed ratio on the cohub proxy is
+// ~1.97 chars/token, so one normalized image can bill ~100k tokens while pi's
+// heuristic estimates a flat 1.2k. Without this lower bound the accurate
+// provider usage stays far below the threshold and auto-compaction never runs
+// until the request hard-fails with a context-overflow error.
+const BASE64_CHARS_PER_TOKEN = 2;
+const TEXT_CHARS_PER_TOKEN = 4;
+
+/** Resolve reserveTokens for a model context window. */
+export function resolveReserveTokens(contextWindow: number): number {
+  if (contextWindow <= 0) return RESERVE_TOKENS_CAP;
+  return Math.min(RESERVE_TOKENS_CAP, Math.max(1, Math.floor(contextWindow * RESERVE_TOKENS_RATIO)));
+}
+
+function safeBlockLength(block: Record<string, unknown>): number {
+  try {
+    return JSON.stringify(block)?.length ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Estimate context tokens the way a base64-counting proxy would bill them. */
+export function estimateProxyContextTokens(messages: AgentMessage[]): number {
+  let textChars = 0;
+  let base64Chars = 0;
+
+  for (const message of messages) {
+    const content = (message as unknown as { content?: unknown }).content;
+    if (typeof content === "string") {
+      textChars += content.length;
+      continue;
+    }
+    if (!Array.isArray(content)) continue;
+
+    for (const block of content) {
+      if (!block || typeof block !== "object" || Array.isArray(block)) continue;
+      const record = block as Record<string, unknown>;
+      if (record.type === "image") {
+        // Data-less image blocks carry no payload to bill.
+        if (typeof record.data === "string") base64Chars += record.data.length;
+        continue;
+      }
+      if (typeof record.text === "string") {
+        textChars += record.text.length;
+        continue;
+      }
+      if (typeof record.thinking === "string") {
+        textChars += record.thinking.length;
+        continue;
+      }
+      textChars += safeBlockLength(record);
+    }
+  }
+
+  return Math.ceil(textChars / TEXT_CHARS_PER_TOKEN) + Math.ceil(base64Chars / BASE64_CHARS_PER_TOKEN);
+}

--- a/apps/agent/src/runtime/compaction.ts
+++ b/apps/agent/src/runtime/compaction.ts
@@ -18,6 +18,8 @@ import { and, eq, sql } from "drizzle-orm";
 import { getCurrentToolExecutionContext } from "../tool-context.js";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { createModelsFromCohubRegistry } from "./pi-models-adapter.js";
+import { estimateProxyContextTokens, resolveReserveTokens } from "./compaction-policy.js";
+import { isRetryableProviderErrorMessage } from "./session-runtime.js";
 
 export type CompactionOutcome =
   | { compacted: true; summary: string; tokensBefore: number; firstKeptEntryId: string; archivePath: string | undefined; compactSequence: number }
@@ -31,17 +33,6 @@ export class OverflowRecoveryError extends Error {
     this.name = "OverflowRecoveryError";
     this.reason = reason;
   }
-}
-
-// Cap above pi default (16k). Scaled down for small windows so we never
-// reserve more than the whole context (which would compact on every turn).
-const RESERVE_TOKENS_CAP = 32_768;
-const RESERVE_TOKENS_RATIO = 0.25;
-
-/** Resolve reserveTokens for a model context window (exported for tests). */
-export function resolveReserveTokens(contextWindow: number): number {
-  if (contextWindow <= 0) return RESERVE_TOKENS_CAP;
-  return Math.min(RESERVE_TOKENS_CAP, Math.max(1, Math.floor(contextWindow * RESERVE_TOKENS_RATIO)));
 }
 
 function resolveCompactionSettings(contextWindow: number) {
@@ -91,6 +82,42 @@ function getCompactableBranchEntries(handle: SessionHandle) {
   return currentTurnStartIndex >= 0 ? branchEntries.slice(0, currentTurnStartIndex) : branchEntries;
 }
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const SUMMARIZE_MAX_ATTEMPTS = 2;
+const SUMMARIZE_RETRY_DELAY_MS = 1_000;
+
+/**
+ * Summarize with a small retry budget of its own.
+ *
+ * The summarize call is a plain LLM request and hits the same transient upstream
+ * failures (timeouts, 5xx) as any other. Without a retry here a single blip fails
+ * the whole compaction, and for overflow recovery that fails the turn. Retry
+ * eligibility reuses the assistant-retry classification so quota / content-filter
+ * style errors still fail fast.
+ */
+async function compactWithRetry(
+  handle: SessionHandle,
+  preparation: Parameters<typeof compact>[0],
+  models: Parameters<typeof compact>[1],
+  model: Parameters<typeof compact>[2],
+  abortSignal?: AbortSignal,
+): Promise<Awaited<ReturnType<typeof compact>>> {
+  let result = await compact(preparation, models, model, undefined, abortSignal);
+
+  for (let attempt = 1; attempt < SUMMARIZE_MAX_ATTEMPTS && !result.ok; attempt++) {
+    const error = result.error.message;
+    if (abortSignal?.aborted || !isRetryableProviderErrorMessage(error)) break;
+    logger.warn(
+      `[Compaction] summarization attempt ${attempt}/${SUMMARIZE_MAX_ATTEMPTS} failed sessionId=${handle.sessionId}, retrying: ${error}`,
+    );
+    await sleep(SUMMARIZE_RETRY_DELAY_MS);
+    result = await compact(preparation, models, model, undefined, abortSignal);
+  }
+
+  return result;
+}
+
 /**
  * Check if the session needs auto-compaction and run it if so.
  * Called before LLM requests while the session lock is held.
@@ -119,16 +146,21 @@ export async function maybeAutoCompact(
   const force = input.force === true;
   const messages = handle.session.agent.state.messages;
   const tokenBudget = getContextTokenBudget(messages);
+  // Provider usage undercounts inline base64 images on proxies that bill them
+  // as text, so take the larger of the two views for the threshold decision.
+  // tokensBefore reporting keeps using the accurate provider number.
+  const proxyTokens = estimateProxyContextTokens(messages);
+  const thresholdTokens = Math.max(tokenBudget?.estimatedTokens ?? 0, proxyTokens);
   if (!force) {
-    if (!tokenBudget) return { compacted: false, reason: "no_usage_data" };
-    if (!shouldCompact(tokenBudget.estimatedTokens, contextWindow, settings)) {
+    if (!tokenBudget && proxyTokens <= 0) return { compacted: false, reason: "no_usage_data" };
+    if (!shouldCompact(thresholdTokens, contextWindow, settings)) {
       return { compacted: false, reason: "below_threshold" };
     }
   }
 
   const tokensLabel = tokenBudget?.estimatedTokens ?? "unknown";
   logger.info(
-    `[Compaction] ${force ? "overflow-compact" : "auto-compact"} triggered sessionId=${handle.sessionId} contextWindow=${contextWindow} reserve=${settings.reserveTokens} tokens=${tokensLabel}`,
+    `[Compaction] ${force ? "overflow-compact" : "auto-compact"} triggered sessionId=${handle.sessionId} contextWindow=${contextWindow} reserve=${settings.reserveTokens} tokens=${tokensLabel} proxyTokens=${proxyTokens}`,
   );
 
   const tracer = getAgentTracer();
@@ -159,19 +191,14 @@ export async function maybeAutoCompact(
       }
 
       span.setAttribute("agent.compaction.tokens_before", preparation.tokensBefore);
+      span.setAttribute("agent.compaction.proxy_tokens", proxyTokens);
       span.setAttribute("agent.compaction.messages_to_summarize", preparation.messagesToSummarize.length);
 
       const apiKey = handle.session.modelRegistry.getApiKey(model.provider);
       if (!apiKey) return { compacted: false, reason: "no_api_key" };
 
       const models = createModelsFromCohubRegistry(handle.session.modelRegistry, model);
-      const compactResult = await compact(
-        preparation,
-        models,
-        model,
-        undefined,
-        input.abortSignal,
-      );
+      const compactResult = await compactWithRetry(handle, preparation, models, model, input.abortSignal);
       if (!compactResult.ok) {
         span.setAttribute("agent.compaction.error", compactResult.error.message);
         logger.warn(`[Compaction] summarization failed sessionId=${handle.sessionId}: ${compactResult.error.message}`);

--- a/apps/agent/src/runtime/session-runtime.ts
+++ b/apps/agent/src/runtime/session-runtime.ts
@@ -75,16 +75,35 @@ function getHttpErrorStatus(errorMessage: string): number | null {
   return status ? Number(status) : null;
 }
 
+/**
+ * Classify a raw provider error string. `null` means the string alone is
+ * inconclusive and the caller should consult pi's own classification.
+ */
+function classifyProviderErrorMessage(errorMessage: string): boolean | null {
+  if (COHUB_RETRYABLE_ERROR_OVERRIDE_PATTERN.test(errorMessage)) return true;
+  if (COHUB_NON_RETRYABLE_ERROR_PATTERN.test(errorMessage)) return false;
+
+  const status = getHttpErrorStatus(errorMessage);
+  if (status != null) return status === 408 || status === 413 || status === 429 || status >= 500;
+  if (COHUB_MODEL_UNAVAILABLE_PATTERN.test(errorMessage)) return false;
+  if (COHUB_RETRYABLE_ERROR_PATTERN.test(errorMessage)) return true;
+
+  return null;
+}
+
+/**
+ * Whether a raw provider error string is worth retrying. Shares the rules used
+ * for assistant retries so callers holding only an error message (compaction's
+ * summarize step) don't invent their own classification.
+ */
+export function isRetryableProviderErrorMessage(errorMessage: string): boolean {
+  if (!errorMessage) return false;
+  return classifyProviderErrorMessage(errorMessage) === true;
+}
+
 function isRetryableProviderError(message: AssistantMessage | undefined): boolean {
   if (message?.stopReason !== "error" || !message.errorMessage) return false;
-  if (COHUB_RETRYABLE_ERROR_OVERRIDE_PATTERN.test(message.errorMessage)) return true;
-  if (COHUB_NON_RETRYABLE_ERROR_PATTERN.test(message.errorMessage)) return false;
-
-  const status = getHttpErrorStatus(message.errorMessage);
-  if (status != null) return status === 408 || status === 413 || status === 429 || status >= 500;
-  if (COHUB_MODEL_UNAVAILABLE_PATTERN.test(message.errorMessage)) return false;
-
-  return isRetryableAssistantError(message) || COHUB_RETRYABLE_ERROR_PATTERN.test(message.errorMessage);
+  return classifyProviderErrorMessage(message.errorMessage) ?? isRetryableAssistantError(message);
 }
 
 function hasAssistantContent(message: AssistantMessage): boolean {

--- a/apps/agent/src/tests/compaction-policy.test.ts
+++ b/apps/agent/src/tests/compaction-policy.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { DEFAULT_COMPACTION_SETTINGS, shouldCompact } from "@earendil-works/pi-agent-core";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { estimateProxyContextTokens, resolveReserveTokens } from "../runtime/compaction-policy.js";
+
+const asMessages = (messages: unknown[]) => messages as AgentMessage[];
+
+const textMessage = (text: string) => ({ role: "user", content: [{ type: "text", text }] });
+const imageMessage = (base64Chars: number) => ({
+  role: "user",
+  content: [{ type: "image", data: "a".repeat(base64Chars), mimeType: "image/webp" }],
+});
+
+// ── Text is charged at the usual ~4 chars/token ──
+assert.equal(estimateProxyContextTokens(asMessages([textMessage("a".repeat(400))])), 100);
+assert.equal(estimateProxyContextTokens(asMessages([{ role: "user", content: "a".repeat(40) }])), 10);
+
+// ── Inline base64 images are charged at ~2 chars/token, not pi's flat 1.2k ──
+assert.equal(estimateProxyContextTokens(asMessages([imageMessage(200_000)])), 100_000);
+
+// ── Mixed content sums both views ──
+assert.equal(
+  estimateProxyContextTokens(asMessages([textMessage("a".repeat(400)), imageMessage(1_000)])),
+  100 + 500,
+);
+
+// ── Thinking blocks and unknown block shapes still contribute ──
+assert.equal(
+  estimateProxyContextTokens(asMessages([{ role: "assistant", content: [{ type: "thinking", thinking: "a".repeat(40) }] }])),
+  10,
+);
+assert.ok(
+  estimateProxyContextTokens(asMessages([{ role: "assistant", content: [{ type: "toolCall", name: "read", arguments: { path: "/tmp/x" } }] }])) > 0,
+);
+
+// ── Malformed content never throws ──
+assert.equal(estimateProxyContextTokens(asMessages([{ role: "user" }])), 0);
+assert.equal(estimateProxyContextTokens(asMessages([{ role: "user", content: null }])), 0);
+assert.equal(estimateProxyContextTokens(asMessages([{ role: "user", content: [null, 42, "raw"] }])), 0);
+assert.equal(estimateProxyContextTokens(asMessages([])), 0);
+
+// ── Images without usable data are ignored rather than guessed at ──
+assert.equal(estimateProxyContextTokens(asMessages([{ role: "user", content: [{ type: "image", mimeType: "image/webp" }] }])), 0);
+
+// ── Regression: session f17dad70 sat below the threshold and never auto-compacted ──
+// 45 normalized images (~196k base64 chars each) plus ~324k chars of text. The
+// provider reported 4,564,921 tokens against a 1M window while pi's estimate
+// stayed at ~189k, so shouldCompact never fired.
+const contextWindow = 1_000_000;
+const settings = { ...DEFAULT_COMPACTION_SETTINGS, reserveTokens: resolveReserveTokens(contextWindow) };
+const stuckSession = asMessages([
+  textMessage("a".repeat(324_000)),
+  ...Array.from({ length: 45 }, () => imageMessage(196_074)),
+]);
+
+const proxyTokens = estimateProxyContextTokens(stuckSession);
+assert.ok(
+  proxyTokens > 4_000_000 && proxyTokens < 5_000_000,
+  `expected proxy estimate near the reported 4.56M, got ${proxyTokens}`,
+);
+
+// pi's own view of the same context stays far below the threshold …
+assert.equal(shouldCompact(189_451, contextWindow, settings), false);
+// … while the base64-aware lower bound triggers compaction before the 413.
+assert.equal(shouldCompact(Math.max(189_451, proxyTokens), contextWindow, settings), true);
+
+// ── An image-free session is unaffected by the new lower bound ──
+const textOnlySession = asMessages([textMessage("a".repeat(400_000))]);
+assert.equal(estimateProxyContextTokens(textOnlySession), 100_000);
+assert.equal(shouldCompact(Math.max(100_000, estimateProxyContextTokens(textOnlySession)), contextWindow, settings), false);
+
+// ── Reserve tokens scale down for small windows, cap for large ones ──
+assert.equal(resolveReserveTokens(1_000_000), 32_768);
+assert.equal(resolveReserveTokens(8_000), 2_000);
+assert.equal(resolveReserveTokens(0), 32_768);
+assert.ok(resolveReserveTokens(4) >= 1);
+
+console.log("compaction-policy: ok");


### PR DESCRIPTION
Sessions could sit far below the compaction threshold while the provider proxy rejected every request with a context overflow. pi estimates an inline image at a flat 1.2k tokens, but the cohub proxy bills the raw base64 at ~1.97 chars/token, so 45 normalized images read as ~54k tokens locally and ~4.5M upstream. Auto-compaction never fired and the session stalled on repeated 413s.

Take the larger of pi's estimate and a base64-aware lower bound for the threshold decision. tokensBefore reporting keeps using the accurate provider usage, so the UI is unchanged.

Also give the summarize call a small retry budget. It is a plain LLM request and hits the same transient timeouts and 5xx as any other, and a single blip previously failed the whole compaction. Retry eligibility reuses the existing assistant-retry classification, extracted to a tri-state helper so the non-retryable guards (quota, content filter) still win over the status-code check.