### PR TITLE
docs: correct Seedance Fast resolutions

### DIFF
--- a/docs/examples/generations/seedance-2-0-fast.yaml
+++ b/docs/examples/generations/seedance-2-0-fast.yaml
@@ -31,7 +31,7 @@ parameters:
     type: string
     optional: true
     default: 720p
-    enum: [480p, 720p, 1080p, 2K]
+    enum: [480p, 720p]
     description: Output video resolution.
   aspect_ratio:
     type: string


### PR DESCRIPTION
## Summary
- document Seedance 2.0 Fast as supporting only 480p and 720p
- leave the standard Seedance declaration unchanged

## Verification
- parsed the YAML declaration and asserted the resolution enum is `[480p, 720p]`