### PR TITLE
[codex] Fix public Work viewport on iPad Safari

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -28,6 +28,29 @@ body {
 		color 0.2s ease;
 }
 
+/* Public Works must follow Safari's visible viewport, not its larger layout viewport. */
+.public-work-viewport {
+	--public-work-viewport-height: 100vh;
+
+	width: 100%;
+	height: var(--public-work-viewport-height);
+	min-height: 0;
+	overflow: hidden;
+	overscroll-behavior: none;
+}
+
+@supports (height: 100svh) {
+	.public-work-viewport {
+		--public-work-viewport-height: 100svh;
+	}
+}
+
+@supports (height: 100dvh) {
+	.public-work-viewport {
+		--public-work-viewport-height: 100dvh;
+	}
+}
+
 /* Motion tokens — keep numeric values aligned with $lib/motion.svelte.ts */
 :root {
 	--motion-panel-duration: 280ms;

--- a/apps/web/src/lib/components/work/WorkSurface.svelte
+++ b/apps/web/src/lib/components/work/WorkSurface.svelte
@@ -148,7 +148,11 @@ onMount(() => {
 	{/if}
 </svelte:head>
 
-<div class={isBackground ? "work-surface background" : "work-surface page"}>
+<div
+	class={isBackground
+		? "work-surface background"
+		: "work-surface page public-work-viewport"}
+>
 	{#if shouldRenderFrame}
 		<iframe
 			bind:this={frame}
@@ -224,10 +228,6 @@ onMount(() => {
 		color: var(--text-primary);
 	}
 
-	.work-surface.page {
-		min-height: 100vh;
-	}
-
 	.work-surface.background {
 		width: 100%;
 		height: 100%;
@@ -243,7 +243,7 @@ onMount(() => {
 	}
 
 	.work-surface.page .work-frame {
-		height: 100vh;
+		height: 100%;
 	}
 
 	.empty-state {

--- a/apps/web/src/routes/(public)/[username]/[spaceSlug]/w/[workSlug]/+page.svelte
+++ b/apps/web/src/routes/(public)/[username]/[spaceSlug]/w/[workSlug]/+page.svelte
@@ -126,16 +126,16 @@ $effect(() => {
 	/>
 {:else if ready}
 	<!-- SSR / first paint: head already has share meta; surface hydrates client-side. -->
-	<div class="min-h-screen bg-bg-primary" aria-hidden="true"></div>
+	<div class="public-work-viewport bg-bg-primary" aria-hidden="true"></div>
 {:else if clientLoading}
 	<div
-		class="flex min-h-screen items-center justify-center bg-bg-primary px-4 text-[13px] text-text-tertiary"
+		class="public-work-viewport flex items-center justify-center bg-bg-primary px-4 text-[13px] text-text-tertiary"
 	>
 		Loading Work…
 	</div>
 {:else}
 	<div
-		class="flex min-h-screen items-center justify-center bg-bg-primary px-4 text-[13px] text-text-secondary"
+		class="public-work-viewport flex items-center justify-center bg-bg-primary px-4 text-[13px] text-text-secondary"
 	>
 		{clientError || "Work is unavailable."}
 	</div>

--- a/apps/web/src/tests/work-surface-viewport.test.ts
+++ b/apps/web/src/tests/work-surface-viewport.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const appCss = readFileSync(new URL("../app.css", import.meta.url), "utf8");
+const workSurface = readFileSync(
+	new URL("../lib/components/work/WorkSurface.svelte", import.meta.url),
+	"utf8",
+);
+const publicWorkPage = readFileSync(
+	new URL(
+		"../routes/(public)/[username]/[spaceSlug]/w/[workSlug]/+page.svelte",
+		import.meta.url,
+	),
+	"utf8",
+);
+
+test("public Works fit Safari's visible viewport in every render state", () => {
+	const viewportRule = cssRule(appCss, ".public-work-viewport");
+
+	assert.match(viewportRule, /--public-work-viewport-height:\s*100vh/);
+	assert.match(viewportRule, /height:\s*var\(--public-work-viewport-height\)/);
+	assert.match(viewportRule, /overflow:\s*hidden/);
+	assert.match(viewportRule, /overscroll-behavior:\s*none/);
+	assert.match(
+		appCss,
+		/@supports \(height: 100svh\)[\s\S]*--public-work-viewport-height:\s*100svh/,
+	);
+	assert.match(
+		appCss,
+		/@supports \(height: 100dvh\)[\s\S]*--public-work-viewport-height:\s*100dvh/,
+	);
+	assert.match(workSurface, /work-surface page public-work-viewport/);
+	assert.match(
+		workSurface,
+		/\.work-surface\.page \.work-frame\s*\{[^}]*height:\s*100%/s,
+	);
+	assert.doesNotMatch(workSurface, /(?:min-)?height:\s*100vh/);
+	assert.equal(publicWorkPage.match(/public-work-viewport/g)?.length, 3);
+	assert.doesNotMatch(publicWorkPage, /min-h-screen/);
+});
+
+function cssRule(source: string, selector: string): string {
+	const start = source.indexOf(`${selector} {`);
+	assert.notEqual(start, -1, `Missing ${selector} rule`);
+	const end = source.indexOf("}", start);
+	assert.notEqual(end, -1, `Unclosed ${selector} rule`);
+	return source.slice(start, end + 1);
+}


### PR DESCRIPTION
## What changed

- size public Work pages from the dynamic visible viewport instead of `100vh`
- apply the same viewport contract to SSR, loading, error, and iframe states
- keep the Cohub footer bar unchanged
- add a regression test for the public Work viewport contract

## Why

On iPad Safari, `100vh` resolves to the larger viewport used when browser chrome is collapsed. With the address and tab bars visible, the Work iframe extended below the visible page and placed bottom controls off-screen.

## Impact

Public Works now fit the currently visible browser area across desktop, mobile Safari, and standalone/PWA modes. Browsers without dynamic viewport units retain the existing `100vh` fallback.

## Validation

- `pnpm --filter web test` (539 tests)
- `pnpm --filter web typecheck`
- repository pre-commit typecheck across all workspaces
- Biome check on changed files
- production Web build
