### PR TITLE
feat(identity): migrate Cohub principals to Logto sub

### DIFF
--- a/.changeset/logto-sub-identity-bridge.md
+++ b/.changeset/logto-sub-identity-bridge.md
@@ -1,0 +1,9 @@
+---
+"@neta-art/cohub": minor
+---
+
+Add migration-safe canonical and legacy user identity support.
+
+- Expose the optional legacy user UUID alongside the canonical Logto subject.
+- Let Work Bridge hosts provide canonical and legacy viewer identity keys for
+  ownership and persisted-scope checks during the identity migration.

--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -21,6 +21,7 @@
     "@cohub/core": "workspace:*",
     "@cohub/db": "workspace:*",
     "@cohub/infra": "workspace:*",
+    "@cohub/identity": "workspace:*",
     "@cohub/protocol": "workspace:*",
     "@cohub/sandbox-client": "workspace:*",
     "@cohub/sandbox-controller": "workspace:*",

--- a/apps/agent/src/identity-bridge.ts
+++ b/apps/agent/src/identity-bridge.ts
@@ -1,0 +1,32 @@
+import { inArray, or } from "drizzle-orm";
+import { userProfiles } from "@cohub/db";
+import {
+  resolveStoredPrincipalIdentity,
+  resolveStoredPrincipalIdentityForRead,
+  type IdentityMappingRow,
+} from "@cohub/identity";
+import { db } from "./db.js";
+
+export async function resolveStoredPrincipalIdentityForAgent(principalId: string) {
+  const normalized = principalId.trim();
+  const mappings: IdentityMappingRow[] = await db
+    .select({ userUuid: userProfiles.userUuid, logtoUserId: userProfiles.logtoUserId })
+    .from(userProfiles)
+    .where(or(
+      inArray(userProfiles.userUuid, [normalized]),
+      inArray(userProfiles.logtoUserId, [normalized]),
+    ));
+  return resolveStoredPrincipalIdentity({ principalId: normalized, mappings });
+}
+
+export async function resolveStoredPrincipalIdentityForAgentRead(principalId: string) {
+  const normalized = principalId.trim();
+  const mappings: IdentityMappingRow[] = await db
+    .select({ userUuid: userProfiles.userUuid, logtoUserId: userProfiles.logtoUserId })
+    .from(userProfiles)
+    .where(or(
+      inArray(userProfiles.userUuid, [normalized]),
+      inArray(userProfiles.logtoUserId, [normalized]),
+    ));
+  return resolveStoredPrincipalIdentityForRead({ principalId: normalized, mappings });
+}

--- a/apps/agent/src/persistence.ts
+++ b/apps/agent/src/persistence.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, asc, desc, eq, gte, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, inArray, or, sql } from "drizzle-orm";
 import type { ContentBlock, Usage } from "@cohub/protocol/core";
 import type {
   ContextCompactionMeta,
@@ -30,6 +30,8 @@ import { logger } from "./logger.js";
 import { redis, publishRealtimeEnvelope, clearPersistedSessionStreamSnapshot, getGatewayNodeOutboundStreamKey, xaddWithMaxlen } from "./redis.js";
 import { buildTurnObjectPrefix, writeTurnObjectJson } from "./turn-object-storage.js";
 import { pickRealtimeMessageMeta } from "./realtime-message-meta.js";
+import { resolveStoredPrincipalIdentityForAgent } from "./identity-bridge.js";
+import { getIdentityKeys } from "@cohub/identity";
 
 
 const INTERNAL_API_BASE_URL =
@@ -174,26 +176,38 @@ const toTurnRecord = (row: typeof sessionTurns.$inferSelect): SessionTurnRecord 
 
 const fallbackDisplayName = (userUuid: string) => userUuid.replaceAll("-", "").slice(0, 8);
 
-async function hydrateTurnAuthorProfile(turn: SessionTurnRecord): Promise<SessionTurnRecord> {
-  if (!turn.userUuid) return { ...turn, authorProfile: null };
+async function hydrateTurnAuthorProfile(turn: SessionTurnRecord): Promise<{
+  turn: SessionTurnRecord;
+  userRooms: ReturnType<typeof getRealtimeUserRoom>[];
+}> {
+  if (!turn.userUuid) return { turn: { ...turn, authorProfile: null }, userRooms: [] };
+  const identity = await resolveStoredPrincipalIdentityForAgent(turn.userUuid);
   const [profile] = await db.select({
     userUuid: userProfiles.userUuid,
     displayName: userProfiles.displayName,
     avatarUrl: userProfiles.avatarUrl,
-  }).from(userProfiles).where(eq(userProfiles.userUuid, turn.userUuid)).limit(1);
-  return {
+  }).from(userProfiles).where(or(
+    eq(userProfiles.userUuid, turn.userUuid),
+    eq(userProfiles.logtoUserId, turn.userUuid),
+  )).limit(1);
+  const canonicalTurn = {
     ...turn,
+    userUuid: identity.uuid,
     authorProfile: profile
       ? {
-          userUuid: profile.userUuid,
+          userUuid: identity.uuid,
           displayName: profile.displayName,
           avatarUrl: profile.avatarUrl ?? null,
         }
       : {
-          userUuid: turn.userUuid,
-          displayName: fallbackDisplayName(turn.userUuid),
+          userUuid: identity.uuid,
+          displayName: fallbackDisplayName(identity.uuid),
           avatarUrl: null,
         },
+  };
+  return {
+    turn: canonicalTurn,
+    userRooms: getIdentityKeys(identity).map(getRealtimeUserRoom),
   };
 }
 
@@ -210,8 +224,8 @@ async function publishMessagePersisted(spaceId: string, message: MessageRecord) 
 }
 
 async function publishTurnCreated(spaceId: string, turn: SessionTurnRecord) {
-  const hydratedTurn = await hydrateTurnAuthorProfile(turn);
-  await publishRealtimeEnvelope({ domain: "session", type: "session.turn.created", spaceId, sessionId: hydratedTurn.sessionId, payload: { turn: hydratedTurn } });
+  const hydrated = await hydrateTurnAuthorProfile(turn);
+  await publishRealtimeEnvelope({ domain: "session", type: "session.turn.created", spaceId, sessionId: hydrated.turn.sessionId, payload: { turn: hydrated.turn } });
 }
 
 const truncateTurnPreview = (text: string | null | undefined) => {
@@ -221,28 +235,29 @@ const truncateTurnPreview = (text: string | null | undefined) => {
 };
 
 async function publishTurnFinalized(spaceId: string, turn: SessionTurnRecord) {
-  await clearPersistedSessionStreamSnapshot(spaceId, turn.sessionId);
-  await publishRealtimeEnvelope({ domain: "session", type: "session.turn.finalized", spaceId, sessionId: turn.sessionId, payload: { turn } });
-  if (!turn.userUuid) return;
+  const hydrated = await hydrateTurnAuthorProfile(turn);
+  await clearPersistedSessionStreamSnapshot(spaceId, hydrated.turn.sessionId);
+  await publishRealtimeEnvelope({ domain: "session", type: "session.turn.finalized", spaceId, sessionId: hydrated.turn.sessionId, payload: { turn: hydrated.turn } });
+  if (hydrated.userRooms.length === 0) return;
   await publishRealtimeEnvelope({
     domain: "session",
     type: "session.turn.notify",
     spaceId,
-    sessionId: turn.sessionId,
-    rooms: [getRealtimeUserRoom(turn.userUuid)],
+    sessionId: hydrated.turn.sessionId,
+    rooms: hydrated.userRooms,
     payload: {
       spaceId,
-      sessionId: turn.sessionId,
-      turnId: turn.id,
-      status: turn.status,
-      finishReason: turn.summary?.finishReason ?? null,
-      userPreview: truncateTurnPreview(turn.userText),
-      durationMs: turn.durationMs,
-      stepCount: turn.intermediateSummary?.messageCount ?? null,
-      sequence: turn.sequence ?? null,
-      provider: turn.provider,
-      model: turn.model,
-      completedAt: turn.completedAt,
+      sessionId: hydrated.turn.sessionId,
+      turnId: hydrated.turn.id,
+      status: hydrated.turn.status,
+      finishReason: hydrated.turn.summary?.finishReason ?? null,
+      userPreview: truncateTurnPreview(hydrated.turn.userText),
+      durationMs: hydrated.turn.durationMs,
+      stepCount: hydrated.turn.intermediateSummary?.messageCount ?? null,
+      sequence: hydrated.turn.sequence ?? null,
+      provider: hydrated.turn.provider,
+      model: hydrated.turn.model,
+      completedAt: hydrated.turn.completedAt,
     },
   });
 }

--- a/apps/agent/src/processor.ts
+++ b/apps/agent/src/processor.ts
@@ -33,6 +33,7 @@ import { env } from "./env.js";
 import { logger } from "./logger.js";
 import { getPromptAuthScopes, parsePromptEnv, type PromptAccessMode } from "@cohub/core/sessions";
 import { createAgentExecutionToken } from "./execution-grants.js";
+import { resolveStoredPrincipalIdentityForAgent } from "./identity-bridge.js";
 
 
 const sessionHandles = new Map<string, SessionHandle>();
@@ -830,8 +831,9 @@ export async function processAgentTurnJob(job: Job<AgentTurnJobData>) {
       const ownerMeta = (batch.ownerTurn.meta && typeof batch.ownerTurn.meta === "object" && !Array.isArray(batch.ownerTurn.meta)
         ? batch.ownerTurn.meta as Record<string, unknown>
         : {});
-      const actorUserId = resolveActorUserId(ownerMeta);
-      if (!actorUserId) throw new Error("Agent turn requires actorUserId for execution token");
+      const storedActorUserId = resolveActorUserId(ownerMeta);
+      if (!storedActorUserId) throw new Error("Agent turn requires actorUserId for execution token");
+      const actorUserId = (await resolveStoredPrincipalIdentityForAgent(storedActorUserId)).uuid;
       const promptContext = ownerMeta.context && typeof ownerMeta.context === "object" && !Array.isArray(ownerMeta.context)
         ? ownerMeta.context as Record<string, unknown>
         : null;

--- a/apps/agent/src/runtime/cross-space-query-access.ts
+++ b/apps/agent/src/runtime/cross-space-query-access.ts
@@ -5,6 +5,7 @@ import { spaces } from "@cohub/db";
 import { db } from "../db.js";
 import { assertValidSpaceId } from "./ids.js";
 import type { AgentFileVisibility } from "./workspace-visibility.js";
+import { resolveStoredPrincipalIdentityForAgent } from "../identity-bridge.js";
 
 const permissionStore = createDrizzlePermissionStore(db);
 
@@ -28,7 +29,7 @@ export async function resolveSpaceFileVisibility(input: {
   const promptAuthVisibility = visibilityFromPromptAuth(input.promptAuth, spaceId);
   if (promptAuthVisibility) return promptAuthVisibility;
 
-  const user = { uuid: input.actorUserId };
+  const user = await resolveStoredPrincipalIdentityForAgent(input.actorUserId);
   const context = { spaceId };
   const visibility = await hasPermission({ store: permissionStore, user, permission: "file.view", context })
     ? "full"

--- a/apps/agent/src/runtime/ids.ts
+++ b/apps/agent/src/runtime/ids.ts
@@ -1,3 +1,5 @@
+import { isStorageSafePrincipalId } from "@cohub/identity";
+
 export const UUID_PATTERN = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}";
 export const SHORT_UUID_PATTERN = "[0-9a-fA-F]{32}";
 export const UUID_OR_SHORT_UUID_PATTERN = `^(?:${UUID_PATTERN}|${SHORT_UUID_PATTERN})$`;
@@ -17,7 +19,11 @@ export function assertValidId(value: string, label = "id") {
 }
 
 export function assertValidUserId(userId: string) {
-  return assertValidId(userId, "userId");
+  const trimmed = userId.trim();
+  if (!isStorageSafePrincipalId(trimmed)) {
+    throw new Error(`Invalid userId: expected a storage-safe principal id, got ${JSON.stringify(userId)}.`);
+  }
+  return trimmed;
 }
 
 export function assertValidSpaceId(spaceId: string) {

--- a/apps/agent/src/runtime/models-loader.ts
+++ b/apps/agent/src/runtime/models-loader.ts
@@ -11,6 +11,8 @@ import {
 } from "@cohub/infra/config-runtime/models";
 import { redis } from "../redis.js";
 import { getAgentPlatformModelsPath, getAgentUserModelsPath } from "./paths.js";
+import { getIdentityKeys } from "@cohub/identity";
+import { resolveStoredPrincipalIdentityForAgentRead } from "../identity-bridge.js";
 
 async function loadModelsFromFile(input: {
   modelsPath: string;
@@ -64,12 +66,19 @@ export async function loadRuntimeModelsConfigs(userId?: string | null): Promise<
 
   const trimmedUserId = userId?.trim();
   if (trimmedUserId) {
-    const user = await loadCachedModels({
-      redisKey: getUserModelsRedisKey(trimmedUserId),
-      modelsPath: getAgentUserModelsPath(trimmedUserId),
-      allowMissing: true,
-    });
-    if (user) configs.push(user);
+    const identity = await resolveStoredPrincipalIdentityForAgentRead(trimmedUserId);
+    const userIds = [
+      ...getIdentityKeys(identity).filter((key) => key !== identity.uuid),
+      identity.uuid,
+    ];
+    for (const resolvedUserId of userIds) {
+      const user = await loadCachedModels({
+        redisKey: getUserModelsRedisKey(resolvedUserId),
+        modelsPath: getAgentUserModelsPath(resolvedUserId),
+        allowMissing: true,
+      });
+      if (user) configs.push(user);
+    }
   }
 
   return configs;

--- a/apps/agent/src/runtime/system-prompt-builder.ts
+++ b/apps/agent/src/runtime/system-prompt-builder.ts
@@ -1,6 +1,7 @@
 import { access, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { SpaceModListItem } from "@cohub/core/space-mods";
+import { getIdentityKeys, type PrincipalIdentity } from "@cohub/identity";
 import {
   loadSkillsFromDirectory,
   mergeSkillsConfigs,
@@ -33,6 +34,7 @@ type LoadedContextFile = {
 export type BuildCohubSystemPromptOptions = {
   cwd: string;
   userId?: string | null;
+  userIdentity?: PrincipalIdentity | null;
   selectedTools?: string[];
   toolSnippets?: Record<string, string>;
   promptGuidelines?: string[];
@@ -87,6 +89,16 @@ async function loadContextFilesFromRoot(root: string, sandboxRoot: string): Prom
   return files;
 }
 
+async function loadMergedUserContextFiles(userIds: string[]): Promise<LoadedContextFile[]> {
+  const merged = new Map<string, LoadedContextFile>();
+  for (const files of await Promise.all(
+    userIds.map((userId) => loadContextFilesFromRoot(getAgentUserConfigPath(userId), SANDBOX_USER_CONFIG_PATH)),
+  )) {
+    for (const file of files) merged.set(file.sandboxPath, file);
+  }
+  return [...merged.values()];
+}
+
 async function loadSkillsFromDir(input: {
   agentDir: string;
   sandboxDir: string;
@@ -101,25 +113,25 @@ async function loadSkillsFromDir(input: {
   return content.skills;
 }
 
-async function loadMergedSkills(cwd: string, userId?: string | null, spaceMods: SpaceModListItem[] = [], options: { includeUserSkills?: boolean } = {}): Promise<Skill[]> {
+async function loadMergedSkills(cwd: string, userIds: string[], spaceMods: SpaceModListItem[] = [], options: { includeUserSkills?: boolean } = {}): Promise<Skill[]> {
   const modSkillGroups = await Promise.all(spaceMods.map((mod) => loadSkillsFromDir({
     agentDir: join(getAgentWorkspacePath(mod.modSpaceId), ".agents", "skills"),
     sandboxDir: `${mod.mountPath}/.agents/skills`,
     scope: "mod",
   })));
 
-  const [platformSkills, userSkills, workspaceSkills] = await Promise.all([
+  const [platformSkills, userSkillGroups, workspaceSkills] = await Promise.all([
     loadSkillsFromDir({
       agentDir: getAgentPlatformSkillsPath(),
       sandboxDir: SANDBOX_PLATFORM_SKILLS_PATH,
       scope: "platform",
     }),
-    userId && options.includeUserSkills !== false
-      ? loadSkillsFromDir({
+    options.includeUserSkills !== false
+      ? Promise.all(userIds.map((userId) => loadSkillsFromDir({
           agentDir: getAgentUserSkillsPath(userId),
           sandboxDir: SANDBOX_USER_SKILLS_PATH,
           scope: "user",
-        })
+        })))
       : Promise.resolve([]),
     loadSkillsFromDir({
       agentDir: getAgentWorkspaceSkillsPath(cwd),
@@ -132,7 +144,7 @@ async function loadMergedSkills(cwd: string, userId?: string | null, spaceMods: 
   return mergeSkillsConfigs(
     { skills: platformSkills },
     ...modSkillGroups.map((skills) => ({ skills })),
-    { skills: userSkills },
+    ...userSkillGroups.map((skills) => ({ skills })),
     { skills: workspaceSkills },
   ).skills;
 }
@@ -162,33 +174,46 @@ export async function buildCohubSystemPrompt(options: BuildCohubSystemPromptOpti
   const {
     cwd,
     userId,
+    userIdentity,
     selectedTools = ["read", "bash", "edit", "write"],
     toolSnippets = {},
     promptGuidelines = [],
     spaceMods = [],
     includeUserSkills = true,
   } = options;
+  const resolvedIdentity = userIdentity ?? (userId
+    ? await import("../identity-bridge.js")
+        .then(({ resolveStoredPrincipalIdentityForAgentRead }) => resolveStoredPrincipalIdentityForAgentRead(userId))
+    : null);
+  const identityKeys = getIdentityKeys(resolvedIdentity);
+  const userIds = resolvedIdentity
+    ? [...identityKeys.filter((key) => key !== resolvedIdentity.uuid), resolvedIdentity.uuid]
+    : [];
 
   const workspaceAgentDir = getAgentWorkspaceAgentsPath(cwd);
-  const userAgentDir = userId ? getAgentUserAgentsPath(userId) : null;
+  const userAgentDirs = userIds.map(getAgentUserAgentsPath);
+  const userAgentDirsByPriority = [...userAgentDirs].reverse();
   const systemPrompt = await loadFirstExisting([
     join(workspaceAgentDir, "SYSTEM.md"),
-    ...(userAgentDir ? [join(userAgentDir, "SYSTEM.md")] : []),
+    ...userAgentDirsByPriority.map((dir) => join(dir, "SYSTEM.md")),
     join(getAgentPlatformAgentPath(), "SYSTEM.md"),
   ]) ?? FALLBACK_SYSTEM_PROMPT;
 
+  const userAppendSystemPrompt = await loadFirstExisting(
+    userAgentDirsByPriority.map((dir) => join(dir, "APPEND_SYSTEM.md")),
+  );
   const appendSystemPrompts = (await Promise.all([
     readTextIfExists(join(getAgentPlatformAgentPath(), "APPEND_SYSTEM.md")),
     ...spaceMods.map((mod) => readTextIfExists(join(getAgentWorkspacePath(mod.modSpaceId), ".cohub", "APPEND_SYSTEM.md"))),
-    ...(userAgentDir ? [readTextIfExists(join(userAgentDir, "APPEND_SYSTEM.md"))] : []),
+    Promise.resolve(userAppendSystemPrompt),
     readTextIfExists(join(workspaceAgentDir, "APPEND_SYSTEM.md")),
   ])).filter((value): value is string => Boolean(value));
 
   const [userContextFiles, modContextGroups, projectContextFiles, skills] = await Promise.all([
-    userId ? loadContextFilesFromRoot(getAgentUserConfigPath(userId), SANDBOX_USER_CONFIG_PATH) : Promise.resolve([]),
+    loadMergedUserContextFiles(userIds),
     Promise.all(spaceMods.map((mod) => loadContextFilesFromRoot(getAgentWorkspacePath(mod.modSpaceId), mod.mountPath))),
     loadContextFilesFromRoot(cwd, SANDBOX_WORKSPACE_PATH),
-    selectedTools.includes("read") ? loadMergedSkills(cwd, userId, spaceMods, { includeUserSkills }) : Promise.resolve([]),
+    selectedTools.includes("read") ? loadMergedSkills(cwd, userIds, spaceMods, { includeUserSkills }) : Promise.resolve([]),
   ]);
 
   const sections: string[] = [systemPrompt, ...appendSystemPrompts];

--- a/apps/agent/src/session.ts
+++ b/apps/agent/src/session.ts
@@ -27,6 +27,7 @@ import { refreshUserEnv } from "./runtime/env-cache.js";
 import type { createSandboxCodingTools } from "./sandbox/tools.js";
 import type { Permission } from "@cohub/core/permissions";
 import type { PromptAccessMode } from "@cohub/core/sessions";
+import { resolveStoredPrincipalIdentityForAgent } from "./identity-bridge.js";
 import {
   applyAssistantMessageEvent,
   applyToolExecutionEnd,
@@ -1088,7 +1089,10 @@ export async function loadOrCreateSessionHandle(input: {
     logger.warn(`[Agent] Failed to load space info for ${input.spaceId}; falling back to platform config`, error);
     return null;
   });
-  const spaceOwnerUserId = spaceInfo?.space?.userUuid?.trim() || null;
+  const storedSpaceOwnerUserId = spaceInfo?.space?.userUuid?.trim() || null;
+  const spaceOwnerUserId = storedSpaceOwnerUserId
+    ? (await resolveStoredPrincipalIdentityForAgent(storedSpaceOwnerUserId)).uuid
+    : null;
 
   const existing = input.sessionHandles.get(sessionKey);
   if (existing) {

--- a/apps/agent/src/tests/system-prompt-builder.test.ts
+++ b/apps/agent/src/tests/system-prompt-builder.test.ts
@@ -6,16 +6,21 @@ import { join } from "node:path";
 const root = await mkdtemp(join(tmpdir(), "cohub-system-prompt-"));
 process.env.PLATFORM_CONFIG_ROOT = join(root, "configs");
 
-const userId = "11111111-1111-4111-8111-111111111111";
+const legacyUserId = "11111111-1111-4111-8111-111111111111";
+const userId = "logto-user";
 const workspace = join(root, "workspace");
 const userConfig = join(process.env.PLATFORM_CONFIG_ROOT, "users", userId);
+const legacyUserConfig = join(process.env.PLATFORM_CONFIG_ROOT, "users", legacyUserId);
 const platformAgent = join(process.env.PLATFORM_CONFIG_ROOT, "platform", ".cohub");
 
 await mkdir(workspace, { recursive: true });
 await mkdir(userConfig, { recursive: true });
+await mkdir(legacyUserConfig, { recursive: true });
 await mkdir(platformAgent, { recursive: true });
 await writeFile(join(platformAgent, "SYSTEM.md"), "You are a Cohub test assistant.");
 await writeFile(join(userConfig, "AGENTS.md"), "Always prefer concise answers.");
+await writeFile(join(legacyUserConfig, "AGENTS.md"), "Legacy instructions should be replaced.");
+await writeFile(join(legacyUserConfig, "CLAUDE.md"), "Keep legacy-only context available during migration.");
 await mkdir(join(userConfig, ".agents", "skills", "owner-skill"), { recursive: true });
 await writeFile(join(userConfig, ".agents", "skills", "owner-skill", "SKILL.md"), "---\nname: owner-skill\ndescription: Owner-only skill\n---\nOwner skill body.");
 await writeFile(join(workspace, "AGENTS.md"), "Project rule: run typecheck.");
@@ -25,12 +30,15 @@ const { buildCohubSystemPrompt } = await import("../runtime/system-prompt-builde
 const prompt = await buildCohubSystemPrompt({
   cwd: workspace,
   userId,
+  userIdentity: { uuid: userId, legacyUserUuid: legacyUserId },
   selectedTools: [],
 });
 
 assert.ok(prompt.includes("# User Context"), "should include user context section");
 assert.ok(!prompt.includes("/configs/user/AGENTS.md"), "should not expose sandbox user rule path");
 assert.ok(prompt.includes("Always prefer concise answers."), "should include user rules content");
+assert.ok(!prompt.includes("Legacy instructions should be replaced."), "canonical user rules should override the legacy namespace");
+assert.ok(prompt.includes("Keep legacy-only context available during migration."), "missing canonical user context should fall back to the legacy namespace");
 assert.ok(prompt.includes("# Project Context"), "should include project context section");
 assert.ok(prompt.includes("Project rule: run typecheck."), "should include project rules content");
 assert.ok(
@@ -67,6 +75,7 @@ await writeFile(
 const promptWithSkills = await buildCohubSystemPrompt({
   cwd: workspace,
   userId,
+  userIdentity: { uuid: userId, legacyUserUuid: legacyUserId },
   selectedTools: ["read"],
 });
 

--- a/apps/api/src/channel-inbound-identity.test.ts
+++ b/apps/api/src/channel-inbound-identity.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  IdentityMappingConflictError,
+  UnresolvedLegacyIdentityError,
+  resolveStoredPrincipalIdentity,
+  type IdentityMappingRow,
+} from "@cohub/identity";
+import { resolveChannelInboundOwnerIdentity } from "./channel-inbound-identity.js";
+
+const legacyUuid = "5d4ac7d3-1f50-4af4-8d75-6df54d5edc6a";
+const sub = "logto-user";
+
+const resolverWithMappings = (mappings: IdentityMappingRow[]) => async (principalId: string) =>
+  resolveStoredPrincipalIdentity({ principalId, mappings });
+
+describe("channel inbound owner identity", () => {
+  it("uses canonical sub for new gateway writes and retains the legacy permission alias", async () => {
+    const identity = await resolveChannelInboundOwnerIdentity(
+      legacyUuid,
+      resolverWithMappings([{ userUuid: legacyUuid, logtoUserId: sub }]),
+    );
+
+    assert.deepEqual(identity, { userId: sub, legacyUserUuid: legacyUuid });
+  });
+
+  it("fails closed when a legacy channel owner has no mapping", async () => {
+    await assert.rejects(
+      resolveChannelInboundOwnerIdentity(legacyUuid, resolverWithMappings([])),
+      UnresolvedLegacyIdentityError,
+    );
+  });
+
+  it("fails closed when channel owner mappings conflict", async () => {
+    await assert.rejects(
+      resolveChannelInboundOwnerIdentity(
+        legacyUuid,
+        resolverWithMappings([
+          { userUuid: legacyUuid, logtoUserId: sub },
+          { userUuid: legacyUuid, logtoUserId: "other-sub" },
+        ]),
+      ),
+      IdentityMappingConflictError,
+    );
+  });
+});

--- a/apps/api/src/channel-inbound-identity.ts
+++ b/apps/api/src/channel-inbound-identity.ts
@@ -1,0 +1,18 @@
+import type { PrincipalIdentity } from "@cohub/identity";
+
+export type ChannelInboundOwnerIdentity = {
+  userId: string;
+  legacyUserUuid?: string;
+};
+
+type StoredPrincipalResolver = (principalId: string) => Promise<PrincipalIdentity>;
+
+export async function resolveChannelInboundOwnerIdentity(
+  storedUserId: string,
+  resolveStoredPrincipal: StoredPrincipalResolver,
+): Promise<ChannelInboundOwnerIdentity> {
+  const identity = await resolveStoredPrincipal(storedUserId);
+  return identity.legacyUserUuid
+    ? { userId: identity.uuid, legacyUserUuid: identity.legacyUserUuid }
+    : { userId: identity.uuid };
+}

--- a/apps/api/src/channels.ts
+++ b/apps/api/src/channels.ts
@@ -21,6 +21,8 @@ import { buildSessionSourceChannel } from "./lib/session-source-channel.js";
 import { assignSessionChannelSystemLabel } from "@cohub/core/labels/session-channel";
 import { assignSessionSourceSystemLabel } from "@cohub/core/labels/session-source";
 import { dispatchLabelAssignmentsUpdated } from "./realtime-events.js";
+import { resolveStoredPrincipalUser } from "./identity-bridge.js";
+import { resolveChannelInboundOwnerIdentity } from "./channel-inbound-identity.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -68,6 +70,7 @@ type ResolvedChannelInbound = {
   spaceChannelId: string;
   channelId: string;
   userId: string;
+  legacyUserUuid?: string;
   sessionId: string;
   binding: typeof spaceSessionBindings.$inferSelect;
   conversationId: string;
@@ -647,6 +650,10 @@ export async function resolveChannelInboundForEvent(event: GatewayInboundEvent):
   if (!spaceChannel) return null;
   const [userChannel] = await db.select({ userUuid: userChannels.userUuid }).from(userChannels).where(eq(userChannels.id, spaceChannel.channelId)).limit(1);
   if (!userChannel) return null;
+  const ownerIdentity = await resolveChannelInboundOwnerIdentity(
+    userChannel.userUuid,
+    resolveStoredPrincipalUser,
+  );
 
   const conversationId = event.conversation?.id?.trim() || event.externalChatId;
   const existingInboundRef = await getProviderMessageRef({
@@ -660,7 +667,7 @@ export async function resolveChannelInboundForEvent(event: GatewayInboundEvent):
   const bindingKey = resolveInboundBindingKey(event, conversationId);
   const binding = await _resolveOrCreateSessionBindingForEvent({
     spaceId: spaceChannel.spaceId,
-    userUuid: userChannel.userUuid,
+    userUuid: ownerIdentity.userId,
     spaceChannelId: spaceChannel.id,
     channelId: spaceChannel.channelId,
     provider: event.provider,
@@ -673,7 +680,8 @@ export async function resolveChannelInboundForEvent(event: GatewayInboundEvent):
     spaceId: spaceChannel.spaceId,
     spaceChannelId: spaceChannel.id,
     channelId: spaceChannel.channelId,
-    userId: userChannel.userUuid,
+    userId: ownerIdentity.userId,
+    legacyUserUuid: ownerIdentity.legacyUserUuid,
     sessionId: binding.spaceSessionId,
     binding,
     conversationId,
@@ -706,7 +714,10 @@ async function handleMessageCreateInboundEvent(event: GatewayInboundEvent) {
   const resolved = await resolveChannelInboundForEvent(event);
   if (!resolved) return;
 
-  const canChannelOwnerWrite = await hasPermission({ uuid: resolved.userId }, "session.prompt.fullaccess", {
+  const canChannelOwnerWrite = await hasPermission({
+    uuid: resolved.userId,
+    legacyUserUuid: resolved.legacyUserUuid,
+  }, "session.prompt.fullaccess", {
     spaceId: resolved.spaceId,
     sessionId: resolved.sessionId,
   });

--- a/apps/api/src/cron-job-identity.test.ts
+++ b/apps/api/src/cron-job-identity.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { canonicalizeCronJobIdentity } from "./cron-job-identity.js";
+
+describe("cron job identity writes", () => {
+  it("replaces a stored legacy UUID before DB and repeat payload writes", () => {
+    const result = canonicalizeCronJobIdentity({
+      id: "cron-1",
+      userUuid: "5d4ac7d3-1f50-4af4-8d75-6df54d5edc6a",
+      payload: { prompt: "hello" },
+    }, "logto-user");
+
+    assert.deepEqual(result, {
+      id: "cron-1",
+      userUuid: "logto-user",
+      payload: { prompt: "hello" },
+    });
+  });
+});

--- a/apps/api/src/cron-job-identity.ts
+++ b/apps/api/src/cron-job-identity.ts
@@ -1,0 +1,4 @@
+export const canonicalizeCronJobIdentity = <T extends { userUuid: string }>(
+  job: T,
+  canonicalUserId: string,
+): T => ({ ...job, userUuid: canonicalUserId });

--- a/apps/api/src/identity-bridge.ts
+++ b/apps/api/src/identity-bridge.ts
@@ -1,0 +1,105 @@
+import { and, eq, inArray, or } from "drizzle-orm";
+import { userProfiles } from "@cohub/db";
+import {
+  getIdentityKeys,
+  resolveLegacyBillingIdentity,
+  resolveStoredPrincipalIdentity,
+  resolveStoredPrincipalIdentityForRead,
+  resolveVerifiedPrincipalIdentityWithPersistence,
+  type AuthUserProfile,
+  type IdentityMappingRow,
+  type PrincipalIdentity,
+} from "@cohub/identity";
+import { db } from "./db/index.js";
+
+async function loadIdentityMappings(keys: readonly string[]): Promise<IdentityMappingRow[]> {
+  const unique = [...new Set(keys.map((value) => value.trim()).filter(Boolean))];
+  if (unique.length === 0) return [];
+  return db
+    .select({ userUuid: userProfiles.userUuid, logtoUserId: userProfiles.logtoUserId })
+    .from(userProfiles)
+    .where(or(
+      inArray(userProfiles.userUuid, unique),
+      inArray(userProfiles.logtoUserId, unique),
+    ));
+}
+
+const stringField = (value: unknown) =>
+  typeof value === "string" && value.trim() ? value.trim() : null;
+
+async function persistVerifiedIdentityMapping(
+  user: AuthUserProfile,
+  identity: PrincipalIdentity,
+): Promise<void> {
+  const source = Object.fromEntries(
+    Object.entries(user).filter(([, value]) => value !== undefined),
+  );
+  const storageUserUuid = identity.legacyUserUuid ?? identity.uuid;
+  const displayName = (
+    stringField(user.nick_name)
+    ?? stringField(user.name)
+    ?? stringField(user.email)
+    ?? identity.uuid
+  ).slice(0, 120);
+
+  if (identity.legacyUserUuid && identity.legacyUserUuid !== identity.uuid) {
+    const [updated] = await db.update(userProfiles).set({
+      userUuid: identity.legacyUserUuid,
+      updatedAt: new Date(),
+    }).where(and(
+      eq(userProfiles.userUuid, identity.uuid),
+      eq(userProfiles.logtoUserId, identity.uuid),
+    )).returning({ userUuid: userProfiles.userUuid });
+    if (updated) return;
+  }
+
+  await db.insert(userProfiles).values({
+    userUuid: storageUserUuid,
+    logtoUserId: identity.uuid,
+    displayName,
+    avatarUrl: stringField(user.avatar_url),
+    source,
+    syncedAt: new Date(),
+    updatedAt: new Date(),
+  }).onConflictDoNothing();
+}
+
+export async function resolveVerifiedAuthUser(user: AuthUserProfile): Promise<AuthUserProfile> {
+  const identity = await resolveVerifiedPrincipalIdentityWithPersistence({
+    sub: user.uuid,
+    legacyUserUuid: user.legacyUserUuid,
+    loadMappings: loadIdentityMappings,
+    persistMapping: async (resolved) => {
+      await persistVerifiedIdentityMapping(user, resolved);
+    },
+  });
+  return { ...user, ...identity };
+}
+
+export async function resolveStoredPrincipalUser(principalId: string): Promise<PrincipalIdentity> {
+  const mappings = await loadIdentityMappings([principalId]);
+  return resolveStoredPrincipalIdentity({ principalId, mappings });
+}
+
+/** Read legacy namespaces first so canonical sub config wins during merges. */
+export async function resolveStoredPrincipalReadKeys(principalId: string): Promise<string[]> {
+  const mappings = await loadIdentityMappings([principalId]);
+  const identity = resolveStoredPrincipalIdentityForRead({ principalId, mappings });
+  return [
+    ...getIdentityKeys(identity).filter((key) => key !== identity.uuid),
+    identity.uuid,
+  ];
+}
+
+export async function resolveBillingUserId(identity: PrincipalIdentity): Promise<string> {
+  const mappings = await loadIdentityMappings(getIdentityKeys(identity));
+  return resolveLegacyBillingIdentity({ identity, mappings });
+}
+
+export async function resolveBillingUserIdForStoredPrincipal(principalId: string): Promise<string> {
+  const mappings = await loadIdentityMappings([principalId]);
+  const identity = resolveStoredPrincipalIdentity({ principalId, mappings });
+  return resolveLegacyBillingIdentity({ identity, mappings });
+}
+
+export { getIdentityKeys, identityEquals } from "@cohub/identity";

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -17,6 +17,8 @@ import { verifyUserAccessToken } from "@cohub/identity";
 import { getTokenFromRequest, type AuthUserProfile, consumeExecutionAuthFromToken, type ExecutionAuthPrincipal } from "./auth.js";
 import { verifyPreviewSessionToken, type PreviewSessionPrincipal } from "./preview-sessions.js";
 import { verifyWorkSessionToken, type WorkSessionPrincipal } from "./work-sessions.js";
+import { resolveStoredPrincipalUser, resolveVerifiedAuthUser } from "./identity-bridge.js";
+import type { AuthUser, RequestPrincipal } from "./lib/middleware.js";
 import { assertRequiredConfig, config } from "./config.js";
 
 import router from "./routes/index.js";
@@ -31,7 +33,7 @@ const app = new Hono<{
     executionAuth: ExecutionAuthPrincipal | null;
     previewSession: PreviewSessionPrincipal | null;
     workSession: WorkSessionPrincipal | null;
-    principal: { type: "user"; user: AuthUserProfile } | { type: "execution"; execution: ExecutionAuthPrincipal } | { type: "preview_session"; previewSession: PreviewSessionPrincipal } | { type: "work_session"; workSession: WorkSessionPrincipal } | null;
+    principal: RequestPrincipal | null;
     requestId: string;
     traceId: string | null;
   };
@@ -111,8 +113,18 @@ app.use(async (c, next) => {
       return null;
     });
     if (executionAuth) {
+      let user: AuthUser | null = null;
+      if (executionAuth.actorUserId) {
+        try {
+          const identity = await resolveStoredPrincipalUser(executionAuth.actorUserId);
+          user = { ...identity, execution: executionAuth } as AuthUser & { execution: ExecutionAuthPrincipal };
+        } catch (error) {
+          logger.warn("[API] Failed to resolve execution principal identity:", error);
+          return c.json({ message: "unauthorized" }, 401);
+        }
+      }
       c.set("executionAuth", executionAuth);
-      c.set("principal", { type: "execution", execution: executionAuth });
+      c.set("principal", { type: "execution", execution: executionAuth, user });
       await next();
       return;
     }
@@ -120,8 +132,14 @@ app.use(async (c, next) => {
     if (onPreviewHost) {
       const previewSession = verifyPreviewSessionToken(token);
       if (previewSession) {
+        const identity = await resolveStoredPrincipalUser(previewSession.userUuid).catch((error) => {
+          logger.warn("[API] Failed to resolve preview principal identity:", error);
+          return null;
+        });
+        if (!identity) return c.json({ message: "unauthorized" }, 401);
+        const user = { ...identity, previewSession } as AuthUser & { previewSession: PreviewSessionPrincipal };
         c.set("previewSession", previewSession);
-        c.set("principal", { type: "preview_session", previewSession });
+        c.set("principal", { type: "preview_session", previewSession, user });
         await next();
         return;
       }
@@ -129,14 +147,21 @@ app.use(async (c, next) => {
 
     const workSession = verifyWorkSessionToken(token);
     if (workSession) {
+      const identity = await resolveStoredPrincipalUser(workSession.userUuid).catch((error) => {
+        logger.warn("[API] Failed to resolve work principal identity:", error);
+        return null;
+      });
+      if (!identity) return c.json({ message: "unauthorized" }, 401);
+      const user = { ...identity, workSession } as AuthUser & { workSession: WorkSessionPrincipal };
       c.set("workSession", workSession);
-      c.set("principal", { type: "work_session", workSession });
+      c.set("principal", { type: "work_session", workSession, user });
       await next();
       return;
     }
 
     try {
-      const authUser = await verifyUserAccessToken({ token, logtoEndpoint: config.logtoEndpoint });
+      const verifiedUser = await verifyUserAccessToken({ token, logtoEndpoint: config.logtoEndpoint });
+      const authUser = await resolveVerifiedAuthUser(verifiedUser);
       c.set("authUser", authUser);
       c.set("principal", { type: "user", user: authUser });
     } catch {

--- a/apps/api/src/lib/channel-model-config.ts
+++ b/apps/api/src/lib/channel-model-config.ts
@@ -17,6 +17,7 @@ import { spaces } from "@cohub/db";
 import type { db as dbClient } from "../db/index.js";
 import { config } from "../config.js";
 import { redisCommandClient } from "../redis.js";
+import { resolveStoredPrincipalReadKeys } from "../identity-bridge.js";
 
 type DbClient = typeof dbClient;
 type SpaceRow = InferSelectModel<typeof spaces>;
@@ -90,14 +91,15 @@ export async function loadMergedModelsCatalog(db: DbClient, spaceOrId: Pick<Spac
     modelsPath: PLATFORM_MODELS_PATH,
     allowMissing: false,
   });
-  const userModels = space?.userUuid
-    ? await loadModelsConfig({
-        redisKey: getUserModelsRedisKey(space.userUuid),
-        modelsPath: getUserModelsPath(space.userUuid),
-        allowMissing: true,
-      })
-    : null;
-  return mergeModelsConfigs(platformModels, userModels);
+  const userIds = space?.userUuid
+    ? await resolveStoredPrincipalReadKeys(space.userUuid)
+    : [];
+  const userModels = await Promise.all(userIds.map((userId) => loadModelsConfig({
+    redisKey: getUserModelsRedisKey(userId),
+    modelsPath: getUserModelsPath(userId),
+    allowMissing: true,
+  })));
+  return mergeModelsConfigs(platformModels, ...userModels);
 }
 
 export function splitProviderModelInput(value: string): { provider: string | null; id: string } {

--- a/apps/api/src/lib/commerce-http.ts
+++ b/apps/api/src/lib/commerce-http.ts
@@ -4,6 +4,8 @@ import { FEATURE_NOT_ENTITLED_ERROR_CODE } from "@cohub/billing";
 import { featureGateResponse } from "./feature-gate.js";
 import { jsonError } from "./json-error.js";
 import { SpaceCommerceNotInitializedError, resolveSpaceCommerceEntitlement } from "./space-commerce.js";
+import type { AuthUser } from "./middleware.js";
+import { resolveBillingUserId } from "../identity-bridge.js";
 
 export const SPACE_COMMERCE_NOT_INITIALIZED_CODE = "space_commerce_not_initialized";
 export const SPACE_COMMERCE_ENTITLEMENT_REQUIRED_CODE = FEATURE_NOT_ENTITLED_ERROR_CODE;
@@ -58,8 +60,16 @@ export function handleWorkCommerceRouteError(c: Context, error: unknown) {
  */
 export async function requireSpaceCommerceEntitlement(
   c: Context,
-  userId: string,
+  user: AuthUser,
 ): Promise<Response | null> {
+  const userId = await resolveBillingUserId(user).catch(() => null);
+  if (!userId) {
+    return jsonError(c, {
+      status: 503,
+      message: "Could not verify billing identity. Please try again.",
+      code: SPACE_COMMERCE_ENTITLEMENT_UNAVAILABLE_CODE,
+    });
+  }
   const entitled = await resolveSpaceCommerceEntitlement(userId);
   if (entitled === null) {
     return jsonError(c, {

--- a/apps/api/src/lib/middleware.ts
+++ b/apps/api/src/lib/middleware.ts
@@ -5,15 +5,16 @@ import type { AuthUserProfile } from "../auth.js";
 import type { ExecutionAuthPrincipal } from "../auth.js";
 import type { PreviewSessionPrincipal } from "../preview-sessions.js";
 import type { WorkSessionPrincipal } from "../work-sessions.js";
+import { getIdentityKeys } from "../identity-bridge.js";
 
-/** AuthUserProfile with guaranteed uuid (returned after auth checks pass). */
-export type AuthUser = AuthUserProfile & { uuid: string };
+/** AuthUserProfile with a canonical principal and optional legacy alias. */
+export type AuthUser = AuthUserProfile & { uuid: string; legacyUserUuid?: string };
 
 export type RequestPrincipal =
   | { type: "user"; user: AuthUser }
-  | { type: "execution"; execution: ExecutionAuthPrincipal }
-  | { type: "preview_session"; previewSession: PreviewSessionPrincipal }
-  | { type: "work_session"; workSession: WorkSessionPrincipal };
+  | { type: "execution"; execution: ExecutionAuthPrincipal; user: AuthUser | null }
+  | { type: "preview_session"; previewSession: PreviewSessionPrincipal; user: AuthUser }
+  | { type: "work_session"; workSession: WorkSessionPrincipal; user: AuthUser };
 
 import { config } from "../config.js";
 import { getProfilesByUuids } from "../user-profiles.js";
@@ -24,39 +25,10 @@ import { inArray } from "drizzle-orm";
 import type { spaces } from "@cohub/db";
 
 const principalToAuthUser = (principal: RequestPrincipal | null | undefined): AuthUser | null => {
-  if (principal?.type === "user") return principal.user;
-  if (principal?.type === "execution" && principal.execution.actorUserId) {
-    return {
-      uuid: principal.execution.actorUserId,
-      id: undefined,
-      nick_name: undefined,
-      phone_num: undefined,
-      avatar_url: undefined,
-      execution: principal.execution,
-    } as AuthUser & { execution: ExecutionAuthPrincipal };
-  }
-  if (principal?.type === "work_session") {
-    return {
-      uuid: principal.workSession.userUuid,
-      id: undefined,
-      nick_name: undefined,
-      phone_num: undefined,
-      avatar_url: undefined,
-      workSession: principal.workSession,
-    } as AuthUser & { workSession: WorkSessionPrincipal };
-  }
-  if (principal?.type === "preview_session") {
-    return {
-      uuid: principal.previewSession.userUuid,
-      id: undefined,
-      nick_name: undefined,
-      phone_num: undefined,
-      avatar_url: undefined,
-      previewSession: principal.previewSession,
-    } as AuthUser & { previewSession: PreviewSessionPrincipal };
-  }
-  return null;
+  return principal?.user ?? null;
 };
+
+export { getIdentityKeys };
 
 // ── ID validation ────────────────────────────────────────────────────────────
 
@@ -68,6 +40,10 @@ const SHORT_UUID_REGEX = /^[0-9a-f]{32}$/i;
 
 export const requireValidId = (value: string | null | undefined) =>
   Boolean(value && (UUID_REGEX.test(value) || SHORT_UUID_REGEX.test(value)));
+
+/** Identity IDs may be Logto subjects, unlike resource IDs which stay UUIDs. */
+export const requireValidPrincipalId = (value: string | null | undefined) =>
+  Boolean(value && /^[A-Za-z0-9._:-]{1,255}$/.test(value.trim()));
 
 // ── Auth helpers ─────────────────────────────────────────────────────────────
 
@@ -204,12 +180,16 @@ export const buildSpaceListItems = async (spaceList: typeof spaces.$inferSelect[
   const statusBySpaceId = new Map(sandboxRows.map((r) => [r.spaceId, r.status]));
   const profileByUserUuid = await getProfilesByUuids(spaceList.map((space) => space.userUuid));
 
-  return spaceList.map((space) => ({
-    ...space,
-    publicProfile: getSpacePublicProfile(space),
-    sandboxStatus: statusBySpaceId.get(space.id) ?? null,
-    ownerProfile: profileByUserUuid.get(space.userUuid) ?? null,
-  }));
+  return spaceList.map((space) => {
+    const ownerProfile = profileByUserUuid.get(space.userUuid) ?? null;
+    return {
+      ...space,
+      userUuid: ownerProfile?.userUuid ?? space.userUuid,
+      publicProfile: getSpacePublicProfile(space),
+      sandboxStatus: statusBySpaceId.get(space.id) ?? null,
+      ownerProfile,
+    };
+  });
 };
 
 export const buildStorageRepoName = (spaceId: string) => `space-${spaceId}`;

--- a/apps/api/src/llm/models.ts
+++ b/apps/api/src/llm/models.ts
@@ -17,6 +17,7 @@ import {
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { config } from "../config.js";
 import { redisCommandClient } from "../redis.js";
+import { resolveStoredPrincipalReadKeys } from "../identity-bridge.js";
 
 const PLATFORM_MODELS_PATH = join(config.platformConfigRoot, "platform", ".cohub", "models.json");
 const getUserModelsPath = (userId: string) => join(config.platformConfigRoot, "users", userId, ".cohub", "models.json");
@@ -121,12 +122,15 @@ export async function loadRuntimeModelsConfigs(userId?: string | null): Promise<
 
   const trimmedUserId = userId?.trim();
   if (trimmedUserId) {
-    const user = await loadCachedModels({
-      redisKey: getUserModelsRedisKey(trimmedUserId),
-      modelsPath: getUserModelsPath(trimmedUserId),
-      allowMissing: true,
-    });
-    if (user) configs.push(user);
+    const userIds = await resolveStoredPrincipalReadKeys(trimmedUserId);
+    for (const resolvedUserId of userIds) {
+      const user = await loadCachedModels({
+        redisKey: getUserModelsRedisKey(resolvedUserId),
+        modelsPath: getUserModelsPath(resolvedUserId),
+        allowMissing: true,
+      });
+      if (user) configs.push(user);
+    }
   }
   return configs;
 }

--- a/apps/api/src/permissions.account-identity.test.ts
+++ b/apps/api/src/permissions.account-identity.test.ts
@@ -25,4 +25,11 @@ describe("asAccountIdentity", () => {
     assert.equal(asAccountIdentity({}), null);
     assert.equal(asAccountIdentity({ uuid: "   " }), null);
   });
+
+  it("keeps the legacy UUID alias for dual-read account queries", () => {
+    assert.deepEqual(asAccountIdentity({ uuid: "logto-sub", legacyUserUuid: "legacy-uuid" }), {
+      uuid: "logto-sub",
+      legacyUserUuid: "legacy-uuid",
+    });
+  });
 });

--- a/apps/api/src/permissions.ts
+++ b/apps/api/src/permissions.ts
@@ -19,15 +19,28 @@ type ScopedExecutionPrincipal = {
 
 const permissionStore = createBatchDrizzlePermissionStore(db);
 
+const identityKeys = (user: AuthUserProfile | null | undefined): string[] =>
+  [...new Set([user?.uuid, user?.legacyUserUuid]
+    .filter((value): value is string => typeof value === "string" && Boolean(value.trim()))
+    .map((value) => value.trim()))];
+
 export type { Audience, Permission } from "@cohub/core/permissions";
 
 export async function getSpaceMemberRole(spaceId: string, userId: string): Promise<SpaceRole | null> {
   return permissionStore.getSpaceMemberRole(spaceId, userId);
 }
 
+export async function getSpaceMemberRoleForUser(spaceId: string, user: AuthUserProfile | null): Promise<SpaceRole | null> {
+  for (const key of identityKeys(user)) {
+    const role = await getSpaceMemberRole(spaceId, key);
+    if (role) return role;
+  }
+  return null;
+}
+
 const getUserWorkSession = (user: AuthUserProfile | null): CachedWorkSessionPrincipal | null => {
   const session = (user as (AuthUserProfile & { workSession?: CachedWorkSessionPrincipal }) | null)?.workSession;
-  if (!session || user?.uuid !== session.userUuid) return null;
+  if (!session || !identityKeys(user).includes(session.userUuid)) return null;
   return session;
 };
 
@@ -39,7 +52,7 @@ const getUserExecution = (user: AuthUserProfile | null): ScopedExecutionPrincipa
 
 const getUserPreviewSession = (user: AuthUserProfile | null): PreviewSessionPrincipal | null => {
   const session = (user as (AuthUserProfile & { previewSession?: PreviewSessionPrincipal }) | null)?.previewSession;
-  if (!session || user?.uuid !== session.userUuid) return null;
+  if (!session || !identityKeys(user).includes(session.userUuid)) return null;
   return session;
 };
 
@@ -48,9 +61,11 @@ const getUserPreviewSession = (user: AuthUserProfile | null): PreviewSessionPrin
  * (`user.space.list` / `user.session.list` / `user.usage.read`).
  * Gate with the original principal; load data with this identity.
  */
-export function asAccountIdentity(user: { uuid?: string | null } | null | undefined): { uuid: string } | null {
+export function asAccountIdentity(user: { uuid?: string | null; legacyUserUuid?: string | null } | null | undefined): { uuid: string; legacyUserUuid?: string } | null {
   const uuid = typeof user?.uuid === "string" ? user.uuid.trim() : "";
-  return uuid ? { uuid } : null;
+  if (!uuid) return null;
+  const legacyUserUuid = typeof user?.legacyUserUuid === "string" ? user.legacyUserUuid.trim() : "";
+  return legacyUserUuid ? { uuid, legacyUserUuid } : { uuid };
 }
 
 const loadActiveViewerGrantScopes = async (workSession: CachedWorkSessionPrincipal) => {
@@ -116,8 +131,9 @@ export async function hasPermission(
   });
 }
 
-export async function getRoleForSpaceUser(spaceId: string, userId: string): Promise<SpaceRole | null> {
-  return getSpaceMemberRole(spaceId, userId);
+export async function getRoleForSpaceUser(spaceId: string, userId: string | { uuid: string; legacyUserUuid?: string }): Promise<SpaceRole | null> {
+  if (typeof userId === "string") return getSpaceMemberRole(spaceId, userId);
+  return getSpaceMemberRoleForUser(spaceId, userId);
 }
 
 export async function resolvePermissionAccess(

--- a/apps/api/src/prompt-templates.ts
+++ b/apps/api/src/prompt-templates.ts
@@ -19,6 +19,7 @@ import { getSpaceModMountSignature, listEnabledSpaceMods } from "@cohub/core/spa
 import { config } from "./config.js";
 import { db } from "./db/index.js";
 import { redisCommandClient } from "./redis.js";
+import { resolveStoredPrincipalReadKeys } from "./identity-bridge.js";
 
 export type { PromptTemplateCatalogEntry } from "@cohub/infra/config-runtime/prompts";
 
@@ -236,12 +237,14 @@ async function fetchPromptTemplates(options: LoadPromptTemplatesOptions): Promis
   }
 
   if (options.userId) {
-    configs.push(await loadCachedPrompts({
-      redisKey: getUserPromptsRedisKey(options.userId),
-      dir: getUserPromptsDir(options.userId),
+    const userId = options.userId.trim();
+    const userIds = await resolveStoredPrincipalReadKeys(userId);
+    configs.push(...await Promise.all(userIds.map((userId) => loadCachedPrompts({
+      redisKey: getUserPromptsRedisKey(userId),
+      dir: getUserPromptsDir(userId),
       scope: "user",
       allowMissing: true,
-    }));
+    }))));
   }
 
   if (options.spaceId && config.spaceStorageRoot) {

--- a/apps/api/src/realtime-events.ts
+++ b/apps/api/src/realtime-events.ts
@@ -2,9 +2,11 @@ import { randomUUID } from "node:crypto";
 import type { RealtimeMessageRecord, RealtimeSessionRecord, RealtimeTaskRecord, RealtimeTurnRecord, SpacePresenceSnapshot } from "@cohub/protocol/realtime";
 import type { MessageRecord, SessionRecord, SessionTurnRecord } from "@cohub/protocol/model";
 import type { TaskRunStatus } from "@cohub/protocol/task";
+import { getRealtimeUserRoom } from "@cohub/protocol/realtime";
 import { dispatchRealtimeEvent } from "./channels.js";
 import { buildResourceLabelSnapshot, type LabelResourceType } from "@cohub/core/labels/resource-events";
 import { db } from "./db/index.js";
+import { getIdentityKeys, resolveStoredPrincipalUser } from "./identity-bridge.js";
 
 const toIsoOrNull = (value: Date | string | null | undefined) => {
   if (!value) return null;
@@ -201,6 +203,9 @@ export async function dispatchTurnCreated(input: {
 
 export async function dispatchTaskCreated(task: Parameters<typeof toRealtimeTaskRecord>[0]) {
   const realtimeTask = toRealtimeTaskRecord(task);
+  const rooms = realtimeTask.userId && !realtimeTask.spaceId
+    ? getIdentityKeys(await resolveStoredPrincipalUser(realtimeTask.userId)).map(getRealtimeUserRoom)
+    : undefined;
   await dispatchRealtimeEvent({
     id: randomUUID(),
     timestamp: Date.now(),
@@ -208,6 +213,7 @@ export async function dispatchTaskCreated(task: Parameters<typeof toRealtimeTask
     type: "task.created",
     spaceId: realtimeTask.spaceId,
     sessionId: realtimeTask.sessionId,
+    rooms,
     payload: {
       task: realtimeTask,
       ...(realtimeTask.userId && !realtimeTask.spaceId ? { userId: realtimeTask.userId } : {}),
@@ -221,6 +227,9 @@ export async function dispatchTaskUpdated(input: {
 }) {
   if (input.changed.length === 0) return;
   const realtimeTask = toRealtimeTaskRecord(input.task);
+  const rooms = realtimeTask.userId && !realtimeTask.spaceId
+    ? getIdentityKeys(await resolveStoredPrincipalUser(realtimeTask.userId)).map(getRealtimeUserRoom)
+    : undefined;
   await dispatchRealtimeEvent({
     id: randomUUID(),
     timestamp: Date.now(),
@@ -228,6 +237,7 @@ export async function dispatchTaskUpdated(input: {
     type: "task.updated",
     spaceId: realtimeTask.spaceId,
     sessionId: realtimeTask.sessionId,
+    rooms,
     payload: {
       task: realtimeTask,
       changed: input.changed,

--- a/apps/api/src/referrals.ts
+++ b/apps/api/src/referrals.ts
@@ -6,8 +6,10 @@ import {
   userProfiles,
   type ReferralStatus,
 } from "@cohub/db";
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, or } from "drizzle-orm";
 import { db } from "./db/index.js";
+import { getIdentityKeys, identityEquals, resolveStoredPrincipalUser } from "./identity-bridge.js";
+import type { PrincipalIdentity } from "@cohub/identity";
 
 export const REFERRAL_REWARD_USD = 5;
 
@@ -22,18 +24,20 @@ function toIso(value: Date | string | null | undefined) {
   return value instanceof Date ? value.toISOString() : value;
 }
 
-export async function ensureReferralCode(userId: string) {
-  const [existing] = await db
+export async function ensureReferralCode(user: PrincipalIdentity) {
+  const identityKeys = getIdentityKeys(user);
+  const existingCodes = await db
     .select()
     .from(referralCodes)
-    .where(and(eq(referralCodes.userId, userId), eq(referralCodes.status, "active")))
-    .limit(1);
+    .where(and(inArray(referralCodes.userId, identityKeys), eq(referralCodes.status, "active")));
+  if (existingCodes.length > 1) throw new Error("referral identity conflict requires repair");
+  const existing = existingCodes[0];
   if (existing) return existing;
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
     const [created] = await db
       .insert(referralCodes)
-      .values({ userId, code: generateReferralCode() })
+      .values({ userId: user.uuid, code: generateReferralCode() })
       .onConflictDoNothing()
       .returning();
     if (created) return created;
@@ -41,25 +45,26 @@ export async function ensureReferralCode(userId: string) {
     const [concurrent] = await db
       .select()
       .from(referralCodes)
-      .where(and(eq(referralCodes.userId, userId), eq(referralCodes.status, "active")))
+      .where(and(inArray(referralCodes.userId, identityKeys), eq(referralCodes.status, "active")))
       .limit(1);
     if (concurrent) return concurrent;
   }
   throw new Error("failed to create referral code");
 }
 
-export async function rotateReferralCode(userId: string) {
+export async function rotateReferralCode(user: PrincipalIdentity) {
   const now = new Date();
+  const identityKeys = getIdentityKeys(user);
   return db.transaction(async (tx) => {
     await tx
       .update(referralCodes)
       .set({ status: "revoked", revokedAt: now, updatedAt: now })
-      .where(and(eq(referralCodes.userId, userId), eq(referralCodes.status, "active")));
+      .where(and(inArray(referralCodes.userId, identityKeys), eq(referralCodes.status, "active")));
 
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const [created] = await tx
         .insert(referralCodes)
-        .values({ userId, code: generateReferralCode() })
+        .values({ userId: user.uuid, code: generateReferralCode() })
         .onConflictDoNothing()
         .returning();
       if (created) return created;
@@ -74,14 +79,17 @@ export async function getPublicReferral(code: string) {
       codeId: referralCodes.id,
       inviterUserId: referralCodes.userId,
       profile: {
-        userUuid: userProfiles.userUuid,
+        userUuid: userProfiles.logtoUserId,
         username: userProfiles.username,
         displayName: userProfiles.displayName,
         avatarUrl: userProfiles.avatarUrl,
       },
     })
     .from(referralCodes)
-    .leftJoin(userProfiles, eq(userProfiles.userUuid, referralCodes.userId))
+    .leftJoin(userProfiles, or(
+      eq(userProfiles.userUuid, referralCodes.userId),
+      eq(userProfiles.logtoUserId, referralCodes.userId),
+    ))
     .where(and(eq(referralCodes.code, code), eq(referralCodes.status, "active")))
     .limit(1);
   return result ?? null;
@@ -92,22 +100,24 @@ export type ClaimReferralResult = {
   status: ReferralStatus | "self" | "existing_user" | "already_claimed";
 };
 
-export async function claimReferral(code: string, inviteeUserId: string): Promise<ClaimReferralResult | null> {
+export async function claimReferral(code: string, invitee: PrincipalIdentity): Promise<ClaimReferralResult | null> {
   const publicReferral = await getPublicReferral(code);
   if (!publicReferral) return null;
-  if (publicReferral.inviterUserId === inviteeUserId) {
+  if (identityEquals(invitee, publicReferral.inviterUserId)) {
     return { referralId: null, status: "self" };
   }
+  const inviteeIdentityKeys = getIdentityKeys(invitee);
 
-  const [existing] = await db
+  const existingRows = await db
     .select({
       id: referrals.id,
       referralCodeId: referrals.referralCodeId,
       status: referrals.status,
     })
     .from(referrals)
-    .where(eq(referrals.inviteeUserId, inviteeUserId))
-    .limit(1);
+    .where(inArray(referrals.inviteeUserId, inviteeIdentityKeys));
+  if (existingRows.length > 1) throw new Error("referral identity conflict requires repair");
+  const existing = existingRows[0];
   if (existing) {
     return {
       referralId: existing.id,
@@ -123,19 +133,20 @@ export async function claimReferral(code: string, inviteeUserId: string): Promis
     .from(sessionTurns)
     .where(
       and(
-        eq(sessionTurns.userUuid, inviteeUserId),
+        inArray(sessionTurns.userUuid, inviteeIdentityKeys),
         inArray(sessionTurns.status, [...successfulTurnStatuses]),
       ),
     )
     .limit(1);
   if (successfulTurn) return { referralId: null, status: "existing_user" };
+  const inviterIdentity = await resolveStoredPrincipalUser(publicReferral.inviterUserId);
 
   const [created] = await db
     .insert(referrals)
     .values({
       referralCodeId: publicReferral.codeId,
-      inviterUserId: publicReferral.inviterUserId,
-      inviteeUserId,
+      inviterUserId: inviterIdentity.uuid,
+      inviteeUserId: invitee.uuid,
       inviterRewardAmountUsd: String(REFERRAL_REWARD_USD),
       inviteeRewardAmountUsd: String(REFERRAL_REWARD_USD),
     })
@@ -150,7 +161,7 @@ export async function claimReferral(code: string, inviteeUserId: string): Promis
       status: referrals.status,
     })
     .from(referrals)
-    .where(eq(referrals.inviteeUserId, inviteeUserId))
+    .where(inArray(referrals.inviteeUserId, inviteeIdentityKeys))
     .limit(1);
   if (!concurrent) return null;
   return {
@@ -162,8 +173,8 @@ export async function claimReferral(code: string, inviteeUserId: string): Promis
   };
 }
 
-export async function getReferralDashboard(userId: string) {
-  const code = await ensureReferralCode(userId);
+export async function getReferralDashboard(user: PrincipalIdentity) {
+  const code = await ensureReferralCode(user);
   const items = await db
     .select({
       id: referrals.id,
@@ -173,15 +184,18 @@ export async function getReferralDashboard(userId: string) {
       rewardedAt: referrals.rewardedAt,
       inviterRewardAmountUsd: referrals.inviterRewardAmountUsd,
       profile: {
-        userUuid: userProfiles.userUuid,
+        userUuid: userProfiles.logtoUserId,
         username: userProfiles.username,
         displayName: userProfiles.displayName,
         avatarUrl: userProfiles.avatarUrl,
       },
     })
     .from(referrals)
-    .leftJoin(userProfiles, eq(userProfiles.userUuid, referrals.inviteeUserId))
-    .where(eq(referrals.inviterUserId, userId))
+    .leftJoin(userProfiles, or(
+      eq(userProfiles.userUuid, referrals.inviteeUserId),
+      eq(userProfiles.logtoUserId, referrals.inviteeUserId),
+    ))
+    .where(inArray(referrals.inviterUserId, getIdentityKeys(user)))
     .orderBy(desc(referrals.claimedAt));
 
   const pending = items.filter((item) => item.status === "pending").length;

--- a/apps/api/src/routes/billing.route.ts
+++ b/apps/api/src/routes/billing.route.ts
@@ -3,7 +3,8 @@ import { ApiError, isBillingApiError } from "../lib/billing-api-error.js";
 import { billingOperations, COHUB_BILLING_FEATURES, COHUB_BILLING_TOKEN_TYPES, type CohubBillingFeatureKey } from "@cohub/billing";
 import { config } from "../config.js";
 import { jsonError } from "../lib/json-error.js";
-import { getOptionalAuth, useAuth } from "../lib/middleware.js";
+import { getOptionalAuth, useAuth, type AuthUser } from "../lib/middleware.js";
+import { resolveBillingUserId } from "../identity-bridge.js";
 
 const router = new Hono();
 const BILLING_PAGE_SIZE = 10;
@@ -67,6 +68,18 @@ function billingApiErrorResponse(c: Context, error: { status: number; message: s
   });
 }
 
+async function legacyBillingUserId(c: Context, user: AuthUser): Promise<string | Response> {
+  try {
+    return await resolveBillingUserId(user);
+  } catch {
+    return jsonError(c, {
+      status: 503,
+      message: "Billing identity is unavailable",
+      code: "billing_identity_unavailable",
+    });
+  }
+}
+
 const BILLING_FEATURE_KEYS = new Set<string>(Object.values(COHUB_BILLING_FEATURES));
 
 function resolveBillingFeatureKey(value: string): CohubBillingFeatureKey | null {
@@ -78,8 +91,10 @@ router.get("/credits", async (c) => {
   if (user instanceof Response) return user;
   const resolved = resolveTokenType(c.req.query("tokenType"));
   if ("error" in resolved) return c.json({ message: resolved.error }, 400);
+  const userId = await legacyBillingUserId(c, user);
+  if (userId instanceof Response) return userId;
   const credit = await billingOperations.getCreditStatus({
-    userId: user.uuid,
+    userId,
     tokenType: resolved.tokenType,
   });
   return c.json(credit);
@@ -90,8 +105,10 @@ router.get("/balance-activities", async (c) => {
   if (user instanceof Response) return user;
   const resolved = resolveTokenType(c.req.query("tokenType"));
   if ("error" in resolved) return c.json({ message: resolved.error }, 400);
+  const userId = await legacyBillingUserId(c, user);
+  if (userId instanceof Response) return userId;
   const activities = await billingOperations.listBalanceActivities({
-    userId: user.uuid,
+    userId,
     tokenType: resolved.tokenType,
     page: parsePositiveInt(c.req.query("page"), 1, 10_000),
     limit: parsePositiveInt(c.req.query("limit"), BILLING_PAGE_SIZE, BILLING_PAGE_SIZE),
@@ -102,8 +119,10 @@ router.get("/balance-activities", async (c) => {
 router.get("/catalog", async (c) => {
   const user = getOptionalAuth(c);
   try {
+    const userId = user ? await legacyBillingUserId(c, user) : undefined;
+    if (userId instanceof Response) return userId;
     const catalog = await billingOperations.getCatalog(
-      user?.uuid ? { userId: user.uuid } : undefined,
+      userId ? { userId } : undefined,
     );
     return c.json({ catalog });
   } catch (error) {
@@ -118,8 +137,10 @@ router.get("/features/:featureKey", async (c) => {
   const featureKey = resolveBillingFeatureKey(c.req.param("featureKey"));
   if (!featureKey) return c.json({ message: "unsupported billing feature" }, 400);
   try {
+    const userId = await legacyBillingUserId(c, user);
+    if (userId instanceof Response) return userId;
     const entitlement = await billingOperations.getFeatureEntitlement({
-      userId: user.uuid,
+      userId,
       featureKey,
     });
     return c.json({ enabled: Boolean(entitlement?.enabled) });
@@ -133,8 +154,10 @@ router.get("/subscriptions", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
   try {
+    const userId = await legacyBillingUserId(c, user);
+    if (userId instanceof Response) return userId;
     const subscriptions = await billingOperations.listSubscriptions({
-      userId: user.uuid,
+      userId,
       page: parsePositiveInt(c.req.query("page"), 1, 10_000),
       limit: parsePositiveInt(c.req.query("limit"), BILLING_PAGE_SIZE, BILLING_PAGE_SIZE),
     });
@@ -149,6 +172,8 @@ router.post("/orders", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
   try {
+    const userId = await legacyBillingUserId(c, user);
+    if (userId instanceof Response) return userId;
     const body = await readCheckoutBody(c);
     const productKey =
       typeof (body as { productKey?: unknown }).productKey === "string"
@@ -156,7 +181,7 @@ router.post("/orders", async (c) => {
         : "";
     if (!productKey) return c.json({ message: "Product key is required" }, 400);
     const checkout = await billingOperations.purchaseAddon({
-      userId: user.uuid,
+      userId,
       productKey,
       returnUrl: parseReturnUrl((body as { returnUrl?: unknown }).returnUrl),
     });
@@ -171,6 +196,8 @@ router.post("/subscriptions", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
   try {
+    const userId = await legacyBillingUserId(c, user);
+    if (userId instanceof Response) return userId;
     const body = await readCheckoutBody(c);
     const productKey =
       typeof (body as { productKey?: unknown }).productKey === "string"
@@ -178,7 +205,7 @@ router.post("/subscriptions", async (c) => {
         : "";
     if (!productKey) return c.json({ message: "Product key is required" }, 400);
     const checkout = await billingOperations.createSubscription({
-      userId: user.uuid,
+      userId,
       productKey,
       returnUrl: parseReturnUrl((body as { returnUrl?: unknown }).returnUrl),
     });
@@ -193,8 +220,10 @@ router.delete("/subscriptions/:subscriptionId/checkout", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
   try {
+    const userId = await legacyBillingUserId(c, user);
+    if (userId instanceof Response) return userId;
     const subscription = await billingOperations.cancelSubscriptionCheckout({
-      userId: user.uuid,
+      userId,
       subscriptionId: c.req.param("subscriptionId"),
     });
     return c.json({ subscription });
@@ -208,12 +237,14 @@ router.patch("/subscriptions/:subscriptionId", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
   try {
+    const userId = await legacyBillingUserId(c, user);
+    if (userId instanceof Response) return userId;
     const body = await readCheckoutBody(c);
     if ((body as { cancelAtPeriodEnd?: unknown }).cancelAtPeriodEnd !== true) {
       return c.json({ message: "cancelAtPeriodEnd must be true" }, 400);
     }
     const subscription = await billingOperations.cancelSubscriptionAutoRenew({
-      userId: user.uuid,
+      userId,
       subscriptionId: c.req.param("subscriptionId"),
     });
     return c.json({ subscription });
@@ -227,11 +258,13 @@ router.post("/redemptions", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
   try {
+    const userId = await legacyBillingUserId(c, user);
+    if (userId instanceof Response) return userId;
     const body = await readCheckoutBody(c);
     const code = parseRedemptionCode((body as { code?: unknown }).code);
     if (!code) return c.json({ message: "Redemption code is required" }, 400);
     const redemption = await billingOperations.redeemCode({
-      userId: user.uuid,
+      userId,
       code,
     });
     return c.json({ redemption });

--- a/apps/api/src/routes/channels.route.ts
+++ b/apps/api/src/routes/channels.route.ts
@@ -3,10 +3,11 @@ import { Hono } from "hono";
 import { db } from "../db/index.js";
 import { userChannels, spaceChannels, spaces } from "@cohub/db";
 import { eq, and, desc, inArray } from "drizzle-orm";
-import { useAuth, requireValidId } from "../lib/middleware.js";
+import { useAuth, requireValidId, type AuthUser } from "../lib/middleware.js";
 import { redisCommandClient } from "../redis.js";
 import { deleteChannelResponse, type DeleteChannelResult } from "./channel-delete.js";
 import { fallbackBoundChannelHealth, getChannelHealthMap } from "../channel-health.js";
+import { getIdentityKeys, identityEquals } from "../identity-bridge.js";
 
 const WECHAT_LOGIN_BASE_URL = "https://ilinkai.weixin.qq.com";
 const WECHAT_CDN_BASE_URL = "https://novac2c.cdn.weixin.qq.com/c2c";
@@ -85,11 +86,11 @@ type WeChatQrStatusResponse = {
   redirect_host?: string;
 };
 
-async function listUserWeChatChannels(userUuid: string) {
+async function listUserWeChatChannels(user: AuthUser) {
   return db
     .select()
     .from(userChannels)
-    .where(and(eq(userChannels.userUuid, userUuid), eq(userChannels.provider, "wechat")))
+    .where(and(inArray(userChannels.userUuid, getIdentityKeys(user)), eq(userChannels.provider, "wechat")))
     .orderBy(desc(userChannels.updatedAt), desc(userChannels.createdAt));
 }
 
@@ -151,7 +152,7 @@ router.post("/wechat/login/start", async (c) => {
 
   let qr: { qrcode: string; qrDataUrl: string };
   try {
-    const channels = await listUserWeChatChannels(user.uuid);
+    const channels = await listUserWeChatChannels(user);
     const localTokenList = channels
       .map((channel) => getWeChatCredentials(channel).token?.trim())
       .filter((token): token is string => Boolean(token))
@@ -189,7 +190,7 @@ router.post("/wechat/login/wait", async (c) => {
   if (!rawState) return c.json({ connected: false, expired: true, message: "Login session expired. Start again." });
 
   const state = JSON.parse(rawState) as WeChatLoginState;
-  if (state.userUuid !== user.uuid) return c.json({ message: "login session not found" }, 404);
+  if (!identityEquals(user, state.userUuid)) return c.json({ message: "login session not found" }, 404);
 
   const status = await pollWeChatQrStatus(state.qrcode, state.currentBaseUrl, body.verifyCode);
   if (status.status === "scaned_but_redirect" && status.redirect_host) {
@@ -217,7 +218,7 @@ router.post("/wechat/login/wait", async (c) => {
   }
 
   if (status.status === "binded_redirect") {
-    const channels = await listUserWeChatChannels(user.uuid);
+    const channels = await listUserWeChatChannels(user);
     await redisCommandClient.del(wechatLoginKey(sessionKey));
     const onlyChannel = channels.length === 1 ? channels[0] : null;
     if (onlyChannel) {
@@ -248,11 +249,11 @@ router.post("/wechat/login/wait", async (c) => {
       baseUrl: resolveWeChatBaseUrl(status.baseurl),
       cdnBaseUrl: WECHAT_CDN_BASE_URL,
     };
-    const existingChannel = findWeChatChannelByAccountId(await listUserWeChatChannels(user.uuid), status.ilink_bot_id);
+    const existingChannel = findWeChatChannelByAccountId(await listUserWeChatChannels(user), status.ilink_bot_id);
     if (existingChannel) {
       const [channel] = await db.update(userChannels)
-        .set({ credentials, status: "active", updatedAt: new Date() })
-        .where(and(eq(userChannels.id, existingChannel.id), eq(userChannels.userUuid, user.uuid)))
+        .set({ userUuid: user.uuid, credentials, status: "active", updatedAt: new Date() })
+        .where(and(eq(userChannels.id, existingChannel.id), inArray(userChannels.userUuid, getIdentityKeys(user))))
         .returning();
       await redisCommandClient.del(wechatLoginKey(sessionKey));
       return c.json({ connected: true, alreadyConnected: true, message: "WeChat is already connected.", channel: channel ? serializeChannel(channel) : null });
@@ -279,7 +280,7 @@ router.get("/", async (c) => {
   const channels = await db
     .select()
     .from(userChannels)
-    .where(eq(userChannels.userUuid, user.uuid))
+    .where(inArray(userChannels.userUuid, getIdentityKeys(user)))
     .orderBy(desc(userChannels.updatedAt), desc(userChannels.createdAt));
 
   const channelIds = channels.map((ch) => ch.id);
@@ -360,7 +361,7 @@ router.delete("/:id", async (c) => {
     const [channel] = await tx
       .select()
       .from(userChannels)
-      .where(and(eq(userChannels.id, channelId), eq(userChannels.userUuid, user.uuid)))
+      .where(and(eq(userChannels.id, channelId), inArray(userChannels.userUuid, getIdentityKeys(user))))
       .limit(1)
       .for("update");
     if (!channel) return "not_found";

--- a/apps/api/src/routes/cron-jobs.route.ts
+++ b/apps/api/src/routes/cron-jobs.route.ts
@@ -2,13 +2,14 @@ import { Hono } from "hono";
 import * as cronParser from "cron-parser";
 import { db } from "../db/index.js";
 import { cronJobs, taskRuns } from "@cohub/db";
-import { eq, and, isNull, desc, lt, or } from "drizzle-orm";
+import { eq, and, isNull, desc, inArray, lt, or } from "drizzle-orm";
 import { sanitizePostgresJsonValue } from "@cohub/core/content/sanitize";
 import { getOptionalAuth, useAuth, requireValidId, authzDenied } from "../lib/middleware.js";
 import { hasPermission } from "../permissions.js";
 import { disableCronJob, enableCronJob, removeCronJob, updateCronJob } from "../tasks.js";
 import { fallbackPublicUserProfile, getProfilesByUuids } from "../user-profiles.js";
 import { sanitizeTaskRunPricingForViewer } from "../task-run-privacy.js";
+import { getIdentityKeys, identityEquals, resolveStoredPrincipalUser } from "../identity-bridge.js";
 
 const router = new Hono();
 const { CronExpressionParser } = cronParser;
@@ -24,10 +25,14 @@ type CronJobAuthSubject = {
 
 async function hydrateCronJobUserProfiles<T extends { userUuid: string }>(jobs: T[]) {
   const profiles = await getProfilesByUuids(jobs.map((job) => job.userUuid));
-  return jobs.map((job) => ({
-    ...job,
-    userProfile: profiles.get(job.userUuid) ?? fallbackPublicUserProfile(job.userUuid),
-  }));
+  return jobs.map((job) => {
+    const userProfile = profiles.get(job.userUuid) ?? fallbackPublicUserProfile(job.userUuid);
+    return {
+      ...job,
+      userUuid: userProfile.userUuid,
+      userProfile,
+    };
+  });
 }
 
 function validateTimezone(timezone: string) {
@@ -61,17 +66,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 async function authorizeCronJobView(user: ReturnType<typeof getOptionalAuth>, job: CronJobAuthSubject) {
   if (job.spaceId) return hasPermission(user, "cronjob.view", { spaceId: job.spaceId, sessionId: job.sessionId ?? undefined });
-  return !!user && job.userUuid === user.uuid;
+  return !!user && identityEquals(user, job.userUuid);
 }
 
 async function authorizeCronJobManage(user: Exclude<ReturnType<typeof useAuth>, Response>, job: CronJobAuthSubject) {
   if (job.spaceId) return hasPermission(user, "cronjob.manage", { spaceId: job.spaceId, sessionId: job.sessionId ?? undefined });
-  return job.userUuid === user.uuid;
+  return identityEquals(user, job.userUuid);
 }
 
 async function authorizeTaskRunView(user: ReturnType<typeof getOptionalAuth>, job: CronJobAuthSubject) {
   if (job.spaceId) return hasPermission(user, "taskrun.view", { spaceId: job.spaceId, sessionId: job.sessionId ?? undefined });
-  return !!user && job.userUuid === user.uuid;
+  return !!user && identityEquals(user, job.userUuid);
 }
 
 async function loadCronJobAuthSubject(cronJobId: string): Promise<CronJobAuthSubject | null> {
@@ -125,7 +130,7 @@ router.get("/", async (c) => {
   const jobs = await db
     .select()
     .from(cronJobs)
-    .where(and(eq(cronJobs.userUuid, userId), isNull(cronJobs.deletedAt)))
+    .where(and(inArray(cronJobs.userUuid, getIdentityKeys(user)), isNull(cronJobs.deletedAt)))
     .orderBy(desc(cronJobs.createdAt));
 
   return c.json({ jobs: await hydrateCronJobUserProfiles(jobs) });
@@ -179,7 +184,7 @@ router.get("/:id/runs", async (c) => {
     .limit(limit + 1);
   const runs = rows
     .slice(0, limit)
-    .map((run) => sanitizeTaskRunPricingForViewer(run, user?.uuid));
+    .map((run) => sanitizeTaskRunPricingForViewer(run, user));
 
   return c.json({
     runs,
@@ -279,12 +284,13 @@ router.patch("/:id", async (c) => {
 
   if (patch.enabled !== undefined && Object.keys(patch).length === 1) {
     if (patch.enabled && !job.enabled) {
+      const jobIdentity = await resolveStoredPrincipalUser(job.userUuid);
       const enabledJob = await enableCronJob(cronJobId, job.bullJobKey, {
         taskType: job.taskType,
         payload: job.payload as Record<string, unknown>,
         cronExpression: job.cronExpression,
         timezone: job.timezone,
-        userUuid: job.userUuid,
+        userUuid: jobIdentity.uuid,
         spaceId: job.spaceId,
         sessionId: job.sessionId,
       });
@@ -299,7 +305,8 @@ router.patch("/:id", async (c) => {
     return c.json({ ok: true, job: hydrated });
   }
 
-  const updatedJob = await updateCronJob(job, patch);
+  const jobIdentity = await resolveStoredPrincipalUser(job.userUuid);
+  const updatedJob = await updateCronJob({ ...job, userUuid: jobIdentity.uuid }, patch);
   const [hydrated] = await hydrateCronJobUserProfiles([updatedJob]);
   return c.json({ ok: true, job: hydrated });
 });

--- a/apps/api/src/routes/generations.route.ts
+++ b/apps/api/src/routes/generations.route.ts
@@ -26,6 +26,7 @@ import { enqueueTask } from "../tasks.js";
 import { defaultJobRetention } from "@cohub/infra/bullmq";
 import { createLogger } from "@cohub/infra/logging";
 import { applyRequestSourceToMeta } from "../lib/request-source.js";
+import { getIdentityKeys, resolveBillingUserId } from "../identity-bridge.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -81,7 +82,7 @@ router.post("/", async (c) => {
     }
   }
 
-  const declaration = await loadGenerationDeclaration(user.uuid, request.model);
+  const declaration = await loadGenerationDeclaration(user.uuid, request.model, getIdentityKeys(user));
   if (!declaration) {
     return generationError(c, 404, "generation_model_not_found", `Generation model not found: ${request.model}`);
   }
@@ -109,10 +110,22 @@ router.post("/", async (c) => {
     adapterType: declaration.adapter?.type,
     contentTypes: contentTypesFromBlocks(request.content),
   });
+  const billingUserId = await resolveBillingUserId(user).catch((error) => {
+    logger.error("[Billing] failed to resolve legacy billing identity before generation enqueue", { error });
+    return null;
+  });
+  if (!billingUserId) {
+    return generationError(
+      c,
+      503,
+      "generation_pricing_unavailable",
+      "Generation pricing is temporarily unavailable. Please try again later.",
+    );
+  }
   let resolvedDiscount: Awaited<ReturnType<typeof billingOperations.getGenerationModelDiscount>>;
   try {
     resolvedDiscount = await billingOperations.getGenerationModelDiscount({
-      userId: user.uuid,
+      userId: billingUserId,
       model: request.model,
     });
   } catch (error) {
@@ -146,7 +159,7 @@ router.post("/", async (c) => {
   const billingDecision = isGenerationModelDiscountFree(resolvedDiscount)
     ? { status: "allowed" as const, balanceState: "zero" as const, netUsd: 0 }
     : await billingUsageGate.evaluate({
-        userId: user.uuid,
+        userId: billingUserId,
         usageKind: generationUsageKind(usageType),
         source: "generation_task",
         model: request.model,

--- a/apps/api/src/routes/internal/gateway.route.ts
+++ b/apps/api/src/routes/internal/gateway.route.ts
@@ -38,6 +38,7 @@ import {
 import { enqueueSandboxUploadFilesJob } from "../../sandbox-bash-queue.js";
 import { db } from "../../db/index.js";
 import { eq } from "drizzle-orm";
+import { identityEquals } from "../../identity-bridge.js";
 
 const logger = createLogger({ serviceName: "cohub-api" });
 const tracer = getTracer("cohub-api");
@@ -129,7 +130,7 @@ router.post("/authorize-realtime-rooms", async (c) => {
     const normalizedRoom = `${parsed.kind}:${parsed.id}`;
 
     if (parsed.kind === "user") {
-      if (parsed.id === user.uuid) {
+      if (identityEquals(user, parsed.id)) {
         accepted.push(normalizedRoom);
       } else {
         rejected.push({ room, code: "FORBIDDEN", message: "Cannot subscribe to another user" });

--- a/apps/api/src/routes/internal/spaces.route.ts
+++ b/apps/api/src/routes/internal/spaces.route.ts
@@ -31,6 +31,7 @@ import {
   isPrivateNetworkAddress,
   requireValidId,
 } from "../../lib/middleware.js";
+import { identityEquals, resolveStoredPrincipalUser } from "../../identity-bridge.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -283,18 +284,36 @@ router.post("/:spaceId/sessions/:sessionId/messages", async (c) => {
     .catch(() => null);
   if (!body?.idempotencyKey?.trim()) return c.json({ message: "idempotencyKey is required" }, 400);
   if (!body.message || !Array.isArray(body.message.content)) return c.json({ message: "message.content is required" }, 400);
+  const messageIdentity = body.userId?.trim()
+    ? await resolveStoredPrincipalUser(body.userId).catch(() => null)
+    : null;
+  if (body.userId?.trim() && !messageIdentity) {
+    return c.json({ message: "user identity is not resolvable" }, 409);
+  }
+  const messageMeta = body.message.meta && typeof body.message.meta === "object" && !Array.isArray(body.message.meta)
+    ? { ...body.message.meta }
+    : body.message.meta;
+  if (messageIdentity && messageMeta && typeof messageMeta === "object" && !Array.isArray(messageMeta)) {
+    for (const key of ["userId", "actorUserId"] as const) {
+      const value = messageMeta[key];
+      if (typeof value === "string" && identityEquals(messageIdentity, value)) {
+        messageMeta[key] = messageIdentity.uuid;
+      }
+    }
+  }
 
   const messageNode = await persistMessageNode({
     spaceId,
     sessionId,
     previousMessageId: body.previousMessageId ?? null,
     anchorUserMessageId: body.anchorUserMessageId ?? null,
-    userId: body.userId ?? null,
+    userId: messageIdentity?.uuid ?? null,
     idempotencyKey: body.idempotencyKey,
     message: {
       ...(body.message as PersistMessageInput["message"]),
       id: body.message.id ?? undefined,
       content: body.message.content as never,
+      meta: messageMeta,
     } as PersistMessageInput["message"] & { id?: string },
   });
 
@@ -337,11 +356,17 @@ router.post("/:spaceId/sessions/:sessionId/turns/:turnId/abort", async (c) => {
   if (!session || session.spaceId !== spaceId) return c.json({ message: "session not found" }, 404);
 
   const body = await c.req.json<{ actorUserId?: string | null }>().catch(() => null);
+  const actorIdentity = body?.actorUserId?.trim()
+    ? await resolveStoredPrincipalUser(body.actorUserId).catch(() => null)
+    : null;
+  if (body?.actorUserId?.trim() && !actorIdentity) {
+    return c.json({ message: "actor identity is not resolvable" }, 409);
+  }
   const turn = await abortSessionTurn({
     spaceId,
     sessionId,
     turnId,
-    actorUserId: body?.actorUserId ?? null,
+    actorUserId: actorIdentity?.uuid ?? null,
   });
   if (turn) await dispatchTurnFinalized({ spaceId, sessionId, turn }).catch((error) => logger.warn("[SessionTurn] failed to dispatch aborted turn", error));
   return c.json({ ok: true, turn });
@@ -397,8 +422,11 @@ router.post("/:spaceId/sessions/:sessionId/prompt", async (c) => {
   if (!body || !Array.isArray(body.content) || body.content.length === 0) {
     return c.json({ message: "content is required" }, 400);
   }
-  const userId = body.userId?.trim();
-  if (!userId) return c.json({ message: "userId is required" }, 400);
+  const requestedUserId = body.userId?.trim();
+  if (!requestedUserId) return c.json({ message: "userId is required" }, 400);
+  const identity = await resolveStoredPrincipalUser(requestedUserId).catch(() => null);
+  if (!identity) return c.json({ message: "user identity is not resolvable" }, 409);
+  const userId = identity.uuid;
   const accessMode = body.accessMode ?? "full_access";
   if (accessMode !== "read_only" && accessMode !== "full_access") {
     return c.json({ message: "accessMode must be one of: read_only, full_access" }, 400);
@@ -408,10 +436,13 @@ router.post("/:spaceId/sessions/:sessionId/prompt", async (c) => {
   if (promptThinkingLevel === null) return c.json({ message: "thinkingLevel must be one of: off, minimal, low, medium, high, xhigh, max" }, 400);
   const promptPermission = accessMode === "read_only" ? "session.prompt.readonly" : "session.prompt.fullaccess";
   const workSession = body.authToken ? verifyWorkSessionToken(body.authToken) : null;
-  const permissionSubject = workSession && workSession.userUuid === userId
-    ? ({ uuid: userId, workSession } as { uuid: string; workSession: typeof workSession })
-    : { uuid: userId };
-  const promptAuth = workSession?.userUuid === userId ? promptAuthContextFromWorkSession(workSession, spaceId) : null;
+  const workSessionMatches = Boolean(workSession && identityEquals(identity, workSession.userUuid));
+  const permissionSubject = workSessionMatches
+    ? { ...identity, workSession }
+    : identity;
+  const promptAuth = workSessionMatches && workSession
+    ? promptAuthContextFromWorkSession(workSession, spaceId)
+    : null;
   if (!(await hasPermission(permissionSubject, promptPermission, { spaceId, sessionId }))) {
     return c.json({ message: "forbidden" }, 403);
   }

--- a/apps/api/src/routes/invite.route.ts
+++ b/apps/api/src/routes/invite.route.ts
@@ -3,9 +3,10 @@ import { db } from "../db/index.js";
 import { spaceMembers, spaces } from "@cohub/db";
 import type { SpaceRole } from "@cohub/db";
 import { isRoleHigherThan } from "@cohub/core/permissions";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { redisCommandClient } from "../redis.js";
 import { useAuth } from "../lib/middleware.js";
+import { getIdentityKeys } from "../identity-bridge.js";
 
 const INVITE_PREFIX = "invite";
 
@@ -96,11 +97,14 @@ router.post("/:token/accept", async (c) => {
 
   // Check if user is already a member. Invite links may upgrade an existing
   // lower-role member, for example guest -> builder, but must never demote.
-  const [existing] = await db
+  const existingMembers = await db
     .select({ id: spaceMembers.id, role: spaceMembers.role })
     .from(spaceMembers)
-    .where(and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, user.uuid)))
-    .limit(1);
+    .where(and(eq(spaceMembers.spaceId, spaceId), inArray(spaceMembers.userId, getIdentityKeys(user))));
+  if (existingMembers.length > 1) {
+    return c.json({ message: "member identity conflict requires repair" }, 409);
+  }
+  const existing = existingMembers[0];
 
   let acceptedRole = role;
   let consumedInviteUse = false;
@@ -109,8 +113,8 @@ router.post("/:token/accept", async (c) => {
     if (isRoleHigherThan(role, existing.role)) {
       await db
         .update(spaceMembers)
-        .set({ role, updatedBy: user.uuid, updatedAt: new Date() })
-        .where(and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, user.uuid)));
+        .set({ userId: user.uuid, role, updatedBy: user.uuid, updatedAt: new Date() })
+        .where(eq(spaceMembers.id, existing.id));
       consumedInviteUse = true;
     } else {
       acceptedRole = existing.role;

--- a/apps/api/src/routes/me-labels.route.ts
+++ b/apps/api/src/routes/me-labels.route.ts
@@ -9,6 +9,8 @@ import type { LabelResourceType } from "@cohub/core/labels";
 import { hasPermission } from "../permissions.js";
 import { getRealtimeUserRoom } from "@cohub/protocol/realtime";
 import { dispatchRealtimeEvent } from "../channels.js";
+import { getIdentityKeys } from "../identity-bridge.js";
+import type { AuthUser } from "../lib/middleware.js";
 
 const router = new Hono();
 
@@ -41,7 +43,8 @@ router.get("/resources/:resourceType/labels", async (c) => {
   const resourceType = parseResourceType(c.req.param("resourceType") ?? "");
   const resourceRef = c.req.query("resourceRef")?.trim() ?? "";
   if (!resourceType || !resourceRef) return c.json({ message: "resource not found" }, 404);
-  const assignments = await getUserResourceLabelAssignments(db, user.uuid, resourceType, resourceRef);
+  const identity = { uuid: user.uuid, aliases: user.legacyUserUuid ? [user.legacyUserUuid] : [] };
+  const assignments = await getUserResourceLabelAssignments(db, identity, resourceType, resourceRef);
   return c.json({ assignments });
 });
 
@@ -71,13 +74,14 @@ router.patch("/resources/:resourceType/labels", async (c) => {
   const removeLabelRefs = parseLabelRefs((body as { removeLabelRefs?: unknown }).removeLabelRefs);
   if (addLabelRefs === null || removeLabelRefs === null) return c.json({ message: "addLabelRefs and removeLabelRefs must be arrays of strings" }, 400);
   if (addLabelRefs.length === 0 && removeLabelRefs.length === 0) return c.json({ message: "addLabelRefs or removeLabelRefs is required" }, 400);
+  const identity = { uuid: user.uuid, aliases: user.legacyUserUuid ? [user.legacyUserUuid] : [] };
   const assignments = await db.transaction((tx) =>
-    patchUserResourceLabels(tx, user.uuid, resourceType, resourceRef, {
+    patchUserResourceLabels(tx, identity, resourceType, resourceRef, {
       addLabelRefs,
       removeLabelRefs,
     }),
   );
-  await dispatchUserLabelAssignmentsUpdated(user.uuid, resourceType, resourceRef, assignments.map((a) => a.labelId));
+  await dispatchUserLabelAssignmentsUpdated(user, resourceType, resourceRef, assignments.map((a) => a.labelId));
   return c.json({ assignments });
 });
 
@@ -86,12 +90,13 @@ router.patch("/resources/:resourceType/labels", async (c) => {
  * Reuses the existing event type so the web client can handle it uniformly.
  */
 async function dispatchUserLabelAssignmentsUpdated(
-  userUuid: string,
+  user: AuthUser,
   resourceType: LabelResourceType,
   resourceRef: string,
   affectedLabelIds: string[],
 ) {
-  const assignments = await getUserResourceLabelAssignments(db, userUuid, resourceType, resourceRef);
+  const identity = { uuid: user.uuid, aliases: user.legacyUserUuid ? [user.legacyUserUuid] : [] };
+  const assignments = await getUserResourceLabelAssignments(db, identity, resourceType, resourceRef);
   await dispatchRealtimeEvent({
     id: crypto.randomUUID(),
     timestamp: Date.now(),
@@ -99,7 +104,7 @@ async function dispatchUserLabelAssignmentsUpdated(
     type: "label.assignments.updated",
     spaceId: null,
     sessionId: null,
-    rooms: [getRealtimeUserRoom(userUuid)],
+    rooms: getIdentityKeys(user).map(getRealtimeUserRoom),
     payload: {
       resourceType,
       resourceRef,

--- a/apps/api/src/routes/me.route.ts
+++ b/apps/api/src/routes/me.route.ts
@@ -1,15 +1,29 @@
 import { readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { Hono } from "hono";
-import { and, eq, gte, lte, desc } from "drizzle-orm";
+import { and, gte, lte, desc, inArray } from "drizzle-orm";
 import * as schema from "@cohub/db";
+import { isStorageSafePrincipalId } from "@cohub/identity";
 import { db } from "../db/index.js";
 import { config } from "../config.js";
-import { requireValidId, useAuth, authzDenied } from "../lib/middleware.js";
-import { ensureCurrentUserProfile, resolveCurrentUserEmail, updateCurrentUserProfile, LogtoUserRequiredError, UsernameClearError, UsernameConflictError, UsernameReservedError, validateUsername } from "../user-profiles.js";
+import {
+  authzDenied,
+  getIdentityKeys,
+  useAuth,
+} from "../lib/middleware.js";
+import {
+  ensureCurrentUserProfile,
+  LogtoUserRequiredError,
+  resolveCurrentUserEmail,
+  updateCurrentUserProfile,
+  UsernameClearError,
+  UsernameConflictError,
+  UsernameReservedError,
+  validateUsername,
+} from "../user-profiles.js";
 import {
   filterSessionsByPermission,
-  getSpaceMemberRole,
+  getSpaceMemberRoleForUser,
   hasPermission,
   asAccountIdentity,
 } from "../permissions.js";
@@ -46,7 +60,7 @@ function getUserRulesPath(userId: string) {
 }
 
 function assertValidUserId(userId: string) {
-  if (!requireValidId(userId)) {
+  if (!isStorageSafePrincipalId(userId)) {
     throw new Error("invalid user id");
   }
 }
@@ -57,31 +71,31 @@ function getErrorCode(error: unknown) {
     : undefined;
 }
 
-async function readUserRules(userId: string) {
-  assertValidUserId(userId);
-  const path = getUserRulesPath(userId);
-  try {
-    const [content, fileStat] = await Promise.all([
-      readFile(path, "utf-8"),
-      stat(path),
-    ]);
-    return {
-      content,
-      updatedAt: fileStat.mtime.toISOString(),
-      source: "config-space" as const,
-      path: USER_RULES_SANDBOX_PATH,
-    };
-  } catch (error) {
-    if (getErrorCode(error) === "ENOENT") {
+async function readUserRules(userIds: readonly string[]) {
+  for (const userId of userIds) {
+    assertValidUserId(userId);
+    const path = getUserRulesPath(userId);
+    try {
+      const [content, fileStat] = await Promise.all([
+        readFile(path, "utf-8"),
+        stat(path),
+      ]);
       return {
-        content: "",
-        updatedAt: null,
+        content,
+        updatedAt: fileStat.mtime.toISOString(),
         source: "config-space" as const,
         path: USER_RULES_SANDBOX_PATH,
       };
+    } catch (error) {
+      if (getErrorCode(error) !== "ENOENT") throw error;
     }
-    throw error;
   }
+  return {
+    content: "",
+    updatedAt: null,
+    source: "config-space" as const,
+    path: USER_RULES_SANDBOX_PATH,
+  };
 }
 
 router.get("/", async (c) => {
@@ -89,7 +103,12 @@ router.get("/", async (c) => {
   if (user instanceof Response) return user;
   const profile = await ensureCurrentUserProfile(user);
   const email = await resolveCurrentUserEmail(user);
-  return c.json({ uuid: user.uuid, profile, email });
+  return c.json({
+    uuid: user.uuid,
+    ...(user.legacyUserUuid ? { legacyUserUuid: user.legacyUserUuid } : {}),
+    profile,
+    email,
+  });
 });
 
 router.patch("/profile", async (c) => {
@@ -166,13 +185,13 @@ router.patch("/profile", async (c) => {
 router.get("/referrals", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
-  return c.json(await getReferralDashboard(user.uuid));
+  return c.json(await getReferralDashboard(user));
 });
 
 router.post("/referrals/code/rotate", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
-  const code = await rotateReferralCode(user.uuid);
+  const code = await rotateReferralCode(user);
   return c.json({ code: code.code });
 });
 
@@ -180,7 +199,7 @@ router.get("/rules", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
   try {
-    return c.json(await readUserRules(user.uuid));
+    return c.json(await readUserRules(getIdentityKeys(user)));
   } catch {
     return c.json({ message: "failed to load user rules" }, 500);
   }
@@ -212,7 +231,7 @@ async function listVisibleUserSessions(
   const canViewAllInSpace = async (spaceId: string) => {
     const cached = memberViewBySpace.get(spaceId);
     if (cached !== undefined) return cached;
-    const isMember = (await getSpaceMemberRole(spaceId, identity.uuid)) !== null;
+    const isMember = (await getSpaceMemberRoleForUser(spaceId, identity)) !== null;
     const allowed = isMember
       ? await hasPermission(identity, "session.view", { spaceId })
       : false;
@@ -223,7 +242,7 @@ async function listVisibleUserSessions(
   while (visible.length < limit && hasMore && guard < 8) {
     guard += 1;
     const batchLimit = Math.min(100, Math.max(limit * 2, limit - visible.length + 4));
-    const batch = await listUserSessions(identity.uuid, { limit: batchLimit, cursor });
+    const batch = await listUserSessions([identity.uuid, identity.legacyUserUuid].filter((value): value is string => Boolean(value)), { limit: batchLimit, cursor });
     hasMore = Boolean(batch.pageInfo.hasMore);
     cursor = batch.pageInfo.nextCursor;
 
@@ -317,7 +336,7 @@ router.get("/usage", async (c) => {
         .from(schema.tokenUsageStatsHourly)
         .where(
           and(
-            eq(schema.tokenUsageStatsHourly.userId, identity.uuid),
+            inArray(schema.tokenUsageStatsHourly.userId, [identity.uuid, identity.legacyUserUuid].filter((value): value is string => Boolean(value))),
             gte(schema.tokenUsageStatsHourly.bucketStartAt, startDate),
             lte(schema.tokenUsageStatsHourly.bucketStartAt, now),
           ),
@@ -328,7 +347,7 @@ router.get("/usage", async (c) => {
         .from(schema.generationUsageStatsHourly)
         .where(
           and(
-            eq(schema.generationUsageStatsHourly.userId, identity.uuid),
+            inArray(schema.generationUsageStatsHourly.userId, [identity.uuid, identity.legacyUserUuid].filter((value): value is string => Boolean(value))),
             gte(schema.generationUsageStatsHourly.bucketStartAt, startDate),
             lte(schema.generationUsageStatsHourly.bucketStartAt, now),
           ),

--- a/apps/api/src/routes/models.route.ts
+++ b/apps/api/src/routes/models.route.ts
@@ -16,6 +16,7 @@ import {
   type ModelsConfig,
 } from "@cohub/infra/config-runtime/models";
 import { loadPublicGenerationModels } from "../generations/declarations.js";
+import { getIdentityKeys, resolveStoredPrincipalReadKeys } from "../identity-bridge.js";
 import { config } from "../config.js";
 import { useAuth } from "../lib/middleware.js";
 import { redisCommandClient } from "../redis.js";
@@ -102,13 +103,14 @@ async function fetchModelsCatalog(userId: string): Promise<ModelCatalogEntry[]> 
   });
   if (!platformModels) throw new Error("Models catalog file not found");
 
-  const userModels = await loadCachedModels({
-    redisKey: getUserModelsRedisKey(userId),
-    modelsPath: getUserModelsPath(userId),
+  const userIds = await resolveStoredPrincipalReadKeys(userId);
+  const userModels = await Promise.all(userIds.map((resolvedUserId) => loadCachedModels({
+    redisKey: getUserModelsRedisKey(resolvedUserId),
+    modelsPath: getUserModelsPath(resolvedUserId),
     allowMissing: true,
-  });
+  })));
 
-  return flattenModelsCatalog(mergeModelsConfigs(platformModels, userModels));
+  return flattenModelsCatalog(mergeModelsConfigs(platformModels, ...userModels));
 }
 
 const router = new Hono();
@@ -123,7 +125,7 @@ router.get("/", async (c) => {
   try {
     const modelType = c.req.query("modelType");
     if (modelType === MULTIMODAL_MODEL_TYPE) {
-      return c.json(await loadPublicGenerationModels(user.uuid));
+      return c.json(await loadPublicGenerationModels(user.uuid, getIdentityKeys(user)));
     }
 
     const catalog = await fetchModelsCatalog(user.uuid);

--- a/apps/api/src/routes/referrals.route.ts
+++ b/apps/api/src/routes/referrals.route.ts
@@ -32,7 +32,7 @@ router.post("/:code/claim", async (c) => {
   const code = c.req.param("code");
   if (!CODE_PATTERN.test(code)) return c.json({ message: "referral not found" }, 404);
 
-  const result = await claimReferral(code, user.uuid);
+  const result = await claimReferral(code, user);
   if (!result) return c.json({ message: "referral not found" }, 404);
   if (result.status === "self") return c.json({ message: "this is your referral link", status: "self" }, 409);
   if (result.status === "existing_user") {

--- a/apps/api/src/routes/search.route.ts
+++ b/apps/api/src/routes/search.route.ts
@@ -4,6 +4,7 @@ import { db } from "../db/index.js";
 import { fallbackPublicUserProfile, getProfilesByUuids } from "../user-profiles.js";
 import { normalizePublicAvatarUrl, useAuth } from "../lib/middleware.js";
 import { createLogger } from "@cohub/infra/logging";
+import { getIdentityKeys } from "../identity-bridge.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -183,6 +184,7 @@ router.get("/", async (c) => {
   const combinedResults = sql.join(resultQueries, sql`
       UNION ALL
       `);
+  const identityList = sql.join(getIdentityKeys(user).map((key) => sql`${key}`), sql`, `);
 
   try {
     const rows = await db.transaction(async (tx) => {
@@ -192,16 +194,16 @@ router.get("/", async (c) => {
       SELECT
         s.*,
         CASE
-          WHEN s.user_uuid = ${user.uuid} OR sm.user_id IS NOT NULL THEN 1.0::double precision
+          WHEN s.user_uuid IN (${identityList}) OR sm.user_id IS NOT NULL THEN 1.0::double precision
           ELSE 0.0::double precision
         END AS membership_priority_score
       FROM v2.spaces s
       LEFT JOIN v2.space_members sm
-        ON sm.space_id = s.id AND sm.user_id = ${user.uuid}
+        ON sm.space_id = s.id AND sm.user_id IN (${identityList})
       WHERE
         (${spaceId}::uuid IS NULL OR s.id = ${spaceId}::uuid)
         AND (
-          s.user_uuid = ${user.uuid}
+          s.user_uuid IN (${identityList})
           OR sm.user_id IS NOT NULL
           OR EXISTS (
             SELECT 1

--- a/apps/api/src/routes/spaces/commerce.route.ts
+++ b/apps/api/src/routes/spaces/commerce.route.ts
@@ -265,7 +265,7 @@ router.post("/:id/commerce/setup", async (c) => {
   const spaceId = c.req.param("id");
   if (!requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
   if (!(await hasPermission(user, "space.commerce.manage", { spaceId }))) return authzDenied(c);
-  const entitlementDenied = await requireSpaceCommerceEntitlement(c, user.uuid);
+  const entitlementDenied = await requireSpaceCommerceEntitlement(c, user);
   if (entitlementDenied) return entitlementDenied;
   try {
     const mapping = await ensureSpaceCommerceBusiness(spaceId);
@@ -312,7 +312,7 @@ router.post("/:id/commerce/products", async (c) => {
   const spaceId = c.req.param("id");
   if (!requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
   if (!(await hasPermission(user, "space.commerce.manage", { spaceId }))) return authzDenied(c);
-  const entitlementDenied = await requireSpaceCommerceEntitlement(c, user.uuid);
+  const entitlementDenied = await requireSpaceCommerceEntitlement(c, user);
   if (entitlementDenied) return entitlementDenied;
   const body = await c.req.json().catch(() => null) as Record<string, unknown> | null;
   const explicitKey = typeof body?.key === "string" ? body.key.trim() : "";
@@ -371,7 +371,7 @@ router.patch("/:id/commerce/products/:productKey", async (c) => {
   if (!requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
   if (!productKey) return c.json({ message: "product not found" }, 404);
   if (!(await hasPermission(user, "space.commerce.manage", { spaceId }))) return authzDenied(c);
-  const entitlementDenied = await requireSpaceCommerceEntitlement(c, user.uuid);
+  const entitlementDenied = await requireSpaceCommerceEntitlement(c, user);
   if (entitlementDenied) return entitlementDenied;
   const body = await c.req.json().catch(() => null) as Record<string, unknown> | null;
   const patch: Record<string, unknown> = {};
@@ -433,7 +433,7 @@ router.post("/:id/commerce/benefits", async (c) => {
   const spaceId = c.req.param("id");
   if (!requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
   if (!(await hasPermission(user, "space.commerce.manage", { spaceId }))) return authzDenied(c);
-  const entitlementDenied = await requireSpaceCommerceEntitlement(c, user.uuid);
+  const entitlementDenied = await requireSpaceCommerceEntitlement(c, user);
   if (entitlementDenied) return entitlementDenied;
   const body = await c.req.json().catch(() => null) as Record<string, unknown> | null;
   const explicitKey = typeof body?.key === "string" ? body.key.trim() : "";
@@ -508,7 +508,7 @@ router.patch("/:id/commerce/benefits/:benefitKey", async (c) => {
   if (!requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
   if (!benefitKey) return c.json({ message: "benefit not found" }, 404);
   if (!(await hasPermission(user, "space.commerce.manage", { spaceId }))) return authzDenied(c);
-  const entitlementDenied = await requireSpaceCommerceEntitlement(c, user.uuid);
+  const entitlementDenied = await requireSpaceCommerceEntitlement(c, user);
   if (entitlementDenied) return entitlementDenied;
   const body = await c.req.json().catch(() => null) as Record<string, unknown> | null;
   const patch: Record<string, unknown> = {};
@@ -576,7 +576,7 @@ router.post("/:id/commerce/product-benefits", async (c) => {
   const spaceId = c.req.param("id");
   if (!requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
   if (!(await hasPermission(user, "space.commerce.manage", { spaceId }))) return authzDenied(c);
-  const entitlementDenied = await requireSpaceCommerceEntitlement(c, user.uuid);
+  const entitlementDenied = await requireSpaceCommerceEntitlement(c, user);
   if (entitlementDenied) return entitlementDenied;
   const body = await c.req.json().catch(() => null) as Record<string, unknown> | null;
   const productKey = typeof body?.productKey === "string" ? body.productKey.trim() : "";
@@ -612,7 +612,7 @@ router.delete("/:id/commerce/product-benefits", async (c) => {
   const spaceId = c.req.param("id");
   if (!requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
   if (!(await hasPermission(user, "space.commerce.manage", { spaceId }))) return authzDenied(c);
-  const entitlementDenied = await requireSpaceCommerceEntitlement(c, user.uuid);
+  const entitlementDenied = await requireSpaceCommerceEntitlement(c, user);
   if (entitlementDenied) return entitlementDenied;
   const productKey = c.req.query("productKey")?.trim() ?? "";
   const benefitKey = c.req.query("benefitKey")?.trim() ?? "";

--- a/apps/api/src/routes/spaces/completions.route.ts
+++ b/apps/api/src/routes/spaces/completions.route.ts
@@ -33,6 +33,7 @@ import {
   streamCompletionEvents,
   type RunCompletionOutcome,
 } from "../../llm/stream-completion.js";
+import { resolveBillingUserId } from "../../identity-bridge.js";
 
 const logger = createLogger({ serviceName: "cohub-api" });
 const router = new Hono();
@@ -409,9 +410,17 @@ router.post("/", async (c) => {
   const model = resolved.model;
   const registry = resolved.registry;
 
+  const billingUserId = await resolveBillingUserId(user).catch((error) => {
+    logger.error("[Billing] failed to resolve legacy billing identity before raw completion", { error });
+    return null;
+  });
+  if (!billingUserId) {
+    return completionError(c, 503, "billing_identity_unavailable", "Billing identity is temporarily unavailable.");
+  }
+
   // Pre-check balance before spending tokens. Fail-open if credit lookup errors.
   const decision = await billingUsageGate.evaluate({
-    userId: user.uuid,
+    userId: billingUserId,
     usageKind: "llm.raw_completion",
     source: "raw_completion",
     model: model.id,
@@ -441,7 +450,7 @@ router.post("/", async (c) => {
     const completedAt = new Date();
     await recordCompletionBilling({
       completionId,
-      userId: user.uuid,
+      userId: billingUserId,
       provider: model.provider,
       model: model.id,
       usage: outcome.usage,

--- a/apps/api/src/routes/spaces/fs.route.ts
+++ b/apps/api/src/routes/spaces/fs.route.ts
@@ -7,6 +7,7 @@ import { ensureFsCdnManifest, shouldUseFsCdnForMeta } from "../../space-fs-cdn-c
 import { FS_CDN_DOWNLOAD_WAIT_TIMEOUT_MS } from "../../space-fs-cdn-constants.js";
 import { getOptionalAuth, useAuth, requireValidId, authzDenied } from "../../lib/middleware.js";
 import { hasPermission } from "../../permissions.js";
+import { identityEquals } from "../../identity-bridge.js";
 import { getSpacePendingDiffFile, getSpacePendingDiffSummary } from "../../checkpoint-pending-diff.js";
 import { checkpointFsJsonError } from "../../checkpoint-fs.js";
 import {
@@ -467,7 +468,7 @@ router.post("/uploads/:uploadId/complete", async (c) => {
 
   try {
     const manifest = await getSpaceUploadManifest(spaceId, uploadId);
-    if (!manifest || manifest.userId !== user.uuid) {
+    if (!manifest || !identityEquals(user, manifest.userId)) {
       await cancelSpaceUploadComplete(spaceId, uploadId);
       return c.json({ message: "upload not found" }, 404);
     }

--- a/apps/api/src/routes/spaces/invitations.route.ts
+++ b/apps/api/src/routes/spaces/invitations.route.ts
@@ -33,7 +33,7 @@ router.post("/", async (c) => {
   if (!space) return c.json({ message: "space not found" }, 404);
 
   // Only hosts can create invitations
-  const actorRole = await getRoleForSpaceUser(spaceId, user.uuid);
+  const actorRole = await getRoleForSpaceUser(spaceId, user);
   if (actorRole !== "host") return c.json({ message: "forbidden" }, 403);
 
   const body = await c.req.json<{
@@ -135,7 +135,7 @@ router.delete("/:token", async (c) => {
   const token = c.req.param("token");
   if (!spaceId || !requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
 
-  const actorRole = await getRoleForSpaceUser(spaceId, user.uuid);
+  const actorRole = await getRoleForSpaceUser(spaceId, user);
   if (actorRole !== "host") return c.json({ message: "forbidden" }, 403);
 
   const key = inviteKey(token);

--- a/apps/api/src/routes/spaces/members.route.ts
+++ b/apps/api/src/routes/spaces/members.route.ts
@@ -1,15 +1,16 @@
-import { and, count, eq, inArray } from "drizzle-orm";
+import { and, count, eq, inArray, or } from "drizzle-orm";
 import { Hono } from "hono";
 import { unbindSpaceChannelFromGateway } from "../../channels.js";
 import { db } from "../../db/index.js";
 import { spaceChannels, spaceMembers, userChannels, userProfiles } from "@cohub/db";
 import type { SpaceRole } from "@cohub/db";
-import { requireValidId, useAuth, authzDenied } from "../../lib/middleware.js";
+import { requireValidId, requireValidPrincipalId, useAuth, authzDenied } from "../../lib/middleware.js";
 import { isRoleLowerThan } from "@cohub/core/permissions";
 import { hasPermission, getRoleForSpaceUser } from "../../permissions.js";
 import { getSpaceById } from "../../space-sessions.js";
 import { fallbackPublicUserProfile } from "../../user-profiles.js";
 import { createLogger } from "@cohub/infra/logging";
+import { getIdentityKeys, resolveStoredPrincipalUser } from "../../identity-bridge.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -44,24 +45,33 @@ router.get("/", async (c) => {
       createdAt: spaceMembers.createdAt,
       updatedAt: spaceMembers.updatedAt,
       profile: {
-        userUuid: userProfiles.userUuid,
+        userUuid: userProfiles.logtoUserId,
         displayName: userProfiles.displayName,
         avatarUrl: userProfiles.avatarUrl,
       },
     })
     .from(spaceMembers)
-    .leftJoin(userProfiles, eq(userProfiles.userUuid, spaceMembers.userId))
+    .leftJoin(userProfiles, or(
+      eq(userProfiles.userUuid, spaceMembers.userId),
+      eq(userProfiles.logtoUserId, spaceMembers.userId),
+    ))
     .where(eq(spaceMembers.spaceId, spaceId))
     .orderBy(spaceMembers.createdAt);
 
-  return c.json({
-    items: items.map((item) => ({
-      ...item,
-      profile: item.profile?.userUuid
+  const canonicalItems = items.map((item) => {
+      const profile = item.profile?.userUuid
         ? item.profile
-        : fallbackPublicUserProfile(item.userId),
-    })),
-  });
+        : fallbackPublicUserProfile(item.userId);
+      return {
+        ...item,
+        userId: profile.userUuid,
+        profile,
+      };
+    });
+  if (new Set(canonicalItems.map((item) => item.userId)).size !== canonicalItems.length) {
+    return c.json({ message: "member identity conflict requires repair" }, 409);
+  }
+  return c.json({ items: canonicalItems });
 });
 
 router.put("/", async (c) => {
@@ -70,7 +80,7 @@ router.put("/", async (c) => {
   const spaceId = c.req.param("id");
   if (!spaceId || !requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
   if (!(await hasPermission(user, "member.manage", { spaceId }))) return authzDenied(c);
-  const actorRole = await getRoleForSpaceUser(spaceId, user.uuid);
+  const actorRole = await getRoleForSpaceUser(spaceId, user);
   if (actorRole !== "host") return authzDenied(c);
 
   const space = await getSpaceById(spaceId);
@@ -78,12 +88,20 @@ router.put("/", async (c) => {
 
   const body = await c.req.json<{ userId?: string; role?: SpaceRole }>().catch(() => null);
   if (!body?.userId || !body.role) return c.json({ message: "userId and role are required" }, 400);
-  if (!requireValidId(body.userId)) return c.json({ message: "userId must be a valid UUID" }, 400);
+  if (!requireValidPrincipalId(body.userId)) return c.json({ message: "userId must be a valid principal id" }, 400);
   if (!VALID_ROLES.includes(body.role)) return c.json({ message: "invalid role" }, 400);
-  const targetUserId = body.userId;
+  const targetIdentity = await resolveStoredPrincipalUser(body.userId).catch(() => null);
+  if (!targetIdentity) return c.json({ message: "user identity is not resolvable" }, 409);
+  const targetUserId = targetIdentity.uuid;
+  const targetIdentityKeys = getIdentityKeys(targetIdentity);
   const newRole = body.role;
 
-  const currentRole = await getRoleForSpaceUser(spaceId, targetUserId);
+  const currentMembers = await db
+    .select({ id: spaceMembers.id, role: spaceMembers.role })
+    .from(spaceMembers)
+    .where(and(eq(spaceMembers.spaceId, spaceId), inArray(spaceMembers.userId, targetIdentityKeys)));
+  if (currentMembers.length > 1) return c.json({ message: "member identity conflict requires repair" }, 409);
+  const currentRole = currentMembers[0]?.role ?? null;
   if (currentRole === "host" && newRole !== "host") {
     if (await isLastHost(spaceId))
       return c.json({ message: "cannot demote the last host" }, 400);
@@ -91,20 +109,26 @@ router.put("/", async (c) => {
 
   const shouldUnbindChannels = Boolean(currentRole && isRoleLowerThan(newRole, currentRole));
   const { member, spaceChannelIdsToUnbind } = await db.transaction(async (tx) => {
-    const [updatedMember] = await tx
-      .insert(spaceMembers)
-      .values({
+    const existingMembers = await tx
+      .select({ id: spaceMembers.id })
+      .from(spaceMembers)
+      .where(and(eq(spaceMembers.spaceId, spaceId), inArray(spaceMembers.userId, targetIdentityKeys)))
+      .for("update");
+    if (existingMembers.length > 1) throw new Error("member identity conflict requires repair");
+    const [updatedMember] = existingMembers[0]
+      ? await tx.update(spaceMembers).set({
+          userId: targetUserId,
+          role: newRole,
+          updatedBy: user.uuid,
+          updatedAt: new Date(),
+        }).where(eq(spaceMembers.id, existingMembers[0].id)).returning()
+      : await tx.insert(spaceMembers).values({
         spaceId,
         userId: targetUserId,
         role: newRole,
         createdBy: user.uuid,
         updatedBy: user.uuid,
-      })
-      .onConflictDoUpdate({
-        target: [spaceMembers.spaceId, spaceMembers.userId],
-        set: { role: newRole, updatedBy: user.uuid, updatedAt: new Date() },
-      })
-      .returning();
+      }).returning();
 
     if (!shouldUnbindChannels) {
       return { member: updatedMember, spaceChannelIdsToUnbind: [] };
@@ -114,7 +138,7 @@ router.put("/", async (c) => {
       .select({ id: spaceChannels.id })
       .from(spaceChannels)
       .innerJoin(userChannels, eq(userChannels.id, spaceChannels.channelId))
-      .where(and(eq(spaceChannels.spaceId, spaceId), eq(userChannels.userUuid, targetUserId)));
+      .where(and(eq(spaceChannels.spaceId, spaceId), inArray(userChannels.userUuid, targetIdentityKeys)));
     const spaceChannelIds = channels.map((channel) => channel.id);
     if (spaceChannelIds.length > 0) {
       await tx.delete(spaceChannels).where(inArray(spaceChannels.id, spaceChannelIds));
@@ -134,14 +158,21 @@ router.delete("/", async (c) => {
   const spaceId = c.req.param("id");
   if (!spaceId || !requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
   if (!(await hasPermission(user, "member.manage", { spaceId }))) return authzDenied(c);
-  const actorRole = await getRoleForSpaceUser(spaceId, user.uuid);
+  const actorRole = await getRoleForSpaceUser(spaceId, user);
   if (actorRole !== "host") return authzDenied(c);
 
   const body = await c.req.json<{ userId?: string }>().catch(() => null);
-  if (!body?.userId || !requireValidId(body.userId)) return c.json({ message: "userId is required" }, 400);
-  const targetUserId = body.userId;
+  if (!body?.userId || !requireValidPrincipalId(body.userId)) return c.json({ message: "userId is required" }, 400);
+  const targetIdentity = await resolveStoredPrincipalUser(body.userId).catch(() => null);
+  if (!targetIdentity) return c.json({ message: "user identity is not resolvable" }, 409);
+  const targetIdentityKeys = getIdentityKeys(targetIdentity);
 
-  const targetRole = await getRoleForSpaceUser(spaceId, targetUserId);
+  const targetMembers = await db
+    .select({ role: spaceMembers.role })
+    .from(spaceMembers)
+    .where(and(eq(spaceMembers.spaceId, spaceId), inArray(spaceMembers.userId, targetIdentityKeys)));
+  if (targetMembers.length > 1) return c.json({ message: "member identity conflict requires repair" }, 409);
+  const targetRole = targetMembers[0]?.role ?? null;
   if (!targetRole) return c.json({ ok: true });
 
   if (targetRole === "host" && await isLastHost(spaceId))
@@ -152,7 +183,7 @@ router.delete("/", async (c) => {
       .select({ id: spaceChannels.id })
       .from(spaceChannels)
       .innerJoin(userChannels, eq(userChannels.id, spaceChannels.channelId))
-      .where(and(eq(spaceChannels.spaceId, spaceId), eq(userChannels.userUuid, targetUserId)));
+      .where(and(eq(spaceChannels.spaceId, spaceId), inArray(userChannels.userUuid, targetIdentityKeys)));
     const spaceChannelIds = channels.map((channel) => channel.id);
 
     if (spaceChannelIds.length > 0) {
@@ -160,7 +191,7 @@ router.delete("/", async (c) => {
     }
     await tx
       .delete(spaceMembers)
-      .where(and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, targetUserId)));
+      .where(and(eq(spaceMembers.spaceId, spaceId), inArray(spaceMembers.userId, targetIdentityKeys)));
 
     return spaceChannelIds;
   });

--- a/apps/api/src/routes/spaces/spaces.route.ts
+++ b/apps/api/src/routes/spaces/spaces.route.ts
@@ -84,6 +84,7 @@ import { redisCommandClient } from "../../redis.js";
 import { featureGateResponse } from "../../lib/feature-gate.js";
 import { billingBlockedResponse } from "../../lib/billing-blocked.js";
 import { applyRequestSourceToMeta, getRequestSource, resolveSessionSourceFromRequest } from "../../lib/request-source.js";
+import { getIdentityKeys, resolveBillingUserId, resolveBillingUserIdForStoredPrincipal } from "../../identity-bridge.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -335,15 +336,16 @@ const uniqueViolationConstraint = (error: unknown): string | null => {
 
 type SpaceRow = typeof spaces.$inferSelect;
 
-async function listAccessibleSpaceIds(userUuid: string): Promise<string[]> {
+async function listAccessibleSpaceIds(userUuids: readonly string[]): Promise<string[]> {
+  const unique = [...new Set(userUuids)];
   const owned = await db
     .select({ id: spaces.id })
     .from(spaces)
-    .where(eq(spaces.userUuid, userUuid));
+    .where(inArray(spaces.userUuid, unique));
   const member = await db
     .select({ id: spaceMembers.spaceId })
     .from(spaceMembers)
-    .where(eq(spaceMembers.userId, userUuid));
+    .where(inArray(spaceMembers.userId, unique));
 
   return Array.from(new Set([...owned.map((item) => item.id), ...member.map((item) => item.id)]));
 }
@@ -422,15 +424,18 @@ const getSpaceSandboxSpec = (space: typeof spaces.$inferSelect): SandboxSpecId =
   return isSandboxSpecId(sandbox.spec) ? sandbox.spec : DEFAULT_SANDBOX_SPEC_ID;
 };
 
-async function getAllowedSandboxSpecId(userId: string): Promise<SandboxSpecId> {
+async function getAllowedSandboxSpecId(user: AuthUser | string): Promise<SandboxSpecId> {
   try {
+    const userId = typeof user === "string"
+      ? await resolveBillingUserIdForStoredPrincipal(user)
+      : await resolveBillingUserId(user);
     const state = await billingOperations.getState({ userId });
     const keys = new Set(state.entitlements.filter((entitlement) => entitlement.enabled).map((entitlement) => entitlement.key));
     if (keys.has(COHUB_BILLING_FEATURES.sandboxSpecUltra)) return "ultra";
     if (keys.has(COHUB_BILLING_FEATURES.sandboxSpecBoost)) return "boost";
     return DEFAULT_SANDBOX_SPEC_ID;
   } catch (error) {
-    logger.warn("[SandboxSpec] failed to check entitlement", { userId, error });
+    logger.warn("[SandboxSpec] failed to check entitlement", { error });
     return DEFAULT_SANDBOX_SPEC_ID;
   }
 }
@@ -550,33 +555,33 @@ function getSpaceProvisionParams(
   };
 }
 
-async function findOwnedHomeSpace(userUuid: string): Promise<SpaceRow | null> {
+async function findOwnedHomeSpace(userUuids: readonly string[]): Promise<SpaceRow | null> {
   const [ownedHome] = await db
     .select()
     .from(spaces)
-    .where(and(eq(spaces.userUuid, userUuid), eq(spaces.slug, HOME_SPACE_SLUG)))
+    .where(and(inArray(spaces.userUuid, [...new Set(userUuids)]), eq(spaces.slug, HOME_SPACE_SLUG)))
     .limit(1);
   return ownedHome ?? null;
 }
 
-async function findOwnedRecentSpace(userUuid: string): Promise<SpaceRow | null> {
+async function findOwnedRecentSpace(userUuids: readonly string[]): Promise<SpaceRow | null> {
   const [ownedRecent] = await db
     .select()
     .from(spaces)
-    .where(eq(spaces.userUuid, userUuid))
+    .where(inArray(spaces.userUuid, [...new Set(userUuids)]))
     .orderBy(sql`${spaces.lastActivityAt} desc nulls last`, desc(spaces.createdAt))
     .limit(1);
   return ownedRecent ?? null;
 }
 
 /** After a unique conflict, prefer the real home slug, then any owned space. */
-async function resolveHomeEnsureConflict(userUuid: string, reason: string): Promise<SpaceRow | null> {
-  const home = await findOwnedHomeSpace(userUuid);
+async function resolveHomeEnsureConflict(userUuids: readonly string[], reason: string): Promise<SpaceRow | null> {
+  const home = await findOwnedHomeSpace(userUuids);
   if (home) return home;
-  const recent = await findOwnedRecentSpace(userUuid);
+  const recent = await findOwnedRecentSpace(userUuids);
   if (recent) {
     logger.warn("[DefaultSpace] home ensure conflict without slug=home", {
-      userUuid,
+      userUuid: userUuids[0],
       reason,
       spaceId: recent.id,
       name: recent.name,
@@ -586,19 +591,20 @@ async function resolveHomeEnsureConflict(userUuid: string, reason: string): Prom
   return recent;
 }
 
-async function findDefaultSpaceCandidate(userUuid: string): Promise<SpaceRow | null> {
+async function findDefaultSpaceCandidate(userUuids: readonly string[]): Promise<SpaceRow | null> {
+  const unique = [...new Set(userUuids)];
   // Hot path: most accounts already have a home space.
   const [[ownedHome], [memberHome]] = await Promise.all([
     db
       .select()
       .from(spaces)
-      .where(and(eq(spaces.userUuid, userUuid), eq(spaces.slug, HOME_SPACE_SLUG)))
+      .where(and(inArray(spaces.userUuid, unique), eq(spaces.slug, HOME_SPACE_SLUG)))
       .limit(1),
     db
       .select({ space: spaces })
       .from(spaceMembers)
       .innerJoin(spaces, eq(spaces.id, spaceMembers.spaceId))
-      .where(and(eq(spaceMembers.userId, userUuid), eq(spaces.slug, HOME_SPACE_SLUG)))
+      .where(and(inArray(spaceMembers.userId, unique), eq(spaces.slug, HOME_SPACE_SLUG)))
       .orderBy(sql`${spaces.lastActivityAt} desc nulls last`, desc(spaces.createdAt))
       .limit(1),
   ]);
@@ -609,14 +615,14 @@ async function findDefaultSpaceCandidate(userUuid: string): Promise<SpaceRow | n
     db
       .select()
       .from(spaces)
-      .where(eq(spaces.userUuid, userUuid))
+      .where(inArray(spaces.userUuid, unique))
       .orderBy(sql`${spaces.lastActivityAt} desc nulls last`, desc(spaces.createdAt))
       .limit(1),
     db
       .select({ space: spaces })
       .from(spaceMembers)
       .innerJoin(spaces, eq(spaces.id, spaceMembers.spaceId))
-      .where(eq(spaceMembers.userId, userUuid))
+      .where(inArray(spaceMembers.userId, unique))
       .orderBy(sql`${spaces.lastActivityAt} desc nulls last`, desc(spaces.createdAt))
       .limit(1),
   ]);
@@ -692,7 +698,7 @@ async function ensureHomeSpace(user: AuthUser): Promise<SpaceRow | null> {
     const constraint = uniqueViolationConstraint(error);
     if (constraint?.includes("user_slug") || constraint?.includes("user_name")) {
       return resolveHomeEnsureConflict(
-        user.uuid,
+        getIdentityKeys(user),
         constraint.includes("user_slug") ? "slug_conflict" : "name_conflict",
       );
     }
@@ -709,7 +715,7 @@ async function ensureHomeSpace(user: AuthUser): Promise<SpaceRow | null> {
       } catch (retryError) {
         const retryConstraint = uniqueViolationConstraint(retryError);
         if (retryConstraint?.includes("user_slug") || retryConstraint?.includes("user_name")) {
-          return resolveHomeEnsureConflict(user.uuid, "retry_unique_conflict");
+          return resolveHomeEnsureConflict(getIdentityKeys(user), "retry_unique_conflict");
         }
         throw retryError;
       }
@@ -718,7 +724,7 @@ async function ensureHomeSpace(user: AuthUser): Promise<SpaceRow | null> {
     }
   }
 
-  if (!space) return resolveHomeEnsureConflict(user.uuid, "missing_space");
+  if (!space) return resolveHomeEnsureConflict(getIdentityKeys(user), "missing_space");
   const provisioned = await provisionCreatedSpace({
     user,
     space,
@@ -741,7 +747,8 @@ router.get("/", async (c) => {
   if (!identity) return authzDenied(c);
 
   // Account list: owned/member by viewer uuid, independent of work space scopes.
-  const spaceIds = await listAccessibleSpaceIds(identity.uuid);
+  const identityKeys = [identity.uuid, identity.legacyUserUuid].filter((value): value is string => Boolean(value));
+  const spaceIds = await listAccessibleSpaceIds(identityKeys);
   if (spaceIds.length === 0) return c.json([]);
 
   const spaceList = await db
@@ -751,7 +758,10 @@ router.get("/", async (c) => {
     .orderBy(sql`${spaces.lastActivityAt} desc nulls last`, desc(spaces.createdAt));
 
   const items = await buildSpaceListItems(spaceList);
-  const pinnedSpaceIds = await getPinnedSpaceIds(db, identity.uuid);
+  const pinnedSpaceIds = await getPinnedSpaceIds(db, {
+    uuid: identity.uuid,
+    aliases: identity.legacyUserUuid ? [identity.legacyUserUuid] : [],
+  });
   const itemsWithPins = items.map((item) => ({
     ...item,
     isPinned: pinnedSpaceIds.has(item.id),
@@ -768,7 +778,7 @@ router.get("/default", async (c) => {
   if (!identity) return authzDenied(c);
 
   // Prefer existing home / recent space.
-  let space = await findDefaultSpaceCandidate(identity.uuid);
+  let space = await findDefaultSpaceCandidate([identity.uuid, identity.legacyUserUuid].filter((value): value is string => Boolean(value)));
   // Ensure only for normal account sessions. Work / preview / execution
   // principals may list via viewer grants but must not mint spaces.
   const canEnsureHome =
@@ -837,7 +847,7 @@ router.post("/", async (c) => {
   const existingSpace = await db
     .select({ id: spaces.id })
     .from(spaces)
-    .where(and(eq(spaces.userUuid, user.uuid), eq(spaces.name, name)))
+    .where(and(inArray(spaces.userUuid, getIdentityKeys(user)), eq(spaces.name, name)))
     .limit(1);
   if (existingSpace.length > 0) return c.json({ message: "space already exists" }, 409);
 
@@ -852,7 +862,7 @@ router.post("/", async (c) => {
     return c.json({ message: error instanceof Error ? error.message : "invalid space config" }, 400);
   }
   const requestedSpec = normalizedConfig.sandbox?.spec ?? DEFAULT_SANDBOX_SPEC_ID;
-  const allowedSpec = await getAllowedSandboxSpecId(user.uuid);
+  const allowedSpec = await getAllowedSandboxSpecId(user);
   if (getSandboxSpecRank(requestedSpec) > getSandboxSpecRank(allowedSpec)) {
     return createSandboxSpecRequiredResponse(c, requestedSpec);
   }
@@ -873,7 +883,7 @@ router.post("/", async (c) => {
     const channels = await db
       .select({ id: userChannels.id })
       .from(userChannels)
-      .where(and(eq(userChannels.userUuid, user.uuid), inArray(userChannels.id, ids)));
+      .where(and(inArray(userChannels.userUuid, getIdentityKeys(user)), inArray(userChannels.id, ids)));
     if (channels.length !== ids.length) return c.json({ message: "one or more channels are invalid" }, 400);
   }
 
@@ -1057,6 +1067,7 @@ async function serializeSpaceForResponse(space: typeof spaces.$inferSelect, user
 
   return {
     ...space,
+    userUuid: ownerProfile.userUuid,
     meta: sanitizeSpaceMeta(space.meta),
     publicProfile: getSpacePublicProfile(space),
     sandboxStatus: sandbox?.status ?? null,
@@ -1146,7 +1157,7 @@ router.get("/by-slug/:username/:slug", async (c) => {
   if (slugError || !slug) return c.json({ message: "space not found" }, 404);
 
   const [profile] = await db
-    .select({ userUuid: userProfiles.userUuid })
+    .select({ userUuid: userProfiles.userUuid, logtoUserId: userProfiles.logtoUserId })
     .from(userProfiles)
     .where(eq(userProfiles.username, username))
     .limit(1);
@@ -1155,7 +1166,7 @@ router.get("/by-slug/:username/:slug", async (c) => {
   const [space] = await db
     .select()
     .from(spaces)
-    .where(and(eq(spaces.userUuid, profile.userUuid), eq(spaces.slug, slug)))
+    .where(and(inArray(spaces.userUuid, [profile.logtoUserId, profile.userUuid]), eq(spaces.slug, slug)))
     .limit(1);
   if (!space) return c.json({ message: "space not found" }, 404);
 
@@ -1682,7 +1693,7 @@ router.get("/:id/config", async (c) => {
   if (!space) return c.json({ message: "space not found" }, 404);
 
   const [allowedSpec, sandbox] = await Promise.all([
-    user?.uuid ? getAllowedSandboxSpecId(user.uuid) : Promise.resolve(DEFAULT_SANDBOX_SPEC_ID),
+    user ? getAllowedSandboxSpecId(user) : Promise.resolve(DEFAULT_SANDBOX_SPEC_ID),
     getSpaceSandboxBySpaceId(spaceId),
   ]);
   return c.json({
@@ -2284,7 +2295,7 @@ router.post("/:id/channels/:channelId", async (c) => {
   if (!(await hasPermission(user, "channel.manage", { spaceId }))) return authzDenied(c);
 
   // Verify ownership: the channel must belong to the same user
-  const [userChannel] = await db.select().from(userChannels).where(and(eq(userChannels.id, channelId), eq(userChannels.userUuid, user.uuid))).limit(1);
+  const [userChannel] = await db.select().from(userChannels).where(and(eq(userChannels.id, channelId), inArray(userChannels.userUuid, getIdentityKeys(user)))).limit(1);
   if (!userChannel) return c.json({ message: "channel not owned by you" }, 403);
 
   // Check if already bound to any space

--- a/apps/api/src/routes/tasks.route.ts
+++ b/apps/api/src/routes/tasks.route.ts
@@ -7,6 +7,8 @@ import { hasPermission } from "../permissions.js";
 import { taskQueue } from "../tasks.js";
 import { fallbackPublicUserProfile, getProfilesByUuids } from "../user-profiles.js";
 import { sanitizeTaskRunPricingForViewer } from "../task-run-privacy.js";
+import { getIdentityKeys, identityEquals } from "../identity-bridge.js";
+import type { AuthUser } from "../lib/middleware.js";
 
 const router = new Hono();
 
@@ -98,16 +100,20 @@ function hydrateTaskRunUserProfiles<T extends {
   result: unknown;
 }>(
   runs: T[],
-  options?: { sanitizeForList?: boolean; viewerUserId?: string | null },
+  options?: { sanitizeForList?: boolean; viewer?: AuthUser | null },
 ) {
   const userUuids = runs.map((run) => run.userUuid).filter((value): value is string => Boolean(value));
   return getProfilesByUuids(userUuids).then((profiles) =>
     runs.map((run) => {
-      const privateRun = sanitizeTaskRunPricingForViewer(run, options?.viewerUserId);
+      const privateRun = sanitizeTaskRunPricingForViewer(run, options?.viewer);
       const sanitized = options?.sanitizeForList ? sanitizeTaskRunForList(privateRun) : privateRun;
+      const userProfile = sanitized.userUuid
+        ? profiles.get(sanitized.userUuid) ?? fallbackPublicUserProfile(sanitized.userUuid)
+        : undefined;
       return {
         ...sanitized,
-        userProfile: sanitized.userUuid ? profiles.get(sanitized.userUuid) ?? fallbackPublicUserProfile(sanitized.userUuid) : undefined,
+        userUuid: userProfile?.userUuid ?? null,
+        userProfile,
       };
     }),
   );
@@ -147,14 +153,14 @@ router.get("/", async (c) => {
       .limit(limit + 1);
     const runs = await hydrateTaskRunUserProfiles(rows.slice(0, limit), {
       sanitizeForList: true,
-      viewerUserId: userId,
+      viewer: user,
     });
     return c.json({ runs, pageInfo: { hasMore: rows.length > limit, nextCursor: rows.length > limit ? buildTaskCursor(runs.at(-1)) : null } });
   }
 
   if (!userId) return c.json({ message: "unauthorized" }, 401);
 
-  const conditions = [eq(taskRuns.userUuid, userId)];
+  const conditions = [inArray(taskRuns.userUuid, getIdentityKeys(user))];
   applyTaskFilters({ conditions, sessionId, cronJobId, taskType, status, cursor: cursorValue });
   const rows = await db
     .select()
@@ -164,7 +170,7 @@ router.get("/", async (c) => {
     .limit(limit + 1);
   const runs = await hydrateTaskRunUserProfiles(rows.slice(0, limit), {
     sanitizeForList: true,
-    viewerUserId: userId,
+    viewer: user,
   });
 
   return c.json({ runs, pageInfo: { hasMore: rows.length > limit, nextCursor: rows.length > limit ? buildTaskCursor(runs.at(-1)) : null } });
@@ -183,12 +189,12 @@ router.get("/:taskId", async (c) => {
     if (!(await hasPermission(user, "taskrun.view", { spaceId: run.spaceId, sessionId: run.sessionId ?? undefined }))) {
       return authzDenied(c);
     }
-  } else if (!user || run.userUuid !== user.uuid) {
+  } else if (!user || !identityEquals(user, run.userUuid)) {
     return authzDenied(c);
   }
 
   const job = await taskQueue.getJob(run.jobId).catch(() => null);
-  const [hydratedRun] = await hydrateTaskRunUserProfiles([run], { viewerUserId: user?.uuid });
+  const [hydratedRun] = await hydrateTaskRunUserProfiles([run], { viewer: user });
   return c.json({ run: hydratedRun, progress: job?.progress ?? null });
 });
 

--- a/apps/api/src/routes/trending.route.ts
+++ b/apps/api/src/routes/trending.route.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from "hono";
-import { sql, and, gte, lt, isNotNull, ne } from "drizzle-orm";
+import { sql, and, eq, gte, lt, isNotNull, ne, or } from "drizzle-orm";
 import { db } from "../db/index.js";
 import * as schema from "@cohub/db";
 import { getSpacePublicProfile } from "../lib/middleware.js";
@@ -148,7 +148,7 @@ async function loadTrendingSpaces() {
       rank: i + 1,
       spaceId: r.spaceId,
       spaceName: nameMap.get(r.spaceId) ?? r.spaceId.slice(0, 8),
-      userId: uid,
+      userId: userProfile.userUuid,
       userDisplay: userProfile.displayName,
       userProfile,
       spaceProfile: spaceProfileMap.get(r.spaceId as string) ?? { avatarUrl: null },
@@ -162,23 +162,28 @@ async function loadTrendingSpaces() {
 
 async function loadTrendingUsers() {
   const { yesterdayStart, todayStart } = getYesterdayWindow();
+  const canonicalUserId = sql<string>`coalesce(${schema.userProfiles.logtoUserId}, ${schema.tokenUsageStatsHourly.userId})`;
 
   const rows = await db
     .select({
-      userId: schema.tokenUsageStatsHourly.userId,
+      userId: canonicalUserId,
       totalTokens: sql<number>`SUM(${schema.tokenUsageStatsHourly.totalTokens})`.as("total_tokens"),
       costTotal: sql<string>`SUM(${schema.tokenUsageStatsHourly.costTotal})`.as("cost_total"),
       sessionCount: sql<number>`COUNT(DISTINCT ${schema.tokenUsageStatsHourly.sessionId})`.as("session_count"),
       requestCount: sql<number>`SUM(${schema.tokenUsageStatsHourly.requestCount})`.as("request_count"),
     })
     .from(schema.tokenUsageStatsHourly)
+    .leftJoin(schema.userProfiles, or(
+      eq(schema.userProfiles.userUuid, schema.tokenUsageStatsHourly.userId),
+      eq(schema.userProfiles.logtoUserId, schema.tokenUsageStatsHourly.userId),
+    ))
     .where(
       and(
         gte(schema.tokenUsageStatsHourly.bucketStartAt, yesterdayStart),
         lt(schema.tokenUsageStatsHourly.bucketStartAt, todayStart),
       ),
     )
-    .groupBy(schema.tokenUsageStatsHourly.userId)
+    .groupBy(canonicalUserId)
     .orderBy(sql`total_tokens DESC`)
     .limit(10);
 
@@ -290,7 +295,7 @@ async function loadGenerationTrendingSpaces() {
       rank: i + 1,
       spaceId: r.spaceId,
       spaceName: nameMap.get(r.spaceId) ?? r.spaceId.slice(0, 8),
-      userId: uid,
+      userId: userProfile.userUuid,
       userDisplay: userProfile.displayName,
       userProfile,
       spaceProfile: spaceProfileMap.get(r.spaceId as string) ?? { avatarUrl: null },
@@ -303,15 +308,20 @@ async function loadGenerationTrendingSpaces() {
 
 async function loadGenerationTrendingUsers() {
   const { yesterdayStart, todayStart } = getYesterdayWindow();
+  const canonicalUserId = sql<string>`coalesce(${schema.userProfiles.logtoUserId}, ${schema.generationUsageStatsHourly.userId})`;
 
   const rows = await db
     .select({
-      userId: schema.generationUsageStatsHourly.userId,
+      userId: canonicalUserId,
       costTotal: sql<string>`SUM(${schema.generationUsageStatsHourly.costTotal})`.as("cost_total"),
       sessionCount: sql<number>`COUNT(DISTINCT ${schema.generationUsageStatsHourly.sessionId})`.as("session_count"),
       requestCount: sql<number>`SUM(${schema.generationUsageStatsHourly.requestCount})`.as("request_count"),
     })
     .from(schema.generationUsageStatsHourly)
+    .leftJoin(schema.userProfiles, or(
+      eq(schema.userProfiles.userUuid, schema.generationUsageStatsHourly.userId),
+      eq(schema.userProfiles.logtoUserId, schema.generationUsageStatsHourly.userId),
+    ))
     .where(
       and(
         gte(schema.generationUsageStatsHourly.bucketStartAt, yesterdayStart),
@@ -320,7 +330,7 @@ async function loadGenerationTrendingUsers() {
         ne(schema.generationUsageStatsHourly.userId, "unknown"),
       ),
     )
-    .groupBy(schema.generationUsageStatsHourly.userId)
+    .groupBy(canonicalUserId)
     .orderBy(sql`request_count DESC`, sql`cost_total DESC`)
     .limit(10);
 

--- a/apps/api/src/routes/users.route.ts
+++ b/apps/api/src/routes/users.route.ts
@@ -1,9 +1,9 @@
 import { Hono } from "hono";
-import { and, desc, eq, or, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, or, sql } from "drizzle-orm";
 import { accessPolicies, spaces, userProfiles, works } from "@cohub/db";
 import { readWorkPageFields, workTitleFromMeta } from "@cohub/core/works";
 import { db } from "../db/index.js";
-import { getSpacePublicProfile, requireValidId, useAuth } from "../lib/middleware.js";
+import { getSpacePublicProfile, requireValidPrincipalId, useAuth } from "../lib/middleware.js";
 import { createWorkPublicUrl } from "../lib/work-public-url.js";
 import {
   getProfileByUsername,
@@ -44,7 +44,7 @@ router.post("/profiles/batch", async (c) => {
     }
 
     const userUuid = value.trim();
-    if (!requireValidId(userUuid)) {
+    if (!requireValidPrincipalId(userUuid)) {
       return c.json({ message: "userUuids contains an invalid id" }, 400);
     }
 
@@ -70,6 +70,13 @@ router.get("/by-username/:username", async (c) => {
 
   const profile = await getProfileByUsername(username);
   if (!profile?.username) return c.json({ message: "user not found" }, 404);
+  const [profileIdentity] = await db
+    .select({ userUuid: userProfiles.userUuid, logtoUserId: userProfiles.logtoUserId })
+    .from(userProfiles)
+    .where(eq(userProfiles.username, username))
+    .limit(1);
+  if (!profileIdentity) return c.json({ message: "user not found" }, 404);
+  const profileIdentityKeys = [profileIdentity.logtoUserId, profileIdentity.userUuid];
   const ownerUsername = profile.username;
 
   // Discoverable spaces only: join access policy + limit in SQL.
@@ -94,7 +101,7 @@ router.get("/by-username/:username", async (c) => {
       ),
     )
     .where(and(
-      eq(spaces.userUuid, profile.userUuid),
+      inArray(spaces.userUuid, profileIdentityKeys),
       isDiscoverableSpacePolicy,
     ))
     .orderBy(
@@ -137,9 +144,12 @@ router.get("/by-username/:username", async (c) => {
     })
     .from(works)
     .innerJoin(spaces, eq(spaces.id, works.spaceId))
-    .innerJoin(userProfiles, eq(userProfiles.userUuid, spaces.userUuid))
+    .innerJoin(userProfiles, or(
+      eq(userProfiles.userUuid, spaces.userUuid),
+      eq(userProfiles.logtoUserId, spaces.userUuid),
+    ))
     .where(and(
-      eq(works.userUuid, profile.userUuid),
+      inArray(works.userUuid, profileIdentityKeys),
       eq(works.status, "published"),
       eq(works.visibility, "public"),
       sql`${spaces.slug} is not null`,

--- a/apps/api/src/routes/work-commerce.route.ts
+++ b/apps/api/src/routes/work-commerce.route.ts
@@ -15,8 +15,13 @@ import {
 import { serializeProduct, serializeOrder } from "../lib/commerce-serialize.js";
 import { db } from "../db/index.js";
 import { spaces, userProfiles } from "@cohub/db";
-import { eq } from "drizzle-orm";
+import { eq, or } from "drizzle-orm";
 import { config } from "../config.js";
+import {
+  identityEquals,
+  resolveBillingUserId,
+  resolveBillingUserIdForStoredPrincipal,
+} from "../identity-bridge.js";
 
 const router = new Hono();
 
@@ -33,7 +38,10 @@ async function resolvePublicWorkUrl(input: { spaceId: string; workSlug: string }
   const [row] = await db
     .select({ username: userProfiles.username, spaceSlug: spaces.slug })
     .from(spaces)
-    .innerJoin(userProfiles, eq(userProfiles.userUuid, spaces.userUuid))
+    .innerJoin(userProfiles, or(
+      eq(userProfiles.userUuid, spaces.userUuid),
+      eq(userProfiles.logtoUserId, spaces.userUuid),
+    ))
     .where(eq(spaces.id, input.spaceId))
     .limit(1);
   if (!row?.username || !row.spaceSlug) return null;
@@ -102,7 +110,8 @@ router.get("/works/:id/commerce/entitlements", async (c) => {
   try {
     const businessKey = await requireSpaceCommerceBusinessKey(resolved.work.spaceId);
     const ops = await createSpaceBusinessBillingOperations(businessKey);
-    const state = await ops.getEntitlements({ userId: user.uuid });
+    const billingUserId = await resolveBillingUserId(user);
+    const state = await ops.getEntitlements({ userId: billingUserId });
     const creditBalance = state.credits.find((c: { tokenType: string }) => c.tokenType === "cohub_credit");
     return c.json({
       entitlements: state.entitlements.map((entitlement: { key: string; enabled: boolean; metadata: Record<string, string | number | boolean> }) => ({
@@ -148,11 +157,13 @@ router.post("/works/:id/commerce/credits/consume", async (c) => {
   const reason = typeof body?.reason === "string" ? body.reason.trim().slice(0, 512) : undefined;
 
   const consumerUserId = typeof body?.consumerUserId === "string" ? body.consumerUserId.trim() : null;
-  const targetUserId = consumerUserId ?? user.uuid;
-  if (consumerUserId && consumerUserId !== user.uuid) {
+  if (consumerUserId && !identityEquals(user, consumerUserId)) {
     if (!(await hasPermission(user, "space.commerce.manage", { spaceId: resolved.work.spaceId }))) return authzDenied(c);
   }
   try {
+    const targetUserId = consumerUserId && !identityEquals(user, consumerUserId)
+      ? await resolveBillingUserIdForStoredPrincipal(consumerUserId)
+      : await resolveBillingUserId(user);
     const businessKey = await requireSpaceCommerceBusinessKey(resolved.work.spaceId);
     const ops = await createSpaceBusinessBillingOperations(businessKey);
     const result = await ops.consume({
@@ -188,6 +199,7 @@ router.post("/works/:id/commerce/purchase", async (c) => {
   const productKey = typeof body?.productKey === "string" ? body.productKey.trim() : "";
   if (!productKey) return c.json({ message: "productKey is required" }, 400);
   try {
+    const billingUserId = await resolveBillingUserId(user);
     const businessKey = await requireSpaceCommerceBusinessKey(resolved.work.spaceId);
     const sdk = await createSpaceCommerceSdk();
     const product = await sdk.admin.products.get({ business_key: businessKey, product_key: productKey });
@@ -202,7 +214,7 @@ router.post("/works/:id/commerce/purchase", async (c) => {
     const provisionalRedirects = buildWorkCheckoutReturnUrls({ workUrl });
     const result = await sdk.admin.orders.create({
       business_key: businessKey,
-      external_user_id: user.uuid,
+      external_user_id: billingUserId,
       product_key: product.key,
       billing_reason: "purchase",
       success_redirect_url: provisionalRedirects.successRedirectUrl,
@@ -242,13 +254,14 @@ router.get("/works/:id/commerce/orders/:orderId", async (c) => {
   if ("error" in resolved) return c.json({ message: resolved.error }, 404);
   if ((resolved.work.workVisibility ?? "public") === "space" && !(await hasPermission(user, "space.view", { spaceId: resolved.work.spaceId }))) return authzDenied(c);
   try {
+    const billingUserId = await resolveBillingUserId(user);
     const businessKey = await requireSpaceCommerceBusinessKey(resolved.work.spaceId);
     const sdk = await createSpaceCommerceSdk();
     const order = await sdk.admin.orders.get({
       business_key: businessKey,
       order_id: orderId,
     });
-    if (order.external_user_id !== user.uuid) return authzDenied(c);
+    if (order.external_user_id !== billingUserId) return authzDenied(c);
     return c.json({ order: serializeOrder(order) });
   } catch (error) {
     const response = handleWorkCommerceRouteError(c, error);

--- a/apps/api/src/routes/works.route.ts
+++ b/apps/api/src/routes/works.route.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from "hono";
-import { and, desc, eq, ne, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, ne, or, sql } from "drizzle-orm";
 import { spaces, works, workVersions, workViewerGrants, userProfiles } from "@cohub/db";
 import { createWorkAssetPublicUrl, deleteWorkAssetsByObjectKey, isConfiguredWorkAssetPublicUrl } from "../work-asset-storage.js";
 import { publishWorkAssetInWorker, type WorkPublishAssetJobResult } from "../work-publish-asset-queue.js";
@@ -26,7 +26,12 @@ import { featureGateResponse } from "../lib/feature-gate.js";
 import { createWorkPublicUrl } from "../lib/work-public-url.js";
 import { applyRequestSourceToMeta, getRequestSource } from "../lib/request-source.js";
 import { dispatchWorkVersionPublished } from "../work-events.js";
-import { ensureUserProfileByUuid } from "../user-profiles.js";
+import {
+  ensureUserProfileByUuid,
+  getProfilesByUuids,
+} from "../user-profiles.js";
+import { resolveBillingUserId } from "../identity-bridge.js";
+import { getIdentityKeys } from "../identity-bridge.js";
 
 const logger = createLogger({ serviceName: "cohub-api" });
 const router = new Hono();
@@ -66,22 +71,23 @@ const getHideCohubBar = (meta: WorkMeta | null | undefined): boolean => {
   return presentation?.hideCohubBar === true;
 };
 
-async function canHideCohubBar(userId: string) {
+async function canHideCohubBar(user: AuthUser) {
   try {
+    const userId = await resolveBillingUserId(user);
     const entitlement = await billingOperations.getFeatureEntitlement({
       userId,
       featureKey: COHUB_BILLING_FEATURES.workPublishHideCohubBar,
     });
     return Boolean(entitlement?.enabled);
   } catch (error) {
-    logger.warn("[works] failed to check hide Cohub bar entitlement", { userId, error });
+    logger.warn("[works] failed to check hide Cohub bar entitlement", { error });
     return false;
   }
 }
 
-async function ensureWorkPresentationAllowed(c: Context, input: { userId: string; meta: WorkMeta | null | undefined }) {
+async function ensureWorkPresentationAllowed(c: Context, input: { user: AuthUser; meta: WorkMeta | null | undefined }) {
   if (!getHideCohubBar(input.meta)) return null;
-  if (await canHideCohubBar(input.userId)) return null;
+  if (await canHideCohubBar(input.user)) return null;
   return workHideCohubBarRequiredResponse(c);
 }
 
@@ -108,7 +114,10 @@ async function getWorkPublicIdentity(spaceId: string) {
       ownerUsername: userProfiles.username,
     })
     .from(spaces)
-    .leftJoin(userProfiles, eq(userProfiles.userUuid, spaces.userUuid))
+    .leftJoin(userProfiles, or(
+      eq(userProfiles.userUuid, spaces.userUuid),
+      eq(userProfiles.logtoUserId, spaces.userUuid),
+    ))
     .where(eq(spaces.id, spaceId))
     .limit(1);
   return {
@@ -182,6 +191,20 @@ const serializeWork = (work: typeof works.$inferSelect): RealtimeWorkRecord => (
   createdAt: work.createdAt?.toISOString() ?? null,
   updatedAt: work.updatedAt?.toISOString() ?? null,
 });
+
+const serializeWorksForResponse = async (workList: Array<typeof works.$inferSelect>): Promise<RealtimeWorkRecord[]> => {
+  const profiles = await getProfilesByUuids(workList.map((work) => work.userUuid));
+  return workList.map((work) => ({
+    ...serializeWork(work),
+    userUuid: profiles.get(work.userUuid)?.userUuid ?? work.userUuid,
+  }));
+};
+
+const serializeWorkForResponse = async (work: typeof works.$inferSelect): Promise<RealtimeWorkRecord> => {
+  const [serialized] = await serializeWorksForResponse([work]);
+  if (!serialized) throw new Error("Failed to serialize work");
+  return serialized;
+};
 
 const serializeWorkVersion = (version: typeof workVersions.$inferSelect): RealtimeWorkVersionRecord => ({
   id: version.id,
@@ -348,12 +371,15 @@ router.get("/by-slug/:username/:spaceSlug/:workSlug", async (c) => {
 
   const [row] = await db
     .select({
-      owner: { userUuid: userProfiles.userUuid, username: userProfiles.username, displayName: userProfiles.displayName, avatarUrl: userProfiles.avatarUrl },
+      owner: { userUuid: userProfiles.logtoUserId, username: userProfiles.username, displayName: userProfiles.displayName, avatarUrl: userProfiles.avatarUrl },
       space: spaces,
       work: works,
     })
     .from(userProfiles)
-    .innerJoin(spaces, and(eq(spaces.userUuid, userProfiles.userUuid), eq(spaces.slug, spaceSlug)))
+    .innerJoin(spaces, and(or(
+      eq(spaces.userUuid, userProfiles.userUuid),
+      eq(spaces.userUuid, userProfiles.logtoUserId),
+    ), eq(spaces.slug, spaceSlug)))
     .innerJoin(works, and(eq(works.spaceId, spaces.id), eq(works.slug, workSlug), eq(works.status, "published")))
     .where(eq(userProfiles.username, username))
     .limit(1);
@@ -367,8 +393,8 @@ router.get("/by-slug/:username/:spaceSlug/:workSlug", async (c) => {
     requiresSpaceWorkAccess(row.work) ? PRIVATE_WORK_HTTP_CACHE : PUBLIC_WORK_HTTP_CACHE,
   );
   return c.json({
-    work: serializeWork(row.work),
-    space: { id: row.space.id, slug: row.space.slug, name: row.space.name, userUuid: row.space.userUuid, publicProfile: getSpacePublicProfile(row.space) },
+    work: await serializeWorkForResponse(row.work),
+    space: { id: row.space.id, slug: row.space.slug, name: row.space.name, userUuid: row.owner.userUuid, publicProfile: getSpacePublicProfile(row.space) },
     owner: { ...row.owner, username: row.owner.username },
     publicUrl: createWorkPublicUrl({ ownerUsername: row.owner.username, spaceSlug: row.space.slug, workSlug: row.work.slug, status: row.work.status }),
     content: await getPublishedWorkContent(row.work),
@@ -383,7 +409,7 @@ router.get("/space/:spaceId", async (c) => {
   if (!requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
   if (!(await hasPermission(user, "space.view", { spaceId }))) return authzDenied(c);
   const rows = await db.select().from(works).where(eq(works.spaceId, spaceId));
-  return c.json({ works: rows.map(serializeWork) });
+  return c.json({ works: await serializeWorksForResponse(rows) });
 });
 
 router.get("/:id/public", async (c) => {
@@ -398,18 +424,21 @@ router.get("/:id/public", async (c) => {
   if (requiresSpaceWorkAccess(work) && !(await hasPermission(user, "space.view", { spaceId: work.spaceId }))) return authzDenied(c);
   const [row] = await db
     .select({
-      owner: { userUuid: userProfiles.userUuid, username: userProfiles.username, displayName: userProfiles.displayName, avatarUrl: userProfiles.avatarUrl },
+      owner: { userUuid: userProfiles.logtoUserId, username: userProfiles.username, displayName: userProfiles.displayName, avatarUrl: userProfiles.avatarUrl },
       space: spaces,
     })
     .from(spaces)
-    .innerJoin(userProfiles, eq(userProfiles.userUuid, spaces.userUuid))
+    .innerJoin(userProfiles, or(
+      eq(userProfiles.userUuid, spaces.userUuid),
+      eq(userProfiles.logtoUserId, spaces.userUuid),
+    ))
     .where(eq(spaces.id, work.spaceId))
     .limit(1);
   if (!row) return c.json({ message: "work not found" }, 404);
   if (!row.owner.username || !row.space.slug) return c.json({ message: "work public identity is incomplete" }, 409);
-  const space = { id: row.space.id, slug: row.space.slug, name: row.space.name, userUuid: row.space.userUuid, publicProfile: getSpacePublicProfile(row.space) };
+  const space = { id: row.space.id, slug: row.space.slug, name: row.space.name, userUuid: row.owner.userUuid, publicProfile: getSpacePublicProfile(row.space) };
   return c.json({
-    work: serializeWork(work),
+    work: await serializeWorkForResponse(work),
     space,
     owner: { ...row.owner, username: row.owner.username },
   });
@@ -425,18 +454,21 @@ router.get("/:id", async (c) => {
   if (!(await hasPermission(user, "space.view", { spaceId: work.spaceId }))) return authzDenied(c);
   const [row] = await db
     .select({
-      owner: { userUuid: userProfiles.userUuid, username: userProfiles.username, displayName: userProfiles.displayName, avatarUrl: userProfiles.avatarUrl },
+      owner: { userUuid: userProfiles.logtoUserId, username: userProfiles.username, displayName: userProfiles.displayName, avatarUrl: userProfiles.avatarUrl },
       space: spaces,
     })
     .from(spaces)
-    .innerJoin(userProfiles, eq(userProfiles.userUuid, spaces.userUuid))
+    .innerJoin(userProfiles, or(
+      eq(userProfiles.userUuid, spaces.userUuid),
+      eq(userProfiles.logtoUserId, spaces.userUuid),
+    ))
     .where(eq(spaces.id, work.spaceId))
     .limit(1);
   if (!row) return c.json({ message: "work not found" }, 404);
   if (!row.owner.username || !row.space.slug) return c.json({ message: "work public identity is incomplete" }, 409);
-  const space = { id: row.space.id, slug: row.space.slug, name: row.space.name, userUuid: row.space.userUuid, publicProfile: getSpacePublicProfile(row.space) };
+  const space = { id: row.space.id, slug: row.space.slug, name: row.space.name, userUuid: row.owner.userUuid, publicProfile: getSpacePublicProfile(row.space) };
   return c.json({
-    work: serializeWork(work),
+    work: await serializeWorkForResponse(work),
     space,
     owner: { ...row.owner, username: row.owner.username },
     publicUrl: createWorkPublicUrl({ ownerUsername: row.owner.username, spaceSlug: row.space.slug, workSlug: work.slug, status: work.status }),
@@ -473,7 +505,7 @@ router.post("/", async (c) => {
   const identityError = await ensureWorkPublicIdentity(c, spaceId, user);
   if (identityError) return identityError;
   const meta = getWorkMeta(body?.meta);
-  const presentationError = await ensureWorkPresentationAllowed(c, { userId: user.uuid, meta });
+  const presentationError = await ensureWorkPresentationAllowed(c, { user, meta });
   if (presentationError) return presentationError;
   const now = new Date();
 
@@ -534,7 +566,7 @@ router.post("/", async (c) => {
       await cleanupWorkAssets(assetKey, { workId: "new", spaceId, reason: "create_slug_conflict" });
       return c.json({ message: "slug already exists" }, 409);
     }
-    const serializedWork = serializeWork(result.work);
+    const serializedWork = await serializeWorkForResponse(result.work);
     if (result.version) {
       const serializedVersion = serializeWorkVersion(result.version);
       await dispatchWorkVersionPublished({
@@ -592,7 +624,7 @@ async function updateWork(
   const identityError = await ensureWorkPublicIdentity(c, current.spaceId, actor);
   if (identityError) return identityError;
   const nextMeta = "meta" in (body ?? {}) ? getWorkMeta(body?.meta) : getWorkMeta(current.meta);
-  const presentationError = await ensureWorkPresentationAllowed(c, { userId: actor.uuid, meta: nextMeta });
+  const presentationError = await ensureWorkPresentationAllowed(c, { user: actor, meta: nextMeta });
   if (presentationError) return presentationError;
 
   const assetKey = nextStatus === "published" ? current.assetKey : null;
@@ -620,7 +652,7 @@ async function updateWork(
     throw error;
   });
   if (!work) return c.json({ message: "slug already exists" }, 409);
-  return c.json({ work: serializeWork(work) });
+  return c.json({ work: await serializeWorkForResponse(work) });
 }
 
 async function publishWorkVersion(
@@ -687,7 +719,7 @@ async function publishWorkVersion(
       if (!work) throw new Error("failed to publish work version");
       return { work, version, previousVersionId: versionedWork.previousVersionId };
     });
-    const serializedWork = serializeWork(result.work);
+    const serializedWork = await serializeWorkForResponse(result.work);
     const serializedVersion = serializeWorkVersion(result.version);
     await dispatchWorkVersionPublished({
       work: serializedWork,
@@ -780,7 +812,7 @@ router.post("/:id/session", async (c) => {
     spaceId: work.spaceId,
     workScopes: work.workScopes as Permission[],
   });
-  return c.json({ token, expiresIn: WORK_SESSION_TTL_SECONDS, work: serializeWork(work) });
+  return c.json({ token, expiresIn: WORK_SESSION_TTL_SECONDS, work: await serializeWorkForResponse(work) });
 });
 
 router.post("/:id/authorize", async (c) => {
@@ -797,16 +829,28 @@ router.post("/:id/authorize", async (c) => {
   if (!isSubset(requested, work.allowedViewerScopes ?? [])) return c.json({ message: "scope not allowed for this work" }, 403);
 
   const expiresAt = new Date(Date.now() + WORK_SESSION_TTL_SECONDS * 1000);
-  const [grant] = await db.insert(workViewerGrants).values({
-    workId: work.id,
-    spaceId: work.spaceId,
-    viewerUserUuid: user.uuid,
-    scopes: requested,
-    expiresAt,
-  }).onConflictDoUpdate({
-    target: [workViewerGrants.workId, workViewerGrants.viewerUserUuid],
-    set: { scopes: requested, expiresAt, revokedAt: null, updatedAt: new Date() },
-  }).returning();
+  const existingGrants = await db.select({ id: workViewerGrants.id })
+    .from(workViewerGrants)
+    .where(and(
+      eq(workViewerGrants.workId, work.id),
+      inArray(workViewerGrants.viewerUserUuid, getIdentityKeys(user)),
+    ));
+  if (existingGrants.length > 1) return c.json({ message: "viewer identity conflict requires repair" }, 409);
+  const [grant] = existingGrants[0]
+    ? await db.update(workViewerGrants).set({
+        viewerUserUuid: user.uuid,
+        scopes: requested,
+        expiresAt,
+        revokedAt: null,
+        updatedAt: new Date(),
+      }).where(eq(workViewerGrants.id, existingGrants[0].id)).returning()
+    : await db.insert(workViewerGrants).values({
+        workId: work.id,
+        spaceId: work.spaceId,
+        viewerUserUuid: user.uuid,
+        scopes: requested,
+        expiresAt,
+      }).returning();
   if (!grant) return c.json({ message: "failed to create grant" }, 500);
 
   const token = createWorkSessionToken({

--- a/apps/api/src/sandbox-principal-identity.test.ts
+++ b/apps/api/src/sandbox-principal-identity.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  IdentityMappingConflictError,
+  UnresolvedLegacyIdentityError,
+  resolveStoredPrincipalIdentity,
+  type IdentityMappingRow,
+} from "@cohub/identity";
+import { resolveSandboxPrincipalIdentities } from "./sandbox-principal-identity.js";
+
+const actorLegacyUuid = "5d4ac7d3-1f50-4af4-8d75-6df54d5edc6a";
+const ownerLegacyUuid = "59dad1f7-807d-4ac6-8a95-747f475f84b1";
+const actorSub = "actor-logto-sub";
+const ownerSub = "owner-logto-sub";
+
+const resolverWithMappings = (mappings: IdentityMappingRow[]) => async (principalId: string) => {
+  const matches = mappings.filter(
+    (mapping) => mapping.userUuid === principalId || mapping.logtoUserId === principalId,
+  );
+  return resolveStoredPrincipalIdentity({ principalId, mappings: matches });
+};
+
+describe("sandbox principal identity", () => {
+  it("uses canonical sub for the Pod label and owner config mount", async () => {
+    const resolved = await resolveSandboxPrincipalIdentities({
+      userUuid: actorLegacyUuid,
+      ownerUserUuid: ownerLegacyUuid,
+    }, resolverWithMappings([
+      { userUuid: actorLegacyUuid, logtoUserId: actorSub },
+      { userUuid: ownerLegacyUuid, logtoUserId: ownerSub },
+    ]));
+
+    assert.equal(resolved.userId, actorSub);
+    assert.equal(resolved.ownerUserId, ownerSub);
+  });
+
+  it("fails before Pod creation when a legacy owner has no mapping", async () => {
+    await assert.rejects(
+      resolveSandboxPrincipalIdentities({
+        userUuid: actorSub,
+        ownerUserUuid: ownerLegacyUuid,
+      }, resolverWithMappings([])),
+      UnresolvedLegacyIdentityError,
+    );
+  });
+
+  it("fails before Pod creation when owner mappings conflict", async () => {
+    await assert.rejects(
+      resolveSandboxPrincipalIdentities({
+        userUuid: actorSub,
+        ownerUserUuid: ownerLegacyUuid,
+      }, resolverWithMappings([
+        { userUuid: ownerLegacyUuid, logtoUserId: ownerSub },
+        { userUuid: ownerLegacyUuid, logtoUserId: "other-owner-sub" },
+      ])),
+      IdentityMappingConflictError,
+    );
+  });
+});

--- a/apps/api/src/sandbox-principal-identity.ts
+++ b/apps/api/src/sandbox-principal-identity.ts
@@ -1,0 +1,27 @@
+import type { PrincipalIdentity } from "@cohub/identity";
+
+type StoredPrincipalResolver = (principalId: string) => Promise<PrincipalIdentity>;
+
+export type ResolvedSandboxPrincipalIdentities = {
+  actorIdentity: PrincipalIdentity;
+  ownerIdentity: PrincipalIdentity;
+  userId: string;
+  ownerUserId: string;
+};
+
+export async function resolveSandboxPrincipalIdentities(
+  input: { userUuid: string; ownerUserUuid?: string },
+  resolveStoredPrincipal: StoredPrincipalResolver,
+): Promise<ResolvedSandboxPrincipalIdentities> {
+  const actorIdentity = await resolveStoredPrincipal(input.userUuid);
+  const storedOwnerUserId = input.ownerUserUuid ?? input.userUuid;
+  const ownerIdentity = storedOwnerUserId.trim() === input.userUuid.trim()
+    ? actorIdentity
+    : await resolveStoredPrincipal(storedOwnerUserId);
+  return {
+    actorIdentity,
+    ownerIdentity,
+    userId: actorIdentity.uuid,
+    ownerUserId: ownerIdentity.uuid,
+  };
+}

--- a/apps/api/src/session-fork-identity.ts
+++ b/apps/api/src/session-fork-identity.ts
@@ -1,0 +1,23 @@
+import {
+  resolveStoredPrincipalIdentity,
+  type IdentityMappingRow,
+} from "@cohub/identity";
+
+export const resolveCanonicalStoredUserIds = (
+  userIds: readonly string[],
+  mappings: readonly IdentityMappingRow[],
+): Map<string, string> => {
+  const resolved = new Map<string, string>();
+  for (const rawUserId of userIds) {
+    const userId = rawUserId.trim();
+    if (!userId || resolved.has(userId)) continue;
+    const matches = mappings.filter(
+      (mapping) => mapping.userUuid === userId || mapping.logtoUserId === userId,
+    );
+    resolved.set(
+      userId,
+      resolveStoredPrincipalIdentity({ principalId: userId, mappings: matches }).uuid,
+    );
+  }
+  return resolved;
+};

--- a/apps/api/src/session-forks.identity.test.ts
+++ b/apps/api/src/session-forks.identity.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  IdentityMappingConflictError,
+  UnresolvedLegacyIdentityError,
+} from "@cohub/identity";
+import { resolveCanonicalStoredUserIds } from "./session-fork-identity.js";
+
+const legacyUuid = "5d4ac7d3-1f50-4af4-8d75-6df54d5edc6a";
+const sub = "logto-user";
+
+describe("session fork identity canonicalization", () => {
+  it("canonicalizes participants and label provenance to sub", () => {
+    const resolved = resolveCanonicalStoredUserIds(
+      [legacyUuid, sub, "system"],
+      [{ userUuid: legacyUuid, logtoUserId: sub }],
+    );
+
+    assert.equal(resolved.get(legacyUuid), sub);
+    assert.equal(resolved.get(sub), sub);
+    assert.equal(resolved.get("system"), "system");
+  });
+
+  it("fails closed for an unmapped UUID", () => {
+    assert.throws(
+      () => resolveCanonicalStoredUserIds([legacyUuid], []),
+      UnresolvedLegacyIdentityError,
+    );
+  });
+
+  it("fails closed for conflicting mappings", () => {
+    assert.throws(
+      () => resolveCanonicalStoredUserIds(
+        [legacyUuid],
+        [
+          { userUuid: legacyUuid, logtoUserId: sub },
+          { userUuid: legacyUuid, logtoUserId: "other-sub" },
+        ],
+      ),
+      IdentityMappingConflictError,
+    );
+  });
+});

--- a/apps/api/src/session-forks.ts
+++ b/apps/api/src/session-forks.ts
@@ -1,13 +1,14 @@
 import { createLogger } from "@cohub/infra/logging";
-import { and, asc, eq, gte, inArray, lte } from "drizzle-orm";
+import { and, asc, eq, gte, inArray, lte, or } from "drizzle-orm";
 import type { SessionForkRecord, SessionTurnSegmentRecord } from "@cohub/protocol/model";
 import { db } from "./db/index.js";
-import { labelAssignments, sessionForks, sessionTurnSegments, sessionTurns, spaceSessions } from "@cohub/db";
+import { labelAssignments, sessionForks, sessionTurnSegments, sessionTurns, spaceSessions, userProfiles } from "@cohub/db";
 import { sanitizePostgresJsonValue } from "@cohub/core/content/sanitize";
 import { sessionForkReference } from "@cohub/core/references";
 import { enqueueReferences } from "./reference-index-queue.js";
 import { assignSessionParticipantSystemLabels } from "@cohub/core/labels/session-user";
 import { readSessionParticipantUserUuids, setSessionParticipantsMeta } from "@cohub/core/sessions";
+import { resolveCanonicalStoredUserIds } from "./session-fork-identity.js";
 
 type SegmentRow = typeof sessionTurnSegments.$inferSelect;
 type ForkRow = typeof sessionForks.$inferSelect;
@@ -199,11 +200,36 @@ export async function createSessionFork(input: {
     const [parent] = await tx.select().from(spaceSessions).where(and(eq(spaceSessions.id, input.parentSessionId), eq(spaceSessions.spaceId, input.spaceId))).limit(1);
     if (!parent) throw new Error("Parent session not found");
 
+    const resolveStoredUserIds = async (userIds: readonly string[]) => {
+      const storedUserIds = [...new Set(userIds.map((userId) => userId.trim()).filter(Boolean))];
+      const profileRows = storedUserIds.length > 0
+        ? await tx.select({ userUuid: userProfiles.userUuid, logtoUserId: userProfiles.logtoUserId })
+          .from(userProfiles)
+          .where(or(
+            inArray(userProfiles.userUuid, storedUserIds),
+            inArray(userProfiles.logtoUserId, storedUserIds),
+          ))
+        : [];
+      return resolveCanonicalStoredUserIds(storedUserIds, profileRows);
+    };
+
     const existingChild = await tx.select().from(spaceSessions).where(eq(spaceSessions.id, input.childSessionId)).limit(1);
     if (existingChild[0]) {
       const [existingFork] = await tx.select().from(sessionForks).where(eq(sessionForks.childSessionId, input.childSessionId)).limit(1);
       if (existingFork?.parentSessionId === parent.id && existingFork.anchorTurnId === input.turnId && existingFork.anchorSequence === anchorSequence) {
-        return { session: existingChild[0], fork: existingFork, participantUserUuids: [createdBy, ...readSessionParticipantUserUuids(existingChild[0].meta)] };
+        const existingParticipantUserUuids = readSessionParticipantUserUuids(existingChild[0].meta);
+        const canonicalUserIds = await resolveStoredUserIds(existingParticipantUserUuids);
+        const canonicalParticipantUserUuids = existingParticipantUserUuids.map(
+          (userId) => canonicalUserIds.get(userId) ?? userId,
+        );
+        return {
+          session: existingChild[0],
+          fork: existingFork,
+          participantUserUuids: [...new Set([createdBy, ...canonicalParticipantUserUuids])],
+          replacedParticipantUserUuids: existingParticipantUserUuids.filter(
+            (userId, index) => canonicalParticipantUserUuids[index] !== userId,
+          ),
+        };
       }
       throw new Error("Session id already exists");
     }
@@ -240,7 +266,31 @@ export async function createSessionFork(input: {
       for (const row of rows) if (row.userUuid?.trim()) visibleTurnUserUuids.add(row.userUuid.trim());
     }
 
-    const childParticipantUserUuids = [createdBy, ...visibleTurnUserUuids];
+    // Inherit the parent session's label assignments so the fork is categorized
+    // consistently with its origin. Identity-bearing provenance is canonicalized
+    // together with visible participants before any child rows are inserted.
+    const parentLabelAssignments = await tx.select({
+      labelId: labelAssignments.labelId,
+      rank: labelAssignments.rank,
+      source: labelAssignments.source,
+      createdBy: labelAssignments.createdBy,
+      meta: labelAssignments.meta,
+    }).from(labelAssignments).where(and(
+      eq(labelAssignments.scopeType, "space"),
+      eq(labelAssignments.scopeId, input.spaceId),
+      eq(labelAssignments.resourceType, "session"),
+      eq(labelAssignments.resourceRef, parent.id),
+    ));
+
+    const visibleUserIds = [...visibleTurnUserUuids];
+    const labelCreatorIds = parentLabelAssignments
+      .map((assignment) => assignment.createdBy?.trim() ?? "")
+      .filter(Boolean);
+    const storedUserIds = [...new Set([...visibleUserIds, ...labelCreatorIds])];
+    const canonicalUserIds = await resolveStoredUserIds(storedUserIds);
+    const canonicalVisibleUserIds = visibleUserIds.map((userId) => canonicalUserIds.get(userId) ?? userId);
+    const replacedParticipantUserUuids = visibleUserIds.filter((userId, index) => canonicalVisibleUserIds[index] !== userId);
+    const childParticipantUserUuids = [...new Set([createdBy, ...canonicalVisibleUserIds])];
 
     const [child] = await tx.insert(spaceSessions).values({
       id: input.childSessionId,
@@ -288,21 +338,6 @@ export async function createSessionFork(input: {
       toSequence: segment.toSequence,
     })));
 
-    // Inherit the parent session's label assignments so the fork is categorized
-    // consistently with its origin. Preserves the original source (user/system)
-    // and provenance while pointing the assignment at the new child session.
-    const parentLabelAssignments = await tx.select({
-      labelId: labelAssignments.labelId,
-      rank: labelAssignments.rank,
-      source: labelAssignments.source,
-      createdBy: labelAssignments.createdBy,
-      meta: labelAssignments.meta,
-    }).from(labelAssignments).where(and(
-      eq(labelAssignments.scopeType, "space"),
-      eq(labelAssignments.scopeId, input.spaceId),
-      eq(labelAssignments.resourceType, "session"),
-      eq(labelAssignments.resourceRef, parent.id),
-    ));
     if (parentLabelAssignments.length > 0) {
       await tx.insert(labelAssignments).values(parentLabelAssignments.map((assignment) => ({
         labelId: assignment.labelId,
@@ -312,18 +347,26 @@ export async function createSessionFork(input: {
         resourceRef: child.id,
         rank: assignment.rank,
         source: assignment.source,
-        createdBy: assignment.createdBy,
+        createdBy: assignment.createdBy
+          ? (canonicalUserIds.get(assignment.createdBy.trim()) ?? assignment.createdBy)
+          : null,
         meta: assignment.meta,
       }))).onConflictDoNothing();
     }
 
-    return { session: child, fork, participantUserUuids: childParticipantUserUuids };
+    return {
+      session: child,
+      fork,
+      participantUserUuids: childParticipantUserUuids,
+      replacedParticipantUserUuids,
+    };
   });
   await assignSessionParticipantSystemLabels({
     db,
     spaceId: input.spaceId,
     sessionId: result.session.id,
     userUuids: result.participantUserUuids,
+    replacedUserUuids: result.replacedParticipantUserUuids,
   }).catch((error) => {
     logger.warn("[SessionFork] failed to assign participant labels", { sessionId: result.session.id, error });
   });

--- a/apps/api/src/session-output.ts
+++ b/apps/api/src/session-output.ts
@@ -15,6 +15,7 @@ import { db } from "./db/index.js";
 import { spaceChannels } from "@cohub/db";
 import { clearSessionStreamSnapshot } from "./session-stream-snapshot.js";
 import { toRealtimeMessageRecord, toRealtimeTurnRecord } from "./realtime-events.js";
+import { getIdentityKeys, resolveStoredPrincipalUser } from "./identity-bridge.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -144,6 +145,7 @@ export const dispatchSessionOutput = async (output: GatewaySessionOutput) => {
 };
 
 export const dispatchTurnUpdated = async (input: { spaceId: string; sessionId: string; turn: SessionTurnRecord }) => {
+  const resolved = await resolveRealtimeTurnIdentity(input.turn);
   await dispatchRealtimeEvent({
     id: randomUUID(),
     timestamp: Date.now(),
@@ -152,7 +154,7 @@ export const dispatchTurnUpdated = async (input: { spaceId: string; sessionId: s
     spaceId: input.spaceId,
     sessionId: input.sessionId,
     payload: {
-      turn: toRealtimeTurnRecord(input.turn),
+      turn: toRealtimeTurnRecord(resolved.turn),
     },
   });
 };
@@ -163,7 +165,23 @@ const truncateTurnPreview = (text: string | null | undefined) => {
   return normalized.length > 180 ? `${normalized.slice(0, 177)}...` : normalized;
 };
 
+const resolveRealtimeTurnIdentity = async (turn: SessionTurnRecord) => {
+  if (!turn.userUuid) return { turn, userRooms: [] };
+  const identity = await resolveStoredPrincipalUser(turn.userUuid);
+  return {
+    turn: {
+      ...turn,
+      userUuid: identity.uuid,
+      authorProfile: turn.authorProfile
+        ? { ...turn.authorProfile, userUuid: identity.uuid }
+        : turn.authorProfile,
+    },
+    userRooms: getIdentityKeys(identity).map(getRealtimeUserRoom),
+  };
+};
+
 export const dispatchTurnFinalized = async (input: { spaceId: string; sessionId: string; turn: SessionTurnRecord }) => {
+  const resolved = await resolveRealtimeTurnIdentity(input.turn);
   await clearSessionStreamSnapshot({ spaceId: input.spaceId, sessionId: input.sessionId });
   await dispatchSpaceDomainEvent({
     id: randomUUID(),
@@ -173,11 +191,11 @@ export const dispatchTurnFinalized = async (input: { spaceId: string; sessionId:
     spaceId: input.spaceId,
     sessionId: input.sessionId,
     payload: {
-      turn: toRealtimeTurnRecord(input.turn),
+      turn: toRealtimeTurnRecord(resolved.turn),
     },
   });
 
-  if (!input.turn.userUuid) return;
+  if (resolved.userRooms.length === 0) return;
   await dispatchRealtimeEvent({
     id: randomUUID(),
     timestamp: Date.now(),
@@ -185,20 +203,20 @@ export const dispatchTurnFinalized = async (input: { spaceId: string; sessionId:
     type: "session.turn.notify",
     spaceId: input.spaceId,
     sessionId: input.sessionId,
-    rooms: [getRealtimeUserRoom(input.turn.userUuid)],
+    rooms: resolved.userRooms,
     payload: {
       spaceId: input.spaceId,
       sessionId: input.sessionId,
-      turnId: input.turn.id,
-      status: input.turn.status,
-      finishReason: input.turn.summary?.finishReason ?? null,
-      userPreview: truncateTurnPreview(input.turn.userText),
-      durationMs: input.turn.durationMs,
-      stepCount: input.turn.intermediateSummary?.messageCount ?? null,
-      sequence: input.turn.sequence ?? null,
-      provider: input.turn.provider,
-      model: input.turn.model,
-      completedAt: input.turn.completedAt,
+      turnId: resolved.turn.id,
+      status: resolved.turn.status,
+      finishReason: resolved.turn.summary?.finishReason ?? null,
+      userPreview: truncateTurnPreview(resolved.turn.userText),
+      durationMs: resolved.turn.durationMs,
+      stepCount: resolved.turn.intermediateSummary?.messageCount ?? null,
+      sequence: resolved.turn.sequence ?? null,
+      provider: resolved.turn.provider,
+      model: resolved.turn.model,
+      completedAt: resolved.turn.completedAt,
     },
   });
 };

--- a/apps/api/src/session-services.ts
+++ b/apps/api/src/session-services.ts
@@ -15,6 +15,7 @@ import { getSpaceSessionById, getSpaceById } from "./space-sessions.js";
 import { touchSpaceActivity } from "./space-activity.js";
 import { dispatchLabelAssignmentsUpdated, dispatchSessionUpdated } from "./realtime-events.js";
 import { createLogger } from "@cohub/infra/logging";
+import { resolveBillingUserIdForStoredPrincipal, resolveStoredPrincipalUser } from "./identity-bridge.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -48,12 +49,18 @@ const agentTurnQueue = createBullmqQueue<{
 });
 
 const sandboxLifecycle = createSandboxLifecycleController({ db, infra: null });
-const billingUsageGate = createBillingUsageGate({
+const legacyBillingUsageGate = createBillingUsageGate({
   operations: billingOperations,
   onEvaluationError: (error, gateInput) => {
     logger.warn("[BillingGate] fail-open after billing evaluation error", { error, gateInput });
   },
 });
+const billingUsageGate: ReturnType<typeof createBillingUsageGate> = {
+  async evaluate(input) {
+    const userId = await resolveBillingUserIdForStoredPrincipal(input.userId);
+    return legacyBillingUsageGate.evaluate({ ...input, userId });
+  },
+};
 
 let defaultSessionDomainServices: ReturnType<typeof createSessionServices> | null = null;
 
@@ -97,6 +104,13 @@ export function getSessionDomainServices(input?: {
     },
     injectTrace,
     getRequestId: getCurrentRequestId,
+    resolvePrincipalIdentity: async (userId) => {
+      const identity = await resolveStoredPrincipalUser(userId);
+      return {
+        uuid: identity.uuid,
+        aliases: identity.legacyUserUuid ? [identity.legacyUserUuid] : [],
+      };
+    },
     onSessionActivityUpdated: async ({ sessionId, changed }) => {
       const session = await getSpaceSessionById(sessionId);
       if (!session) return;
@@ -105,8 +119,8 @@ export function getSessionDomainServices(input?: {
       });
       await dispatchSessionUpdated({ session, changed });
     },
-    onSessionParticipantsUpdated: async ({ spaceId, sessionId, userUuids }) => {
-      const affectedLabelIds = await assignSessionParticipantSystemLabels({ db, spaceId, sessionId, userUuids });
+    onSessionParticipantsUpdated: async ({ spaceId, sessionId, userUuids, replacedUserUuids }) => {
+      const affectedLabelIds = await assignSessionParticipantSystemLabels({ db, spaceId, sessionId, userUuids, replacedUserUuids });
       await dispatchLabelAssignmentsUpdated({
         spaceId,
         resourceType: "session",

--- a/apps/api/src/session-turns.ts
+++ b/apps/api/src/session-turns.ts
@@ -20,6 +20,7 @@ import { ensureSessionTurnSegments, findSegmentForTurn } from "./session-forks.j
 import { fallbackPublicUserProfile, getProfilesByUuids } from "./user-profiles.js";
 import { buildTurnObjectPrefix, assertTurnObjectKeyForTurn, createTurnObjectCdnUrl, writeTurnObjectJson } from "./turn-object-storage.js";
 import { deriveMessagePreviewText } from "./session-content.js";
+import { resolveStoredPrincipalUser } from "./identity-bridge.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -207,9 +208,11 @@ export async function hydrateTurnAuthorProfiles(turns: SessionTurnRecord[]) {
   const profiles = await getProfilesByUuids(userUuids);
   return turns.map((turn) => {
     if (!turn.userUuid) return { ...turn, authorProfile: null };
+    const authorProfile = profiles.get(turn.userUuid) ?? fallbackPublicUserProfile(turn.userUuid);
     return {
       ...turn,
-      authorProfile: profiles.get(turn.userUuid) ?? fallbackPublicUserProfile(turn.userUuid),
+      userUuid: authorProfile.userUuid,
+      authorProfile,
     };
   });
 }
@@ -266,9 +269,11 @@ export const hydrateTurnIndexAuthorProfiles = async (turns: SessionTurnIndexItem
   const profiles = await getProfilesByUuids(userUuids);
   return turns.map((turn) => {
     if (!turn.userUuid) return { ...turn, authorProfile: null };
+    const authorProfile = profiles.get(turn.userUuid) ?? fallbackPublicUserProfile(turn.userUuid);
     return {
       ...turn,
-      authorProfile: profiles.get(turn.userUuid) ?? fallbackPublicUserProfile(turn.userUuid),
+      userUuid: authorProfile.userUuid,
+      authorProfile,
     };
   });
 };
@@ -288,6 +293,8 @@ export const createSessionTurn = async (input: {
   intent?: SessionTurnIntent;
   meta?: Record<string, unknown> | null;
 }) => {
+  const identity = input.userUuid ? await resolveStoredPrincipalUser(input.userUuid) : null;
+  const userUuid = identity?.uuid ?? null;
   const userContent = sanitizeContentBlocksForPostgresJson(input.userContent);
   const meta = input.meta ? sanitizePostgresJsonValue(input.meta) : null;
   const userText = deriveMessagePreviewText({ content: userContent }) || null;
@@ -303,15 +310,19 @@ export const createSessionTurn = async (input: {
     )).orderBy(desc(sessionTurnSegments.ordinal)).limit(1);
     startSequence = localSegment?.fromSequence ?? 1;
     const sequence = seqRow?.max ? (seqRow.max + 1) : startSequence;
-    if (input.userUuid) {
+    if (userUuid) {
       await tx.update(spaceSessions).set({
-        meta: sanitizePostgresJsonValue(addSessionParticipantMeta(sessionRow.meta, input.userUuid)),
+        meta: sanitizePostgresJsonValue(addSessionParticipantMeta(
+          sessionRow.meta,
+          userUuid,
+          identity?.legacyUserUuid ? [identity.legacyUserUuid] : [],
+        )),
       }).where(eq(spaceSessions.id, input.sessionId));
     }
     return tx.insert(sessionTurns).values({
       ...(input.id ? { id: input.id } : {}),
       sessionId: input.sessionId,
-      userUuid: input.userUuid,
+      userUuid,
       sequence,
       status: "queued",
       intent: input.intent ?? "steer",

--- a/apps/api/src/skills.ts
+++ b/apps/api/src/skills.ts
@@ -28,6 +28,7 @@ import { join, resolve } from "node:path";
 import { config } from "./config.js";
 import { db } from "./db/index.js";
 import { redisCommandClient } from "./redis.js";
+import { resolveStoredPrincipalReadKeys } from "./identity-bridge.js";
 
 const logger = createLogger({ serviceName: "cohub-api" });
 
@@ -232,13 +233,15 @@ async function fetchSkills(options: LoadSkillsOptions): Promise<Skill[]> {
   }
 
   if (options.userId) {
-    configs.push(await loadCachedSkills({
-      redisKey: getUserSkillsRedisKey(options.userId),
-      dir: getUserSkillsDir(options.userId),
+    const userId = options.userId.trim();
+    const userIds = await resolveStoredPrincipalReadKeys(userId);
+    configs.push(...await Promise.all(userIds.map((userId) => loadCachedSkills({
+      redisKey: getUserSkillsRedisKey(userId),
+      dir: getUserSkillsDir(userId),
       sandboxDir: SANDBOX_USER_SKILLS_PATH,
       scope: "user",
       allowMissing: true,
-    }));
+    }))));
   }
 
   if (options.spaceId && config.spaceStorageRoot) {

--- a/apps/api/src/space-presence.ts
+++ b/apps/api/src/space-presence.ts
@@ -8,7 +8,7 @@ const MAX_META_JSON_LENGTH = 4096;
 
 type StoredPresenceConnection = {
   connectionId: string;
-  userId: string | null;
+  userId: string;
   lastSeenAt: number;
   meta: Record<string, unknown> | null;
 };
@@ -16,6 +16,7 @@ type StoredPresenceConnection = {
 type StoredWsConnection = {
   connectionId?: string;
   userId?: string | null;
+  userIds?: string[];
   rooms?: string[];
 };
 
@@ -60,6 +61,9 @@ const parseWsConnection = (raw: string | null): StoredWsConnection | null => {
     return {
       connectionId: typeof value.connectionId === "string" ? value.connectionId : undefined,
       userId: typeof value.userId === "string" ? value.userId : null,
+      userIds: Array.isArray(value.userIds)
+        ? value.userIds.filter((userId): userId is string => typeof userId === "string")
+        : [],
       rooms: Array.isArray(value.rooms)
         ? value.rooms.filter((room): room is string => typeof room === "string")
         : [],
@@ -90,7 +94,10 @@ export async function getSpacePresenceSnapshot(spaceId: string): Promise<SpacePr
   entries.forEach((entry, index) => {
     const raw = connectionRows?.[index]?.[1];
     const wsConnection = parseWsConnection(typeof raw === "string" ? raw : null);
-    if (!wsConnection?.userId || wsConnection.userId !== entry.userId || !wsConnection.rooms?.includes(room)) {
+    const connectionUserIds = wsConnection
+      ? [...new Set([wsConnection.userId, ...(wsConnection.userIds ?? [])].filter((value): value is string => Boolean(value)))]
+      : [];
+    if (!connectionUserIds.includes(entry.userId) || !wsConnection?.rooms?.includes(room)) {
       staleConnectionIds.push(entry.connectionId);
       return;
     }
@@ -109,14 +116,29 @@ export async function getSpacePresenceSnapshot(spaceId: string): Promise<SpacePr
   }
 
   const profiles = await getProfilesByUuids([...users.keys()]);
-  const snapshotUsers = [...users.entries()]
+  const canonicalUsers = new Map<string, { connectionCount: number; lastSeenAt: number; meta: Record<string, unknown> | null; metas: Record<string, unknown>[]; profile: ReturnType<typeof fallbackPublicUserProfile> }>();
+  for (const [userId, state] of users) {
+    const profile = profiles.get(userId) ?? fallbackPublicUserProfile(userId);
+    const existing = canonicalUsers.get(profile.userUuid);
+    if (!existing) {
+      canonicalUsers.set(profile.userUuid, { ...state, profile });
+      continue;
+    }
+    existing.connectionCount += state.connectionCount;
+    existing.metas.push(...state.metas);
+    if (state.lastSeenAt >= existing.lastSeenAt) {
+      existing.lastSeenAt = state.lastSeenAt;
+      existing.meta = state.meta;
+    }
+  }
+  const snapshotUsers = [...canonicalUsers.entries()]
     .map(([userId, state]) => ({
       userId,
       connectionCount: state.connectionCount,
       lastSeenAt: new Date(state.lastSeenAt).toISOString(),
       meta: state.meta,
       metas: state.metas,
-      profile: profiles.get(userId) ?? fallbackPublicUserProfile(userId),
+      profile: state.profile,
     }))
     .sort((a, b) => Date.parse(b.lastSeenAt) - Date.parse(a.lastSeenAt));
 

--- a/apps/api/src/space-sandboxes.ts
+++ b/apps/api/src/space-sandboxes.ts
@@ -1,5 +1,11 @@
 import { asc, eq, isNull, ne, or, sql } from "drizzle-orm";
 import { billingOperations, COHUB_BILLING_FEATURES } from "@cohub/billing";
+import { resolveBillingUserId, resolveStoredPrincipalUser } from "./identity-bridge.js";
+import {
+  IdentityMappingConflictError,
+  UnresolvedLegacyIdentityError,
+  type PrincipalIdentity,
+} from "@cohub/identity";
 import {
   DEFAULT_SANDBOX_SPEC_ID,
   SANDBOX_SPECS,
@@ -26,6 +32,7 @@ import type { SpaceSandboxRuntimeStatus, SpaceSandboxStatus, SpaceSandboxStopRea
 import { smokeVerifySandboxPod } from "./lib/sandbox/recovery.js";
 import type { V1Pod } from "@kubernetes/client-node";
 import { createLogger } from "@cohub/infra/logging";
+import { resolveSandboxPrincipalIdentities } from "./sandbox-principal-identity.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -58,15 +65,22 @@ const getSpaceSandboxSpec = async (spaceId: string): Promise<SandboxSpecId> => {
   return normalizeSandboxSpecId(sandbox.spec);
 };
 
-const getAllowedSandboxSpecId = async (userId: string): Promise<SandboxSpecId> => {
+const getAllowedSandboxSpecId = async (identity: PrincipalIdentity): Promise<SandboxSpecId> => {
   try {
-    const state = await billingOperations.getState({ userId });
+    const billingUserId = await resolveBillingUserId(identity);
+    const state = await billingOperations.getState({ userId: billingUserId });
     const keys = new Set(state.entitlements.filter((entitlement) => entitlement.enabled).map((entitlement) => entitlement.key));
     if (keys.has(COHUB_BILLING_FEATURES.sandboxSpecUltra)) return "ultra";
     if (keys.has(COHUB_BILLING_FEATURES.sandboxSpecBoost)) return "boost";
     return DEFAULT_SANDBOX_SPEC_ID;
   } catch (error) {
-    logger.warn("[SandboxSpec] failed to check entitlement during reconcile", { userId, error });
+    if (
+      error instanceof IdentityMappingConflictError
+      || error instanceof UnresolvedLegacyIdentityError
+    ) {
+      throw error;
+    }
+    logger.warn("[SandboxSpec] failed to check entitlement during reconcile", { error });
     return DEFAULT_SANDBOX_SPEC_ID;
   }
 };
@@ -428,6 +442,7 @@ export const reconcileSpaceSandbox = async (input: {
   mode: "ensure" | "replace";
   reason: "space_created" | "manual_recreate" | "auto_recover" | "auto_resume" | "space_mods_changed";
 }) => {
+  const principalIdentities = await resolveSandboxPrincipalIdentities(input, resolveStoredPrincipalUser);
   const podName = `sandbox-${input.spaceId}`;
   const existingSandbox = await getSpaceSandboxBySpaceId(input.spaceId);
   const existingMeta = asMetaObject(existingSandbox?.meta);
@@ -475,7 +490,7 @@ export const reconcileSpaceSandbox = async (input: {
   }
 
   const configuredSpec = await getSpaceSandboxSpec(input.spaceId);
-  const allowedSpec = await getAllowedSandboxSpecId(input.ownerUserUuid ?? input.userUuid);
+  const allowedSpec = await getAllowedSandboxSpecId(principalIdentities.ownerIdentity);
   const desiredSpec = getSandboxSpecRank(configuredSpec) > getSandboxSpecRank(allowedSpec) ? allowedSpec : configuredSpec;
   const specEntitlementDowngraded = desiredSpec !== configuredSpec;
   const desiredSpecConfig = SANDBOX_SPECS[desiredSpec] ?? SANDBOX_SPECS[DEFAULT_SANDBOX_SPEC_ID];
@@ -515,8 +530,8 @@ export const reconcileSpaceSandbox = async (input: {
 
   const pod = renderSandboxPodTemplate({
     SPACE_ID: input.spaceId,
-    USER_ID: input.userUuid,
-    OWNER_USER_ID: input.ownerUserUuid ?? input.userUuid,
+    USER_ID: principalIdentities.userId,
+    OWNER_USER_ID: principalIdentities.ownerUserId,
     ENV: config.env,
     SPACE_STORAGE_PVC: config.spaceStoragePvc,
     SPACE_STORAGE_SUBPATH: config.spaceStorageSubpath,
@@ -777,4 +792,3 @@ export const recoverSpaceSandbox = async (input: {
     await redisCommandClient.del(lockKey).catch(() => undefined);
   }
 };
-

--- a/apps/api/src/space-sessions.ts
+++ b/apps/api/src/space-sessions.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "@cohub/infra/logging";
-import { and, asc, desc, eq, gt, inArray, isNull, lt, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, lt, not, or, sql } from "drizzle-orm";
 import type { Usage } from "@cohub/protocol/core";
 import type { PersistMessageInput, RegisterSessionInput, SessionTurnRecord, UpdateSessionInfoInput } from "@cohub/protocol/model";
 import type { ModelThinkingLevel } from "@cohub/protocol";
@@ -26,6 +26,7 @@ import { enqueueAgentSessionForkJob } from "./agent-turn-queue.js";
 import { requestAgentTurnAbort } from "./agent-turn-abort.js";
 import { countToolCallsInContent, deriveMessagePreviewText, extractPlainText } from "./session-content.js";
 import { fallbackPublicUserProfile, getProfilesByUuids } from "./user-profiles.js";
+import { resolveStoredPrincipalUser } from "./identity-bridge.js";
 // space public profile is inlined in attachSessionSpaceSummaries to avoid route-layer coupling
 import { enqueueSessionMessagePostprocess } from "./session-message-postprocess-queue.js";
 import { touchSpaceActivity } from "./space-activity.js";
@@ -207,7 +208,8 @@ async function assignSessionUserLabelsAndDispatch(input: { spaceId: string; sess
 }
 
 export const createInitialSpaceSession = async (input: RegisterSessionInput) => {
-  const userUuid = normalizeRequiredUserUuid(input.userUuid);
+  const requestedUserUuid = normalizeRequiredUserUuid(input.userUuid);
+  const userUuid = (await resolveStoredPrincipalUser(requestedUserUuid)).uuid;
   const [session] = await db.insert(spaceSessions).values({
     id: input.sessionId,
     spaceId: input.spaceId,
@@ -235,7 +237,8 @@ export const registerSpaceSession = async (input: RegisterSessionInput) => {
   const space = await getSpaceById(input.spaceId);
   if (!space) throw new Error("Space not found");
 
-  const userUuid = normalizeRequiredUserUuid(input.userUuid);
+  const requestedUserUuid = normalizeRequiredUserUuid(input.userUuid);
+  const userUuid = (await resolveStoredPrincipalUser(requestedUserUuid)).uuid;
 
   try {
     const [session] = await db.insert(spaceSessions).values({
@@ -281,14 +284,21 @@ export const hydrateSessionParticipantProfiles = async <T extends typeof spaceSe
 
   const profiles = await getProfilesByUuids([...allUserUuids]);
   return sessions.map((session) => {
-    const participantUserUuids = readSessionParticipantUserUuids(session.meta);
-    const userUuid = session.userUuid?.trim() || null;
+    const storedParticipantUserUuids = readSessionParticipantUserUuids(session.meta);
+    const storedUserUuid = session.userUuid?.trim() || null;
+    const userProfile = storedUserUuid
+      ? profiles.get(storedUserUuid) ?? fallbackPublicUserProfile(storedUserUuid)
+      : null;
+    const participantProfiles = [...new Map(storedParticipantUserUuids.map((uuid) => {
+      const profile = profiles.get(uuid) ?? fallbackPublicUserProfile(uuid);
+      return [profile.userUuid, profile] as const;
+    })).values()];
     return {
       ...session,
-      userUuid,
-      userProfile: userUuid ? profiles.get(userUuid) ?? fallbackPublicUserProfile(userUuid) : null,
-      participantUserUuids,
-      participantProfiles: participantUserUuids.map((uuid) => profiles.get(uuid) ?? fallbackPublicUserProfile(uuid)),
+      userUuid: userProfile?.userUuid ?? null,
+      userProfile,
+      participantUserUuids: participantProfiles.map((profile) => profile.userUuid),
+      participantProfiles,
     };
   });
 };
@@ -409,7 +419,7 @@ export const attachSessionSpaceSummaries = async <T extends { spaceId: string }>
  * avoid duplicates before merge.
  */
 export const listUserSessions = async (
-  userUuid: string,
+  userUuid: string | readonly string[],
   options?: { limit?: number; cursor?: string | null },
 ) => {
   const limit = resolveSessionListLimit(options?.limit);
@@ -417,13 +427,17 @@ export const listUserSessions = async (
   const activityCursor = sessionListActivityCursorCondition(cursor);
   const branchLimit = limit + 1;
 
-  const creatorWhere = activityCursor
-    ? and(eq(spaceSessions.userUuid, userUuid), activityCursor)
-    : eq(spaceSessions.userUuid, userUuid);
+  const userIds = [...new Set((Array.isArray(userUuid) ? userUuid : [userUuid]).map((value) => value.trim()).filter(Boolean))];
+  if (userIds.length === 0) return mergeUserSessionListBranches([[], []], limit);
+  const [firstUserId] = userIds;
+  const creatorIdentity = firstUserId && userIds.length === 1
+    ? eq(spaceSessions.userUuid, firstUserId)
+    : inArray(spaceSessions.userUuid, userIds);
+  const creatorWhere = activityCursor ? and(creatorIdentity, activityCursor) : creatorIdentity;
 
   const participantOnly = and(
-    userSessionParticipantCondition(userUuid),
-    sql`${spaceSessions.userUuid} is distinct from ${userUuid}`,
+    or(...userIds.map((id) => userSessionParticipantCondition(id))),
+    or(isNull(spaceSessions.userUuid), not(inArray(spaceSessions.userUuid, userIds))),
   );
   const participantWhere = activityCursor
     ? and(participantOnly, activityCursor)

--- a/apps/api/src/task-run-privacy.ts
+++ b/apps/api/src/task-run-privacy.ts
@@ -9,6 +9,18 @@ type TaskRunPricingView = {
   result: unknown;
 };
 
+type ViewerIdentity = string | {
+  uuid?: string | null;
+  legacyUserUuid?: string | null;
+};
+
+const viewerIdentityKeys = (viewer: ViewerIdentity | null | undefined) => {
+  if (typeof viewer === "string") return [viewer.trim()].filter(Boolean);
+  return [...new Set([viewer?.uuid, viewer?.legacyUserUuid]
+    .filter((value): value is string => typeof value === "string" && Boolean(value.trim()))
+    .map((value) => value.trim()))];
+};
+
 /**
  * Generation pricing reveals the creator's subscription tier. Keep the
  * server-side snapshot intact while removing it from collaborator-visible
@@ -16,11 +28,11 @@ type TaskRunPricingView = {
  */
 export function sanitizeTaskRunPricingForViewer<T extends TaskRunPricingView>(
   run: T,
-  viewerUserId: string | null | undefined,
+  viewer: ViewerIdentity | null | undefined,
 ): T {
   const isGeneration = run.taskType === "generation";
   const isBillingRetry = run.taskType === "generation.billing_retry";
-  if ((!isGeneration && !isBillingRetry) || (viewerUserId && run.userUuid === viewerUserId)) return run;
+  if ((!isGeneration && !isBillingRetry) || (run.userUuid && viewerIdentityKeys(viewer).includes(run.userUuid))) return run;
 
   let payload = run.payload;
   if (isRecord(payload) && isRecord(payload.data)) {

--- a/apps/api/src/tasks.ts
+++ b/apps/api/src/tasks.ts
@@ -9,6 +9,8 @@ import type { TaskPayload, TaskScheduleConfig } from "@cohub/protocol/task";
 import { GENERATION_TASK_TYPE } from "@cohub/protocol/generation";
 import { dispatchTaskCreated } from "./realtime-events.js";
 import { createLogger } from "@cohub/infra/logging";
+import { resolveStoredPrincipalUser } from "./identity-bridge.js";
+import { canonicalizeCronJobIdentity } from "./cron-job-identity.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -26,15 +28,19 @@ export const SUPPORTED_TASK_TYPES = new Set<string>(["send_message", "save_check
 export const enqueueTask = async (
   payload: TaskPayload,
   opts?: TaskEnqueueOptions,
-) => enqueueTaskRun({
-  db,
-  payload,
-  options: opts,
-  enqueue: (name, taskPayload, options) => taskQueue.add(name, taskPayload, options),
-  onTaskCreated: (taskRun) => dispatchTaskCreated(taskRun).catch((error) => {
-    logger.warn("[Realtime] failed to dispatch task.created", error);
-  }),
-});
+) => {
+  const identity = payload.userId ? await resolveStoredPrincipalUser(payload.userId) : null;
+  const canonicalPayload = identity ? { ...payload, userId: identity.uuid } : payload;
+  return enqueueTaskRun({
+    db,
+    payload: canonicalPayload,
+    options: opts,
+    enqueue: (name, taskPayload, options) => taskQueue.add(name, taskPayload, options),
+    onTaskCreated: (taskRun) => dispatchTaskCreated(taskRun).catch((error) => {
+      logger.warn("[Realtime] failed to dispatch task.created", error);
+    }),
+  });
+};
 
 export const createCronJob = async (params: {
   userId: string;
@@ -193,7 +199,12 @@ export const enableCronJob = async (cronJobId: string, bullJobKey: string, jobDa
   try {
     await db
       .update(cronJobs)
-      .set({ enabled: true, bullJobKey: repeatJobKey, updatedAt: new Date() })
+      .set({
+        userUuid: jobData.userUuid,
+        enabled: true,
+        bullJobKey: repeatJobKey,
+        updatedAt: new Date(),
+      })
       .where(eq(cronJobs.id, cronJobId));
   } catch (error) {
     await taskQueue.removeRepeatableByKey(repeatJobKey).catch((cleanupError) => {
@@ -239,6 +250,7 @@ export const updateCronJob = async (
     const [updatedConfig] = await db
       .update(cronJobs)
       .set({
+        userUuid: current.userUuid,
         ...(patch.title !== undefined ? { title: patch.title } : {}),
         ...(patch.payload !== undefined ? { payload: patch.payload } : {}),
         ...(patch.cronExpression !== undefined ? { cronExpression: patch.cronExpression } : {}),
@@ -249,17 +261,23 @@ export const updateCronJob = async (
       .where(eq(cronJobs.id, current.id))
       .returning();
     if (!updatedConfig) throw new Error("Failed to update cron job");
+    const canonicalUpdatedConfig = canonicalizeCronJobIdentity(updatedConfig, current.userUuid);
 
     let nextBullJobKey: string | null = null;
     try {
       nextBullJobKey = await scheduleCronJobRepeat(
         current.id,
         current.bullJobKey,
-        cronJobScheduleData(updatedConfig),
+        cronJobScheduleData(canonicalUpdatedConfig),
       );
       const [updatedJob] = await db
         .update(cronJobs)
-        .set({ bullJobKey: nextBullJobKey, enabled: true, updatedAt: new Date() })
+        .set({
+          userUuid: current.userUuid,
+          bullJobKey: nextBullJobKey,
+          enabled: true,
+          updatedAt: new Date(),
+        })
         .where(eq(cronJobs.id, current.id))
         .returning();
       if (!updatedJob) throw new Error("Failed to persist cron job schedule");
@@ -273,6 +291,7 @@ export const updateCronJob = async (
       const [rolledBack] = await db
         .update(cronJobs)
         .set({
+          userUuid: current.userUuid,
           title: current.title,
           payload: current.payload,
           cronExpression: current.cronExpression,
@@ -289,7 +308,12 @@ export const updateCronJob = async (
           const restoredBullJobKey = await scheduleCronJobRepeat(current.id, "", cronJobScheduleData(current));
           await db
             .update(cronJobs)
-            .set({ bullJobKey: restoredBullJobKey, enabled: true, updatedAt: new Date() })
+            .set({
+              userUuid: current.userUuid,
+              bullJobKey: restoredBullJobKey,
+              enabled: true,
+              updatedAt: new Date(),
+            })
             .where(eq(cronJobs.id, current.id));
         } catch (restoreError) {
           logger.warn("[CronJob] failed to restore previous repeat job after reschedule failure", { cronJobId: current.id, error: restoreError });
@@ -304,7 +328,11 @@ export const updateCronJob = async (
     if (patch.title === undefined) return enabledJob;
     const [updatedJob] = await db
       .update(cronJobs)
-      .set({ title: patch.title, updatedAt: new Date() })
+      .set({
+        userUuid: current.userUuid,
+        title: patch.title,
+        updatedAt: new Date(),
+      })
       .where(eq(cronJobs.id, current.id))
       .returning();
     if (!updatedJob) throw new Error("Failed to update cron job");
@@ -318,6 +346,7 @@ export const updateCronJob = async (
   const [updatedJob] = await db
     .update(cronJobs)
     .set({
+      userUuid: current.userUuid,
       ...(patch.title !== undefined ? { title: patch.title } : {}),
       ...(patch.payload !== undefined ? { payload: patch.payload } : {}),
       ...(patch.cronExpression !== undefined ? { cronExpression: patch.cronExpression } : {}),

--- a/apps/api/src/user-profiles.ts
+++ b/apps/api/src/user-profiles.ts
@@ -1,8 +1,13 @@
 import { randomInt } from "node:crypto";
-import { and, eq, inArray, ne } from "drizzle-orm";
+import { eq, inArray, or } from "drizzle-orm";
 import type { AuthUser } from "./lib/middleware.js";
 import { db } from "./db/index.js";
 import { userProfiles } from "@cohub/db";
+import {
+  getIdentityKeys,
+  resolveVerifiedPrincipalIdentity,
+  type IdentityMappingRow,
+} from "@cohub/identity";
 import { getLogtoUser, updateLogtoUserProfile } from "./logto-management.js";
 import { createLogger } from "@cohub/infra/logging";
 import {
@@ -22,6 +27,11 @@ export type PublicUserProfile = {
 export type UserProfile = PublicUserProfile & {
   logtoUserId?: string;
   syncedAt: string;
+};
+
+const storageUserUuidKey = Symbol("storageUserUuid");
+type StoredUserProfile = UserProfile & {
+  [storageUserUuidKey]: string;
 };
 
 export class UsernameConflictError extends Error {
@@ -49,6 +59,10 @@ type UserProfileFields = {
 
 type UserProfileRow = typeof userProfiles.$inferSelect;
 
+type ProfileIdentity = Pick<AuthUser, "uuid" | "legacyUserUuid">;
+
+const identityKeys = (user: ProfileIdentity | string): string[] =>
+  typeof user === "string" ? [user.trim()].filter(Boolean) : getIdentityKeys(user);
 const asRecord = (value: unknown): Record<string, unknown> =>
   value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
 
@@ -153,13 +167,23 @@ async function filterLocallyAvailableUsernames(input: {
   if (input.candidates.length === 0) return [];
 
   const takenRows = await db
-    .select({ username: userProfiles.username })
+    .select({
+      username: userProfiles.username,
+      userUuid: userProfiles.userUuid,
+      logtoUserId: userProfiles.logtoUserId,
+    })
     .from(userProfiles)
-    .where(and(
-      inArray(userProfiles.username, input.candidates),
-      ne(userProfiles.userUuid, input.userUuid),
-    ));
-  const taken = new Set(takenRows.map((row) => row.username).filter((value): value is string => Boolean(value)));
+    .where(inArray(userProfiles.username, input.candidates));
+  const taken = new Set(
+    takenRows
+      .filter(
+        (row) =>
+          row.userUuid !== input.userUuid &&
+          row.logtoUserId !== input.userUuid,
+      )
+      .map((row) => row.username)
+      .filter((value): value is string => Boolean(value)),
+  );
   return input.candidates.filter((candidate) => !taken.has(candidate));
 }
 
@@ -183,6 +207,15 @@ export function resolveSyncedUsername(
   return validatePublicIdentifierAssignment("username", username).reason === "reserved"
     ? null
     : username;
+}
+
+export function isUsernameOwnedByLogtoUser(
+  owner: Pick<UserProfileRow, "userUuid" | "logtoUserId">,
+  currentLogtoUserId: string,
+): boolean {
+  const ownerLogtoUserId = owner.logtoUserId.trim();
+  const current = currentLogtoUserId.trim();
+  return Boolean(ownerLogtoUserId && current && ownerLogtoUserId === current);
 }
 
 export function validateUsername(value: unknown) {
@@ -256,8 +289,8 @@ function normalizeSyncedUserProfile(input: {
   };
 }
 
-const toUserProfile = (row: UserProfileRow): UserProfile => ({
-  userUuid: row.userUuid,
+const toUserProfile = (row: UserProfileRow, userUuid = row.userUuid): UserProfile => ({
+  userUuid,
   logtoUserId: row.logtoUserId,
   username: row.username ?? null,
   displayName: row.displayName,
@@ -265,8 +298,8 @@ const toUserProfile = (row: UserProfileRow): UserProfile => ({
   syncedAt: row.syncedAt instanceof Date ? row.syncedAt.toISOString() : new Date().toISOString(),
 });
 
-const toPublicUserProfile = (row: UserProfileRow): PublicUserProfile => ({
-  userUuid: row.userUuid,
+const toPublicUserProfile = (row: UserProfileRow, userUuid = row.userUuid): PublicUserProfile => ({
+  userUuid,
   username: row.username ?? null,
   displayName: row.displayName,
   avatarUrl: row.avatarUrl ?? null,
@@ -274,6 +307,7 @@ const toPublicUserProfile = (row: UserProfileRow): PublicUserProfile => ({
 
 async function upsertUserProfile(input: {
   userUuid: string;
+  legacyUserUuid?: string;
   logtoUserId: string;
   fields: UserProfileFields;
 }) {
@@ -282,8 +316,43 @@ async function upsertUserProfile(input: {
   // Never rehydrate a local-only username that Logto does not have.
   const fields = input.fields;
   try {
+    const lookupKeys = [...new Set([
+      input.userUuid,
+      input.legacyUserUuid,
+      input.logtoUserId,
+    ].filter((value): value is string => Boolean(value?.trim())).map((value) => value.trim()))];
+    const existingRows = await db.select({
+      userUuid: userProfiles.userUuid,
+      logtoUserId: userProfiles.logtoUserId,
+    })
+      .from(userProfiles)
+      .where(or(
+        inArray(userProfiles.userUuid, lookupKeys),
+        inArray(userProfiles.logtoUserId, lookupKeys),
+      ));
+    resolveVerifiedPrincipalIdentity({
+      sub: input.logtoUserId,
+      legacyUserUuid: input.legacyUserUuid,
+      mappings: existingRows satisfies IdentityMappingRow[],
+    });
+    const existing = existingRows[0];
+    const storageUserUuid = input.legacyUserUuid?.trim() || existing?.userUuid || input.userUuid;
+    if (existing) {
+      const [row] = await db.update(userProfiles).set({
+        userUuid: storageUserUuid,
+        logtoUserId: input.logtoUserId,
+        username: fields.username,
+        displayName: fields.displayName,
+        avatarUrl: fields.avatarUrl,
+        source: fields.source,
+        syncedAt: now,
+        updatedAt: now,
+      }).where(eq(userProfiles.userUuid, existing.userUuid)).returning();
+      if (!row) throw new Error("failed to update user profile");
+      return toUserProfile(row, input.userUuid);
+    }
     const [row] = await db.insert(userProfiles).values({
-      userUuid: input.userUuid,
+      userUuid: storageUserUuid,
       logtoUserId: input.logtoUserId,
       username: fields.username,
       displayName: fields.displayName,
@@ -305,7 +374,7 @@ async function upsertUserProfile(input: {
     }).returning();
 
     if (!row) throw new Error("failed to upsert user profile");
-    return toUserProfile(row);
+    return toUserProfile(row, input.userUuid);
   } catch (error) {
     const constraint = getUniqueViolationConstraint(error);
     if (constraint?.includes("username")) {
@@ -315,9 +384,31 @@ async function upsertUserProfile(input: {
   }
 }
 
-async function getStoredUserProfile(userUuid: string): Promise<UserProfile | null> {
-  const [row] = await db.select().from(userProfiles).where(eq(userProfiles.userUuid, userUuid)).limit(1);
-  return row ? toUserProfile(row) : null;
+async function getStoredUserProfile(
+  user: ProfileIdentity | string,
+): Promise<StoredUserProfile | null> {
+  const keys = identityKeys(user);
+  if (keys.length === 0) return null;
+  const rows = await db.select().from(userProfiles).where(or(
+    inArray(userProfiles.userUuid, keys),
+    inArray(userProfiles.logtoUserId, keys),
+  ));
+  if (rows.length > 1) {
+    throw new Error("identity profile aliases resolve to multiple rows");
+  }
+  const [row] = rows;
+  if (!row) return null;
+  if (typeof user !== "string") {
+    resolveVerifiedPrincipalIdentity({
+      sub: user.uuid,
+      legacyUserUuid: user.legacyUserUuid,
+      mappings: rows,
+    });
+  }
+  return {
+    ...toUserProfile(row, row.logtoUserId),
+    [storageUserUuidKey]: row.userUuid,
+  };
 }
 
 function sourceFromAuthUser(user: AuthUser): Record<string, unknown> {
@@ -346,7 +437,11 @@ export async function resolveCurrentUserEmail(user: AuthUser): Promise<string | 
   const [row] = await db
     .select({ source: userProfiles.source })
     .from(userProfiles)
-    .where(eq(userProfiles.userUuid, user.uuid))
+    .where(or(
+      eq(userProfiles.userUuid, user.uuid),
+      eq(userProfiles.logtoUserId, user.uuid),
+      ...(user.legacyUserUuid ? [eq(userProfiles.userUuid, user.legacyUserUuid)] : []),
+    ))
     .limit(1);
   if (!row) return null;
   return emailFromSource(asRecord(row.source));
@@ -474,12 +569,20 @@ export function resolveTrustedLogtoUserId(input: {
   userUuid: string;
   tokenLogtoUserId?: string | null;
   storedLogtoUserId?: string | null;
+  storedUserUuid?: string | null;
 }): string | null {
   const tokenLogtoUserId = input.tokenLogtoUserId?.trim();
   if (tokenLogtoUserId) return tokenLogtoUserId;
 
   const storedLogtoUserId = input.storedLogtoUserId?.trim();
-  if (!storedLogtoUserId || storedLogtoUserId === input.userUuid) return null;
+  if (!storedLogtoUserId) return null;
+  const storedUserUuid = input.storedUserUuid?.trim();
+  if (
+    storedLogtoUserId === input.userUuid &&
+    (!storedUserUuid || storedUserUuid === input.userUuid)
+  ) {
+    return null;
+  }
   return storedLogtoUserId;
 }
 
@@ -515,6 +618,7 @@ async function syncUserProfileFromLogto(input: {
     // A verified user token established this binding even when Logto is temporarily unavailable.
     return await upsertUserProfile({
       userUuid: input.user.uuid,
+      legacyUserUuid: input.user.legacyUserUuid,
       logtoUserId: input.logtoUserId,
       fields: mergeAuthEmailIntoFields(
         input.user,
@@ -556,6 +660,7 @@ async function syncUserProfileFromLogto(input: {
 
   return await upsertUserProfile({
     userUuid: input.user.uuid,
+    legacyUserUuid: input.user.legacyUserUuid,
     logtoUserId: input.logtoUserId,
     fields,
   });
@@ -566,12 +671,13 @@ async function syncUserProfileFromLogto(input: {
  * Principals without either identity return a transient profile and never create a guessed binding.
  */
 export async function ensureCurrentUserProfile(user: AuthUser): Promise<UserProfile> {
-  const stored = await getStoredUserProfile(user.uuid);
+  const stored = await getStoredUserProfile(user);
   const tokenLogtoUserId = typeof user.sub === "string" && user.sub.trim() ? user.sub.trim() : null;
   const logtoUserId = resolveTrustedLogtoUserId({
-    userUuid: user.uuid,
+    userUuid: user.legacyUserUuid ?? user.uuid,
     tokenLogtoUserId,
     storedLogtoUserId: stored?.logtoUserId,
+    storedUserUuid: stored?.[storageUserUuidKey],
   });
 
   if (!logtoUserId) return transientUserProfile(user, stored);
@@ -594,8 +700,8 @@ export async function ensureUserProfileByUuid(
   userUuid: string,
   actor?: AuthUser | null,
 ): Promise<UserProfile | null> {
-  const ownerActor = actor?.uuid === userUuid ? actor : null;
-  const stored = await getStoredUserProfile(userUuid);
+  const ownerActor = actor && getIdentityKeys(actor).includes(userUuid) ? actor : null;
+  const stored = await getStoredUserProfile(ownerActor ?? userUuid);
   const tokenLogtoUserId = typeof ownerActor?.sub === "string" && ownerActor.sub.trim()
     ? ownerActor.sub.trim()
     : null;
@@ -603,12 +709,18 @@ export async function ensureUserProfileByUuid(
     userUuid,
     tokenLogtoUserId,
     storedLogtoUserId: stored?.logtoUserId,
+    storedUserUuid: stored?.[storageUserUuidKey],
   });
 
   if (!logtoUserId) return null;
   if (!tokenLogtoUserId && stored?.username) return stored;
 
-  const user = ownerActor ?? ({ uuid: userUuid } as AuthUser);
+  const user = ownerActor ?? ({
+    uuid: stored?.logtoUserId ?? userUuid,
+    ...(stored?.logtoUserId && stored.logtoUserId !== userUuid
+      ? { legacyUserUuid: userUuid }
+      : {}),
+  } as AuthUser);
   return await syncUserProfileFromLogto({ user, logtoUserId, stored });
 }
 
@@ -616,11 +728,12 @@ export async function updateCurrentUserProfile(user: AuthUser, input: { displayN
   // Logto access tokens carry `sub`; execution / work / preview principals only have
   // actor uuid, so fall back to the stored profile's logtoUserId for those cases.
   const logtoUserIdFromToken = typeof user.sub === "string" && user.sub.trim() ? user.sub.trim() : null;
-  const storedProfile = await getStoredUserProfile(user.uuid);
+  const storedProfile = await getStoredUserProfile(user);
   const logtoUserId = resolveTrustedLogtoUserId({
     userUuid: user.uuid,
     tokenLogtoUserId: logtoUserIdFromToken,
     storedLogtoUserId: storedProfile?.logtoUserId,
+    storedUserUuid: storedProfile?.[storageUserUuidKey],
   });
   if (!logtoUserId) throw new LogtoUserRequiredError("profile updates require user sign-in");
 
@@ -645,10 +758,14 @@ export async function updateCurrentUserProfile(user: AuthUser, input: { displayN
   }
 
   if (username) {
-    const existing = await db.select({ userUuid: userProfiles.userUuid }).from(userProfiles).where(
-      and(eq(userProfiles.username, username), ne(userProfiles.userUuid, user.uuid)),
-    ).limit(1);
-    if (existing.length > 0) {
+    const [existing] = await db.select({
+      userUuid: userProfiles.userUuid,
+      logtoUserId: userProfiles.logtoUserId,
+    })
+      .from(userProfiles)
+      .where(eq(userProfiles.username, username))
+      .limit(1);
+    if (existing && !isUsernameOwnedByLogtoUser(existing, logtoUserId)) {
       throw new UsernameConflictError("username is already taken");
     }
   }
@@ -677,6 +794,7 @@ export async function updateCurrentUserProfile(user: AuthUser, input: { displayN
     }
     return await upsertUserProfile({
       userUuid: user.uuid,
+      legacyUserUuid: user.legacyUserUuid,
       logtoUserId,
       fields: updatedFields,
     });
@@ -696,8 +814,20 @@ export async function getProfilesByUuids(userUuids: string[]): Promise<Map<strin
   const unique = [...new Set(userUuids.map((value) => value.trim()).filter(Boolean))];
   if (unique.length === 0) return new Map();
 
-  const rows = await db.select().from(userProfiles).where(inArray(userProfiles.userUuid, unique));
-  return new Map(rows.map((row) => [row.userUuid, toPublicUserProfile(row)]));
+  const rows = await db.select().from(userProfiles).where(or(
+    inArray(userProfiles.userUuid, unique),
+    inArray(userProfiles.logtoUserId, unique),
+  ));
+  const result = new Map<string, PublicUserProfile>();
+  for (const key of unique) {
+    const matching = rows.filter((candidate) => candidate.userUuid === key || candidate.logtoUserId === key);
+    if (matching.length > 1) {
+      throw new Error(`identity profile conflict for ${key}`);
+    }
+    const row = matching[0];
+    if (row) result.set(key, toPublicUserProfile(row, row.logtoUserId));
+  }
+  return result;
 }
 
 export async function getProfilesByUsernames(usernames: string[]): Promise<Map<string, PublicUserProfile>> {
@@ -707,14 +837,14 @@ export async function getProfilesByUsernames(usernames: string[]): Promise<Map<s
   const rows = await db.select().from(userProfiles).where(inArray(userProfiles.username, unique));
   return new Map(rows
     .filter((row): row is typeof row & { username: string } => Boolean(row.username))
-    .map((row) => [row.username, toPublicUserProfile(row)]));
+    .map((row) => [row.username, toPublicUserProfile(row, row.logtoUserId)]));
 }
 
 export async function getProfileByUsername(username: string): Promise<PublicUserProfile | null> {
   const normalized = normalizeUsername(username);
   if (!normalized) return null;
   const [row] = await db.select().from(userProfiles).where(eq(userProfiles.username, normalized)).limit(1);
-  return row ? toPublicUserProfile(row) : null;
+  return row ? toPublicUserProfile(row, row.logtoUserId) : null;
 }
 
 export function fallbackPublicUserProfile(userUuid: string): PublicUserProfile {

--- a/apps/api/src/user-profiles.username.test.ts
+++ b/apps/api/src/user-profiles.username.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   buildDefaultUsernameCandidates,
+  isUsernameOwnedByLogtoUser,
   normalizeUsername,
   resolveSyncedUsername,
   resolveTrustedLogtoUserId,
@@ -24,6 +25,12 @@ describe("resolveTrustedLogtoUserId", () => {
     assert.equal(resolveTrustedLogtoUserId({
       userUuid,
       storedLogtoUserId: "logto-user",
+    }), "logto-user");
+
+    assert.equal(resolveTrustedLogtoUserId({
+      userUuid: "logto-user",
+      storedLogtoUserId: "logto-user",
+      storedUserUuid: userUuid,
     }), "logto-user");
   });
 
@@ -119,5 +126,21 @@ describe("buildDefaultUsernameCandidates", () => {
     assert.ok(candidates.length >= 1);
     assert.ok(candidates.every((value) => value.startsWith("u")));
     assert.ok(candidates.every((value) => /^[a-z][a-z0-9]*$/.test(value)));
+  });
+});
+
+describe("isUsernameOwnedByLogtoUser", () => {
+  it("accepts a migrated user's legacy profile row when its Logto subject matches", () => {
+    assert.equal(isUsernameOwnedByLogtoUser({
+      userUuid: "5d4ac7d3-1f50-4af4-8d75-6df54d5edc6a",
+      logtoUserId: "logto-user",
+    }, "logto-user"), true);
+  });
+
+  it("rejects a profile row owned by another Logto subject", () => {
+    assert.equal(isUsernameOwnedByLogtoUser({
+      userUuid: "logto-user",
+      logtoUserId: "other-user",
+    }, "logto-user"), false);
   });
 });

--- a/apps/gateway/src/api-client.ts
+++ b/apps/gateway/src/api-client.ts
@@ -1,5 +1,3 @@
-import type { AuthUserProfile } from "@cohub/identity";
-import { AuthorizationError, verifyUserAccessToken } from "@cohub/identity";
 import { buildTraceHeaders, getTraceResponseHeaders, type TraceIdentifiers } from "@cohub/infra/tracing";
 import type { ContentBlock } from "@cohub/protocol/core";
 import type { RealtimeRoom } from "@cohub/protocol/realtime";
@@ -14,7 +12,7 @@ const parseJson = async <T>(response: Response): Promise<T | null> => {
 export type RealtimeAuthResult =
   | {
       ok: true;
-      user: GatewayAuthUser & { uuid: string };
+      user: GatewayAuthUser & { uuid: string; legacyUserUuid?: string };
     }
   | {
       ok: false;
@@ -28,7 +26,7 @@ export type RealtimeAuthResult =
 export type SessionAuthorizationResult =
   | {
       ok: true;
-      user: GatewayAuthUser & { uuid: string };
+      user: GatewayAuthUser & { uuid: string; legacyUserUuid?: string };
       spaceId: string;
       sessionId: string;
     }
@@ -42,27 +40,6 @@ export type SessionAuthorizationResult =
     };
 
 export const authenticateRealtimeToken = async (input: { token: string }): Promise<RealtimeAuthResult> => {
-  let user: AuthUserProfile;
-  try {
-    user = await verifyUserAccessToken({ token: input.token, logtoEndpoint: gatewayConfig.logtoEndpoint });
-    return {
-      ok: true,
-      user,
-    };
-  } catch (error) {
-    const status = error instanceof AuthorizationError ? error.status : 401;
-    if (status === 403) {
-      return {
-        ok: false,
-        status,
-        error: {
-          message: "Forbidden",
-          type: "authentication_error",
-        },
-      };
-    }
-  }
-
   const response = await fetch(`${gatewayConfig.apiBaseUrl}/api/me`, {
     headers: {
       authorization: `Bearer ${input.token}`,
@@ -79,7 +56,11 @@ export const authenticateRealtimeToken = async (input: { token: string }): Promi
       },
     };
   }
-  const data = await parseJson<{ uuid?: string; profile?: { displayName?: string | null; avatarUrl?: string | null } }>(response);
+  const data = await parseJson<{
+    uuid?: string;
+    legacyUserUuid?: string;
+    profile?: { displayName?: string | null; avatarUrl?: string | null };
+  }>(response);
   if (!data?.uuid) {
     return {
       ok: false,
@@ -94,6 +75,7 @@ export const authenticateRealtimeToken = async (input: { token: string }): Promi
     ok: true,
     user: {
       uuid: data.uuid,
+      ...(data.legacyUserUuid ? { legacyUserUuid: data.legacyUserUuid } : {}),
       nick_name: data.profile?.displayName ?? undefined,
       avatar_url: data.profile?.avatarUrl ?? undefined,
     },

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -57,6 +57,7 @@ const logger = createLogger({ serviceName: "cohub-gateway" });
 type WsConnectionContext = {
   connectionId: string;
   userId?: string;
+  userIds: string[];
   userName?: string;
   userAvatarUrl?: string;
   token?: string;
@@ -210,6 +211,7 @@ const persistWsConnection = async (ctx: WsConnectionContext) => {
   await redisCommandClient.set(getWsConnectionKey(ctx.connectionId), JSON.stringify({
     connectionId: ctx.connectionId,
     userId: ctx.userId ?? null,
+    userIds: ctx.userIds,
     userName: ctx.userName ?? null,
     userAvatarUrl: ctx.userAvatarUrl ?? null,
     capabilities: [...ctx.capabilities],
@@ -854,6 +856,7 @@ async function main() {
       connectionId,
       capabilities: new Set(),
       rooms: new Set(),
+      userIds: [],
       presenceMetaBySpace: new Map(),
       compactStreamAliases: new Map(),
       nextCompactStreamAlias: 0,
@@ -915,6 +918,9 @@ async function main() {
           ctx.presenceMetaBySpace.clear();
           ctx.boardAwarenessSeqByBoard.clear();
           ctx.userId = result.user.uuid;
+          ctx.userIds = [...new Set([result.user.uuid, result.user.legacyUserUuid]
+            .filter((value): value is string => typeof value === "string" && Boolean(value.trim()))
+            .map((value) => value.trim()))];
           ctx.userName = typeof result.user.nick_name === "string" ? result.user.nick_name : undefined;
           ctx.userAvatarUrl = typeof result.user.avatar_url === "string" ? result.user.avatar_url : undefined;
           ctx.token = token;
@@ -923,7 +929,7 @@ async function main() {
               ? message.payload.capabilities.filter((value) => typeof value === "string" && value.trim())
               : [],
           );
-          subscribeConnectionToRoom(ctx, getRealtimeUserRoom(result.user.uuid));
+          for (const userId of ctx.userIds) subscribeConnectionToRoom(ctx, getRealtimeUserRoom(userId));
           await persistWsConnection(ctx);
           sendWsEnvelope(socket, buildRealtimeEnvelope({
             domain: "system",
@@ -985,7 +991,7 @@ async function main() {
 
         if (message.type === "unsubscribe") {
           for (const room of normalizeRealtimeRooms(message.payload.rooms)) {
-            if (room === getRealtimeUserRoom(ctx.userId)) continue;
+            if (ctx.userIds.some((userId) => room === getRealtimeUserRoom(userId))) continue;
             const boardId = getBoardIdFromRoom(room);
             if (boardId) ctx.boardAwarenessSeqByBoard.delete(boardId);
             const spaceId = getSpaceIdFromRoom(room);

--- a/apps/web/src/lib/components/CommandPalette.svelte
+++ b/apps/web/src/lib/components/CommandPalette.svelte
@@ -182,14 +182,13 @@ const recentItems = $derived.by(() => {
 });
 // Local commands are always resolved synchronously — never blocked by network/IDB.
 const localCommands = $derived(resolveLocalCommandItems(searchPlan));
-const myUserUuid = $derived(authStore.userUuid);
 const filteredSpaceItems = $derived.by(() => {
 	if (!isSpacePickerMode || spaceFilter === "all") return null;
 	return (items: CommandPaletteItem[]) =>
 		items.filter((item) => {
 			if (item.type !== "space") return true;
 			if (spaceFilter === "mine")
-				return item.ownerProfile?.userUuid === myUserUuid;
+				return authStore.matchesUserId(item.ownerProfile?.userUuid);
 			if (spaceFilter === "pinned") return item.isPinned ?? false;
 			return true;
 		});

--- a/apps/web/src/lib/components/Sidebar.svelte
+++ b/apps/web/src/lib/components/Sidebar.svelte
@@ -2455,7 +2455,7 @@ async function handleNavigateToTask(taskId: string) {
 function getCurrentSpaceOwnerUsername() {
 	return (
 		currentSpace?.ownerProfile?.username ??
-		(currentSpace?.userUuid === authStore.userUuid
+		(authStore.matchesUserId(currentSpace?.userUuid)
 			? authStore.profile?.username
 			: null)
 	);

--- a/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
+++ b/apps/web/src/lib/features/space/SpaceWorkspacePage.svelte
@@ -284,7 +284,7 @@ const rightSidebarAvailable = $derived(
 const canEditFiles = $derived(hasAccessPermission("file.edit"));
 const spaceOwnerUsername = $derived(
 	space?.ownerProfile?.username ??
-		(space?.userUuid === authStore.userUuid
+		(authStore.matchesUserId(space?.userUuid)
 			? (authStore.profile?.username ?? null)
 			: null),
 );
@@ -540,7 +540,11 @@ const previewWorksBuffer = createWorkMutationBuffer();
 let previewWorksToken = 0;
 const inlineFileWork = $derived.by(() => {
 	const filePath = inlineFile?.response?.path ?? null;
-	if (!filePath || activeFsReadonly || authStore.userUuid !== space?.userUuid)
+	if (
+		!filePath ||
+		activeFsReadonly ||
+		!authStore.matchesUserId(space?.userUuid)
+	)
 		return null;
 	return (
 		previewWorks.find(
@@ -570,7 +574,7 @@ $effect(() => {
 		try {
 			await authStore.ensureLoaded();
 			if (token !== previewWorksToken) return;
-			if (!authStore.userUuid || authStore.userUuid !== currentOwnerId) {
+			if (!authStore.matchesUserId(currentOwnerId)) {
 				previewWorks = [];
 				previewWorksLoadedFor = currentSpaceId;
 				return;
@@ -867,7 +871,7 @@ const pageVisible = $derived(spaceRealtime.pageVisible);
 const pageOnline = $derived(spaceRealtime.pageOnline);
 const wsConnectionState = $derived(spaceRealtime.connectionState);
 const onlineUsers = $derived(
-	spacePresence.users.filter((user) => user.userId !== authStore.userUuid),
+	spacePresence.users.filter((user) => !authStore.matchesUserId(user.userId)),
 );
 $effect(() => {
 	connectionStateBox.current = wsConnectionState;
@@ -1452,7 +1456,7 @@ async function handleWsEvent(payload: ChannelEnvelope) {
 				typeof turn?.userUuid === "string" ? turn.userUuid : null;
 			if (
 				senderUuid &&
-				senderUuid !== authStore.userUuid &&
+				!authStore.matchesUserId(senderUuid) &&
 				canRunDanmakuCatchup()
 			) {
 				const text = extractDanmakuText(turn);

--- a/apps/web/src/lib/features/work/bridge-host.svelte.ts
+++ b/apps/web/src/lib/features/work/bridge-host.svelte.ts
@@ -95,6 +95,10 @@ export function createWorkBridgeHost(
 			await authStore.ensureLoaded();
 			return authStore.userUuid;
 		},
+		getViewerIdentityKeys: async () => {
+			await authStore.ensureLoaded();
+			return authStore.identityKeys;
+		},
 		requestSignIn: (redirectPath) => signInWithRedirectPath(redirectPath),
 		onStateChange: (next) => {
 			authOpen = next.authOpen;

--- a/apps/web/src/lib/stores/auth.svelte.ts
+++ b/apps/web/src/lib/stores/auth.svelte.ts
@@ -18,6 +18,7 @@ type RestoredAuthSession = {
 	isAuthenticated: boolean;
 	claims: IdTokenClaims | null;
 	userUuid: string | null;
+	legacyUserUuid: string | null;
 	profile: UserProfile | null;
 	email: string | null;
 };
@@ -26,6 +27,7 @@ const unauthenticatedSession = (): RestoredAuthSession => ({
 	isAuthenticated: false,
 	claims: null,
 	userUuid: null,
+	legacyUserUuid: null,
 	profile: null,
 	email: null,
 });
@@ -47,6 +49,7 @@ const restoreAuthSession = async (
 	const claims = await getCurrentIdTokenClaims();
 	const subject = typeof claims?.sub === "string" ? claims.sub : null;
 	let userUuid: string | null = null;
+	let legacyUserUuid: string | null = null;
 	let profile: UserProfile | null = null;
 	let email: string | null = null;
 
@@ -58,12 +61,14 @@ const restoreAuthSession = async (
 	const cached = getCachedMeProfile(subject);
 	if (cached) {
 		userUuid = cached.uuid ?? null;
+		legacyUserUuid = cached.legacyUserUuid ?? null;
 		profile = cached.profile ?? null;
 		email = cached.email ?? null;
 		const cachedSession = {
 			isAuthenticated: true,
 			claims,
 			userUuid,
+			legacyUserUuid,
 			profile,
 			email,
 		};
@@ -77,6 +82,7 @@ const restoreAuthSession = async (
 						isAuthenticated: true,
 						claims,
 						userUuid: me.uuid ?? null,
+						legacyUserUuid: me.legacyUserUuid ?? null,
 						profile: me.profile ?? null,
 						email: me.email ?? null,
 					});
@@ -98,6 +104,7 @@ const restoreAuthSession = async (
 	try {
 		const me = await sdk.user.getMe(meOptions);
 		userUuid = me.uuid ?? null;
+		legacyUserUuid = me.legacyUserUuid ?? null;
 		profile = me.profile ?? null;
 		email = me.email ?? null;
 		setCachedMeProfile(subject, me);
@@ -114,6 +121,7 @@ const restoreAuthSession = async (
 		isAuthenticated: true,
 		claims,
 		userUuid,
+		legacyUserUuid,
 		profile,
 		email,
 	};
@@ -128,6 +136,7 @@ class AuthStore {
 	// userUuid from backend API (/api/me), used for ownership checks
 	// against space.userUuid, session ownership, etc.
 	_userUuid = $state<string | null>(null);
+	_legacyUserUuid = $state<string | null>(null);
 	profile = $state<UserProfile | null>(null);
 	email = $state<string | null>(null);
 
@@ -136,6 +145,21 @@ class AuthStore {
 
 	get userUuid(): string | null {
 		return this._userUuid;
+	}
+
+	get identityKeys(): string[] {
+		return [
+			...new Set(
+				[this._userUuid, this._legacyUserUuid].filter(
+					(value): value is string => Boolean(value),
+				),
+			),
+		];
+	}
+
+	matchesUserId(userId: string | null | undefined): boolean {
+		const normalized = userId?.trim();
+		return Boolean(normalized && this.identityKeys.includes(normalized));
 	}
 
 	async ensureLoaded(force = false) {
@@ -149,6 +173,7 @@ class AuthStore {
 					this.isAuthenticated = restored.isAuthenticated;
 					this.claims = restored.claims;
 					this._userUuid = restored.userUuid;
+					this._legacyUserUuid = restored.legacyUserUuid;
 					this.profile = restored.profile;
 					this.email = restored.email;
 					this.loaded = true;
@@ -177,6 +202,9 @@ class AuthStore {
 		if (this._userUuid) {
 			setCachedMeProfile(this.claims?.sub, {
 				uuid: this._userUuid,
+				...(this._legacyUserUuid
+					? { legacyUserUuid: this._legacyUserUuid }
+					: {}),
 				profile,
 				email: this.email,
 			});
@@ -192,6 +220,7 @@ class AuthStore {
 		this.loaded = false;
 		this.loading = false;
 		this._userUuid = null;
+		this._legacyUserUuid = null;
 		this.profile = null;
 		this.email = null;
 		this._loadPromise = null;

--- a/apps/web/src/routes/(app)/settings/rules/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/rules/+page.svelte
@@ -47,10 +47,11 @@ function formatUpdatedAt(value: string | null) {
 	}
 }
 
-function findConfigSpace(spaces: SpaceRecord[], currentUserUuid: string) {
+function findConfigSpace(spaces: SpaceRecord[]) {
 	return (
 		spaces.find(
-			(space) => space.name === "config" && space.userUuid === currentUserUuid,
+			(space) =>
+				space.name === "config" && authStore.matchesUserId(space.userUuid),
 		) ?? null
 	);
 }
@@ -71,7 +72,7 @@ async function loadRulesPage() {
 		const spaces = setCachedSpaceList(spacesResult);
 		rulesContent = rules.content;
 		updatedAt = rules.updatedAt;
-		configSpace = userUuid ? findConfigSpace(spaces, userUuid) : null;
+		configSpace = userUuid ? findConfigSpace(spaces) : null;
 	} catch (error) {
 		if (
 			await handleUnauthorizedError(error, `${currentPath}${currentSearch}`)

--- a/apps/web/src/routes/(public)/referrals/[code]/+page.svelte
+++ b/apps/web/src/routes/(public)/referrals/[code]/+page.svelte
@@ -50,7 +50,7 @@ async function claim() {
 				return;
 			}
 		}
-		if (authStore.userUuid === referral?.inviter.userUuid) {
+		if (authStore.matchesUserId(referral?.inviter.userUuid)) {
 			action = "self";
 			return;
 		}

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -22,6 +22,7 @@
     "@cohub/core": "workspace:*",
     "@cohub/db": "workspace:*",
     "@cohub/infra": "workspace:*",
+    "@cohub/identity": "workspace:*",
     "@cohub/protocol": "workspace:*",
     "@cohub/sandbox-controller": "workspace:*",
     "@kubernetes/client-node": "^1.4.0",

--- a/apps/worker/src/config-publish.ts
+++ b/apps/worker/src/config-publish.ts
@@ -2,6 +2,7 @@ import { chmod, copyFile, lstat, mkdir, readFile, readdir, rename, rm, stat, wri
 import { dirname, join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { config } from "./config.js";
+import { isStorageSafePrincipalId } from "@cohub/identity";
 
 const DIR_MODE = 0o775;
 const FILE_MODE = 0o664;
@@ -14,13 +15,11 @@ const USER_CONFIG_PUBLISH_WHITELIST = [
   ".agents",
   ".cohub",
 ] as const;
-const USER_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-const SHORT_USER_ID_REGEX = /^[0-9a-f]{32}$/i;
 const MAX_COPY_DEPTH = 16;
 
 function assertValidUserId(userId: string) {
   const value = userId.trim();
-  if (!USER_ID_REGEX.test(value) && !SHORT_USER_ID_REGEX.test(value)) {
+  if (!isStorageSafePrincipalId(value)) {
     throw new Error(`Invalid userId: ${userId}`);
   }
   return value;

--- a/apps/worker/src/identity-bridge.ts
+++ b/apps/worker/src/identity-bridge.ts
@@ -1,0 +1,43 @@
+import { inArray, or } from "drizzle-orm";
+import { userProfiles } from "@cohub/db";
+import {
+  getIdentityKeys,
+  resolveLegacyBillingIdentity,
+  resolveStoredPrincipalIdentity,
+  resolveStoredPrincipalIdentityForRead,
+  type IdentityMappingRow,
+} from "@cohub/identity";
+import { db } from "./db.js";
+
+async function loadIdentityMappings(principalId: string): Promise<IdentityMappingRow[]> {
+  const normalized = principalId.trim();
+  if (!normalized) return [];
+  return db
+    .select({ userUuid: userProfiles.userUuid, logtoUserId: userProfiles.logtoUserId })
+    .from(userProfiles)
+    .where(or(
+      inArray(userProfiles.userUuid, [normalized]),
+      inArray(userProfiles.logtoUserId, [normalized]),
+    ));
+}
+
+export async function resolveStoredPrincipalIdentityForWorker(principalId: string) {
+  const mappings = await loadIdentityMappings(principalId);
+  return resolveStoredPrincipalIdentity({ principalId, mappings });
+}
+
+/** Read legacy namespaces first so canonical sub config wins during merges. */
+export async function resolveStoredPrincipalReadKeysForWorker(principalId: string): Promise<string[]> {
+  const mappings = await loadIdentityMappings(principalId);
+  const identity = resolveStoredPrincipalIdentityForRead({ principalId, mappings });
+  return [
+    ...getIdentityKeys(identity).filter((key) => key !== identity.uuid),
+    identity.uuid,
+  ];
+}
+
+export async function resolveBillingUserIdForStoredPrincipal(principalId: string): Promise<string> {
+  const mappings = await loadIdentityMappings(principalId);
+  const identity = resolveStoredPrincipalIdentity({ principalId, mappings });
+  return resolveLegacyBillingIdentity({ identity, mappings });
+}

--- a/apps/worker/src/prompt-templates.ts
+++ b/apps/worker/src/prompt-templates.ts
@@ -19,6 +19,7 @@ import { getSpaceModMountSignature, listEnabledSpaceMods } from "@cohub/core/spa
 import { config } from "./config.js";
 import { db } from "./db.js";
 import { redisCommandClient } from "./redis.js";
+import { resolveStoredPrincipalReadKeysForWorker } from "./identity-bridge.js";
 
 export type { PromptTemplateCatalogEntry } from "@cohub/infra/config-runtime/prompts";
 
@@ -201,7 +202,14 @@ async function fetchPromptTemplates(options: LoadPromptTemplatesOptions): Promis
     configs.push(await loadSpaceModPrompts(options.spaceId));
   }
   if (options.userId) {
-    configs.push(await loadCachedPrompts({ redisKey: getUserPromptsRedisKey(options.userId), dir: getUserPromptsDir(options.userId), scope: "user", allowMissing: true }));
+    const userId = options.userId.trim();
+    const userIds = await resolveStoredPrincipalReadKeysForWorker(userId);
+    configs.push(...await Promise.all(userIds.map((userId) => loadCachedPrompts({
+      redisKey: getUserPromptsRedisKey(userId),
+      dir: getUserPromptsDir(userId),
+      scope: "user",
+      allowMissing: true,
+    }))));
   }
   if (options.spaceId && config.spaceStorageRoot) {
     configs.push(await loadCachedPrompts({ redisKey: getProjectPromptsRedisKey(options.spaceId), dir: getProjectPromptsDir(options.spaceId), scope: "project", allowMissing: true }));

--- a/apps/worker/src/realtime-events.ts
+++ b/apps/worker/src/realtime-events.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { REALTIME_OUTBOUND_CHANNEL, type RealtimeTaskRecord } from "@cohub/protocol/realtime";
+import { getRealtimeUserRoom, REALTIME_OUTBOUND_CHANNEL, type RealtimeTaskRecord } from "@cohub/protocol/realtime";
 import type { TaskRunStatus } from "@cohub/protocol/task";
+import { getIdentityKeys } from "@cohub/identity";
 import { redisCommandClient } from "./redis.js";
+import { resolveStoredPrincipalIdentityForWorker } from "./identity-bridge.js";
 
 const toIsoOrNull = (value: Date | string | null | undefined) => {
   if (!value) return null;
@@ -56,6 +58,9 @@ async function publishTaskEvent(input: {
 }) {
   const task = toRealtimeTaskRecord(input.task);
   if (!task.spaceId && !task.userId) return;
+  const rooms = task.userId && !task.spaceId
+    ? getIdentityKeys(await resolveStoredPrincipalIdentityForWorker(task.userId)).map(getRealtimeUserRoom)
+    : undefined;
 
   await redisCommandClient.publish(
     REALTIME_OUTBOUND_CHANNEL,
@@ -66,6 +71,7 @@ async function publishTaskEvent(input: {
       type: input.type,
       spaceId: task.spaceId,
       sessionId: task.sessionId,
+      rooms,
       payload: {
         task,
         ...(input.changed ? { changed: input.changed } : {}),

--- a/apps/worker/src/session-services.ts
+++ b/apps/worker/src/session-services.ts
@@ -9,15 +9,22 @@ import { config } from "./config.js";
 import type { PromptTemplateService } from "./prompt-templates.js";
 import type { SkillService } from "./skills.js";
 import { dispatchLabelAssignmentsUpdated } from "./label-events.js";
+import { resolveBillingUserIdForStoredPrincipal, resolveStoredPrincipalIdentityForWorker } from "./identity-bridge.js";
 
 const AGENT_TURN_JOB_NAME = "agent_turns";
 
-const billingUsageGate = createBillingUsageGate({
+const legacyBillingUsageGate = createBillingUsageGate({
   operations: billingOperations,
   onEvaluationError: (error, gateInput) => {
     console.warn("[BillingGate] fail-open after worker prompt billing evaluation error", { error, gateInput });
   },
 });
+const billingUsageGate: ReturnType<typeof createBillingUsageGate> = {
+  async evaluate(input) {
+    const userId = await resolveBillingUserIdForStoredPrincipal(input.userId);
+    return legacyBillingUsageGate.evaluate({ ...input, userId });
+  },
+};
 
 const agentTurnQueue = createBullmqQueue<{
   spaceId: string;
@@ -42,8 +49,15 @@ export function getSessionDomainServices(input: {
     billingUsageGate,
     injectTrace,
     getRequestId: () => null,
-    onSessionParticipantsUpdated: async ({ spaceId, sessionId, userUuids }) => {
-      const affectedLabelIds = await assignSessionParticipantSystemLabels({ db, spaceId, sessionId, userUuids });
+    resolvePrincipalIdentity: async (userId) => {
+      const identity = await resolveStoredPrincipalIdentityForWorker(userId);
+      return {
+        uuid: identity.uuid,
+        aliases: identity.legacyUserUuid ? [identity.legacyUserUuid] : [],
+      };
+    },
+    onSessionParticipantsUpdated: async ({ spaceId, sessionId, userUuids, replacedUserUuids }) => {
+      const affectedLabelIds = await assignSessionParticipantSystemLabels({ db, spaceId, sessionId, userUuids, replacedUserUuids });
       await dispatchLabelAssignmentsUpdated({
         spaceId,
         resourceType: "session",

--- a/apps/worker/src/skills.ts
+++ b/apps/worker/src/skills.ts
@@ -27,6 +27,7 @@ import { join, resolve } from "node:path";
 import { config } from "./config.js";
 import { db } from "./db.js";
 import { redisCommandClient } from "./redis.js";
+import { resolveStoredPrincipalReadKeysForWorker } from "./identity-bridge.js";
 
 const logger = createLogger({ serviceName: "cohub-worker" });
 
@@ -231,13 +232,15 @@ async function fetchSkills(options: LoadSkillsOptions): Promise<Skill[]> {
   }
 
   if (options.userId) {
-    configs.push(await loadCachedSkills({
-      redisKey: getUserSkillsRedisKey(options.userId),
-      dir: getUserSkillsDir(options.userId),
+    const userId = options.userId.trim();
+    const userIds = await resolveStoredPrincipalReadKeysForWorker(userId);
+    configs.push(...await Promise.all(userIds.map((userId) => loadCachedSkills({
+      redisKey: getUserSkillsRedisKey(userId),
+      dir: getUserSkillsDir(userId),
       sandboxDir: SANDBOX_USER_SKILLS_PATH,
       scope: "user",
       allowMissing: true,
-    }));
+    }))));
   }
 
   if (options.spaceId && config.spaceStorageRoot) {

--- a/apps/worker/src/system/jobs/session-message-postprocess/index.ts
+++ b/apps/worker/src/system/jobs/session-message-postprocess/index.ts
@@ -12,6 +12,11 @@ import { createLogger } from "@cohub/infra/logging";
 import { db } from "../../../db.js";
 import { registerSystemJob } from "../../registry.js";
 import { resolveLlmRequestStats } from "./request-stats.js";
+import {
+  resolveBillingUserIdForStoredPrincipal,
+  resolveStoredPrincipalIdentityForWorker,
+} from "../../../identity-bridge.js";
+import { getIdentityKeys } from "@cohub/identity";
 
 const logger = createLogger({ serviceName: "cohub-worker" });
 
@@ -42,8 +47,9 @@ const recordBilling = async (message: typeof sessionMessages.$inferSelect, userI
     ? Number(amount.toFixed(8))
     : 0;
   if (amountUsd <= 0 || !billingOperations.status.configured) return;
+  const billingUserId = await resolveBillingUserIdForStoredPrincipal(userId);
   await billingOperations.recordUsage({
-    userId,
+    userId: billingUserId,
     amountUsd,
     tokenType: COHUB_BILLING_TOKEN_TYPES.usdMicroCent,
     usageType: COHUB_BILLING_USAGE_TYPES.generationLlm,
@@ -68,11 +74,14 @@ const maybeQualifyReferral = async (message: typeof sessionMessages.$inferSelect
   if (turn?.status !== "completed") return;
   const inviteeUserId = turn.userUuid?.trim() || actorUserId;
   if (!inviteeUserId) return;
+  const inviteeIdentity = await resolveStoredPrincipalIdentityForWorker(inviteeUserId);
 
   await qualifyAndRewardReferral({
     db,
     billing: billingOperations,
-    inviteeUserId,
+    resolveBillingUserId: resolveBillingUserIdForStoredPrincipal,
+    inviteeUserId: inviteeIdentity.uuid,
+    inviteeUserAliases: getIdentityKeys(inviteeIdentity),
     logger: {
       warn: (messageText, metaFields) => logger.warn(messageText, metaFields),
       info: (messageText, metaFields) => logger.info(messageText, metaFields),
@@ -178,12 +187,16 @@ registerSystemJob(SESSION_MESSAGE_POSTPROCESS_JOB, async (job: Job) => {
   if (!isLlmUsageMessage(message)) return { ok: true, skipped: "non_llm_usage" };
 
   const usage = normalizeUsage(message.usage);
-  const userId = await resolveActorUserId(message);
+  const storedUserId = await resolveActorUserId(message);
+  const userIdentity = storedUserId
+    ? await resolveStoredPrincipalIdentityForWorker(storedUserId)
+    : null;
+  const canonicalUserId = userIdentity?.uuid ?? null;
 
   // Idempotent external effects first; non-idempotent hourly aggregation must remain last.
-  await recordBilling(message, userId, usage);
+  await recordBilling(message, canonicalUserId, usage);
   await maybeQualifyReferral(message);
-  await aggregateUsage(message, spaceId, userId, usage);
+  await aggregateUsage(message, spaceId, canonicalUserId, usage);
 
   return { ok: true };
 });

--- a/apps/worker/src/system/referral-reward-retry.ts
+++ b/apps/worker/src/system/referral-reward-retry.ts
@@ -5,6 +5,7 @@ import {
 } from "@cohub/core/referrals";
 import { createLogger } from "@cohub/infra/logging";
 import { db } from "../db.js";
+import { resolveBillingUserIdForStoredPrincipal } from "../identity-bridge.js";
 
 const logger = createLogger({ serviceName: "cohub-worker" });
 
@@ -21,6 +22,7 @@ export function startSystemReferralRewardRetryLoop(intervalMs = 60_000) {
       retryQualifiedReferralRewards({
         db,
         billing: billingOperations,
+        resolveBillingUserId: resolveBillingUserIdForStoredPrincipal,
         logger: {
           info: (message, meta) => logger.info(message, meta),
           warn: (message, meta) => logger.warn(message, meta),

--- a/apps/worker/src/tasks/enqueue.ts
+++ b/apps/worker/src/tasks/enqueue.ts
@@ -5,6 +5,7 @@ import { createLogger } from "@cohub/infra/logging";
 import { config } from "../config.js";
 import { db } from "../db.js";
 import { dispatchTaskCreated } from "../realtime-events.js";
+import { resolveStoredPrincipalIdentityForWorker } from "../identity-bridge.js";
 
 const logger = createLogger({ serviceName: "cohub-worker" });
 
@@ -13,12 +14,18 @@ const taskQueue = createBullmqQueue(COHUB_TASKS_QUEUE, {
   telemetryServiceName: "cohub-worker",
 });
 
-export const enqueueTask = (payload: TaskPayload, options?: TaskEnqueueOptions) => enqueueTaskRun({
-  db,
-  payload,
-  options,
-  enqueue: (name, taskPayload, jobOptions) => taskQueue.add(name, taskPayload, jobOptions),
-  onTaskCreated: (taskRun) => dispatchTaskCreated(taskRun).catch((error) => {
-    logger.warn("[Realtime] failed to dispatch task.created", error);
-  }),
-});
+export const enqueueTask = async (payload: TaskPayload, options?: TaskEnqueueOptions) => {
+  const identity = payload.userId
+    ? await resolveStoredPrincipalIdentityForWorker(payload.userId)
+    : null;
+  const canonicalPayload = identity ? { ...payload, userId: identity.uuid } : payload;
+  return enqueueTaskRun({
+    db,
+    payload: canonicalPayload,
+    options,
+    enqueue: (name, taskPayload, jobOptions) => taskQueue.add(name, taskPayload, jobOptions),
+    onTaskCreated: (taskRun) => dispatchTaskCreated(taskRun).catch((error) => {
+      logger.warn("[Realtime] failed to dispatch task.created", error);
+    }),
+  });
+};

--- a/apps/worker/src/tasks/generation-billing-retry-task.ts
+++ b/apps/worker/src/tasks/generation-billing-retry-task.ts
@@ -8,6 +8,7 @@ import { GENERATION_BILLING_RETRY_TASK_TYPE } from "@cohub/protocol/generation";
 import type { TaskPayload } from "@cohub/protocol/task";
 import { parseGenerationBillingRetryData } from "./generation-billing-retry-data.js";
 import { registerTask } from "./registry.js";
+import { resolveBillingUserIdForStoredPrincipal } from "../identity-bridge.js";
 
 /**
  * Retry post-success generation charging. Safe to re-run: recordUsage is
@@ -24,8 +25,9 @@ registerTask(GENERATION_BILLING_RETRY_TASK_TYPE, async (job: Job) => {
     return { status: "skipped", reason: "billing_not_configured", taskRunId: data.taskRunId };
   }
 
+  const billingUserId = await resolveBillingUserIdForStoredPrincipal(data.userId);
   const result = await billingOperations.recordUsage({
-    userId: data.userId,
+    userId: billingUserId,
     amountUsd,
     tokenType: COHUB_BILLING_TOKEN_TYPES.usdMicroCent,
     usageType: data.usageType as CohubBillingUsageType,

--- a/apps/worker/src/tasks/generation-task.ts
+++ b/apps/worker/src/tasks/generation-task.ts
@@ -35,6 +35,9 @@ import { recordGenerationUsageStatsHourly } from "../generation-usage-stats.js";
 import { redisCommandClient } from "../redis.js";
 import { enqueueTask } from "./enqueue.js";
 import { registerTask } from "./registry.js";
+import { resolveBillingUserIdForStoredPrincipal } from "../identity-bridge.js";
+import { resolveStoredPrincipalIdentityForWorker } from "../identity-bridge.js";
+import { getIdentityKeys } from "@cohub/identity";
 
 const loader = createGenerationDeclarationLoader({
   platformConfigRoot: config.platformConfigRoot,
@@ -242,6 +245,7 @@ async function enqueueGenerationBillingRetry(input: {
 
 async function recordGenerationUsageBilling(input: {
   userId: string;
+  billingUserId: string;
   taskRunId: string;
   model: string;
   adapterType: string | null | undefined;
@@ -275,7 +279,7 @@ async function recordGenerationUsageBilling(input: {
 
   try {
     const result = await billingOperations.recordUsage({
-      userId: input.userId,
+      userId: input.billingUserId,
       amountUsd,
       tokenType: COHUB_BILLING_TOKEN_TYPES.usdMicroCent,
       usageType: input.usageType,
@@ -360,13 +364,15 @@ registerTask(GENERATION_TASK_TYPE, async (job: Job, context) => {
   });
 
   try {
-    const declaration = await loader.loadGenerationDeclaration(userId, data.model);
+    const userIdentity = await resolveStoredPrincipalIdentityForWorker(userId);
+    const declaration = await loader.loadGenerationDeclaration(userIdentity.uuid, data.model, getIdentityKeys(userIdentity));
     if (!declaration) throw new Error(`Generation model is unavailable: ${data.model}`);
+    const billingUserId = await resolveBillingUserIdForStoredPrincipal(userId);
 
     // Re-read authoritative entitlements before trusting a queued snapshot. This
     // binds discounts to the task user/model and keeps old API payloads safe.
     const resolvedDiscount = await billingOperations.getGenerationModelDiscount({
-      userId,
+      userId: billingUserId,
       model: data.model,
     });
     const modelDiscount = reconcileGenerationModelDiscountSnapshot({
@@ -394,7 +400,7 @@ registerTask(GENERATION_TASK_TYPE, async (job: Job, context) => {
     const billingDecision = isGenerationModelDiscountFree(modelDiscount)
       ? { status: "allowed" as const, balanceState: "zero" as const, netUsd: 0 }
       : await billingUsageGate.evaluate({
-          userId,
+          userId: billingUserId,
           usageKind: generationUsageKind(gateUsageType),
           source: "generation_task",
           model: data.model,
@@ -424,6 +430,7 @@ registerTask(GENERATION_TASK_TYPE, async (job: Job, context) => {
     });
     const billing = await recordGenerationUsageBilling({
       userId,
+      billingUserId,
       taskRunId,
       model: data.model,
       adapterType: declaration.adapter?.type,

--- a/apps/worker/src/tasks/registry.ts
+++ b/apps/worker/src/tasks/registry.ts
@@ -7,6 +7,7 @@ import { db } from "../db.js";
 import { taskRuns } from "@cohub/db";
 import { dispatchTaskCreated, dispatchTaskUpdated } from "../realtime-events.js";
 import { createLogger } from "@cohub/infra/logging";
+import { resolveStoredPrincipalIdentityForWorker } from "../identity-bridge.js";
 
 
 const logger = createLogger({ serviceName: "cohub-worker" });
@@ -66,7 +67,14 @@ export const registerTask = (type: string, handler: TaskHandler) => {
     const jobId = job.id;
     if (!jobId) throw new Error("Job has no id");
 
-    const payload = job.data as TaskPayload;
+    const rawPayload = job.data as TaskPayload;
+    const identity = rawPayload.userId
+      ? await resolveStoredPrincipalIdentityForWorker(rawPayload.userId)
+      : null;
+    const payload = identity
+      ? { ...rawPayload, userId: identity.uuid }
+      : rawPayload;
+    if (payload !== rawPayload) job.data = payload;
     const now = new Date();
 
     // UPSERT: insert if cron-spawned, or update pending → running

--- a/apps/worker/src/tasks/save-checkpoint-task.ts
+++ b/apps/worker/src/tasks/save-checkpoint-task.ts
@@ -16,6 +16,7 @@ import { getPromptsDir, publishPromptsCacheFromDir } from "../prompts-cache.js";
 import { getSkillsDir, publishSkillsCacheFromDir } from "../skills-cache.js";
 import { publishSpaceEvent } from "../space-events.js";
 import { uploadAssetIfMissing } from "../checkpoint/assets.js";
+import { resolveStoredPrincipalIdentityForWorker } from "../identity-bridge.js";
 import {
   buildStagedDiffSummary,
   materializeDiffMeta,
@@ -301,11 +302,12 @@ export const saveCheckpointForSpace = async (input: SaveCheckpointInput): Promis
 
   let publishedUserConfig: { targetDir: string; copiedPaths: string[]; meta: Record<string, unknown> } | null = null;
   if (space.name === "config") {
-    publishedUserConfig = await timeIt(timings, "publishUserConfig", () => publishUserConfigFromWorkspace({ userId: space.userUuid, spaceId: space.id, checkpointId: checkpoint.id, workspaceDir: dirs.latestDir }));
-    await publishModelsCacheFromFile({ modelsPath: join(publishedUserConfig.targetDir, ".cohub", "models.json"), scope: "user", userId: space.userUuid, sourceCheckpointId: checkpoint.id }).catch((error) => recordPublishWarning({ scope: "user", target: "models_cache", message: formatErrorMessage(error) }, error));
-    await publishGenerationsCacheFromDir({ generationsDir: getGenerationsDir(publishedUserConfig.targetDir), scope: "user", userId: space.userUuid, sourceCheckpointId: checkpoint.id }).catch((error) => recordPublishWarning({ scope: "user", target: "generations_cache", message: formatErrorMessage(error) }, error));
-    await publishPromptsCacheFromDir({ promptsDir: getPromptsDir(publishedUserConfig.targetDir), scope: "user", userId: space.userUuid, sourceCheckpointId: checkpoint.id }).catch((error) => recordPublishWarning({ scope: "user", target: "prompts_cache", message: formatErrorMessage(error) }, error));
-    await publishSkillsCacheFromDir({ skillsDir: getSkillsDir(publishedUserConfig.targetDir), scope: "user", userId: space.userUuid, sourceCheckpointId: checkpoint.id, sandboxDir: "/configs/user/.agents/skills" }).catch((error) => recordPublishWarning({ scope: "user", target: "skills_cache", message: formatErrorMessage(error) }, error));
+    const configOwnerUserId = (await resolveStoredPrincipalIdentityForWorker(space.userUuid)).uuid;
+    publishedUserConfig = await timeIt(timings, "publishUserConfig", () => publishUserConfigFromWorkspace({ userId: configOwnerUserId, spaceId: space.id, checkpointId: checkpoint.id, workspaceDir: dirs.latestDir }));
+    await publishModelsCacheFromFile({ modelsPath: join(publishedUserConfig.targetDir, ".cohub", "models.json"), scope: "user", userId: configOwnerUserId, sourceCheckpointId: checkpoint.id }).catch((error) => recordPublishWarning({ scope: "user", target: "models_cache", message: formatErrorMessage(error) }, error));
+    await publishGenerationsCacheFromDir({ generationsDir: getGenerationsDir(publishedUserConfig.targetDir), scope: "user", userId: configOwnerUserId, sourceCheckpointId: checkpoint.id }).catch((error) => recordPublishWarning({ scope: "user", target: "generations_cache", message: formatErrorMessage(error) }, error));
+    await publishPromptsCacheFromDir({ promptsDir: getPromptsDir(publishedUserConfig.targetDir), scope: "user", userId: configOwnerUserId, sourceCheckpointId: checkpoint.id }).catch((error) => recordPublishWarning({ scope: "user", target: "prompts_cache", message: formatErrorMessage(error) }, error));
+    await publishSkillsCacheFromDir({ skillsDir: getSkillsDir(publishedUserConfig.targetDir), scope: "user", userId: configOwnerUserId, sourceCheckpointId: checkpoint.id, sandboxDir: "/configs/user/.agents/skills" }).catch((error) => recordPublishWarning({ scope: "user", target: "skills_cache", message: formatErrorMessage(error) }, error));
   }
 
   let publishedPlatformConfig: { targetDir: string; copiedPaths: string[]; meta: Record<string, unknown> } | null = null;

--- a/apps/worker/src/tasks/send-message-task.ts
+++ b/apps/worker/src/tasks/send-message-task.ts
@@ -12,6 +12,7 @@ import { getSessionDomainServices } from "../session-services.js";
 import { createLogger } from "@cohub/infra/logging";
 import { db } from "../db.js";
 import { dispatchLabelAssignmentsUpdated } from "../label-events.js";
+import { resolveStoredPrincipalIdentityForWorker } from "../identity-bridge.js";
 
 const MAX_TASK_SOURCE_LENGTH = 255;
 
@@ -29,11 +30,12 @@ const sessionPromptService = getSessionDomainServices({
   skillService: getSkillService(),
 });
 
-function sanitizeTaskPromptAuth(auth: PromptAuthContext | null | undefined, input: { spaceId: string; userId: string }) {
+async function sanitizeTaskPromptAuth(auth: PromptAuthContext | null | undefined, input: { spaceId: string; userId: string }) {
   if (auth?.type !== "delegated_prompt" || auth.spaceId !== input.spaceId) return null;
-  if (auth.actorUserId !== input.userId) return null;
+  const actor = await resolveStoredPrincipalIdentityForWorker(auth.actorUserId).catch(() => null);
+  if (!actor || actor.uuid !== input.userId) return null;
   if (getPromptAuthScopes(auth, input.spaceId).length === 0) return null;
-  return auth;
+  return { ...auth, actorUserId: actor.uuid };
 }
 
 const sendMessageHandler = async (job: import("bullmq").Job, context?: { taskRunId: string }) => {
@@ -104,7 +106,7 @@ const sendMessageHandler = async (job: import("bullmq").Job, context?: { taskRun
       kind: "scheduled_task",
       taskRunId,
       cronJobId: payload.cronJobId ?? null,
-      auth: sanitizeTaskPromptAuth(auth ?? null, { spaceId, userId }),
+      auth: await sanitizeTaskPromptAuth(auth ?? null, { spaceId, userId }),
     } satisfies SubmitSessionPromptContext,
   });
 

--- a/packages/core/src/labels/session-user.ts
+++ b/packages/core/src/labels/session-user.ts
@@ -7,6 +7,7 @@ export type SessionUserLabelInput = {
   spaceId: string;
   sessionId: string;
   userUuids: Array<string | null | undefined>;
+  replacedUserUuids?: Array<string | null | undefined>;
   userId?: string | null;
 };
 
@@ -153,6 +154,28 @@ async function getOrCreateSystemLabel(db: PostgresJsDatabase<Record<string, unkn
 export async function assignSessionParticipantSystemLabels(input: SessionUserLabelInput) {
   const userUuids = normalizeUserUuids(input.userUuids);
   if (userUuids.length === 0) return [];
+  const replacedUserUuids = normalizeUserUuids(input.replacedUserUuids ?? [])
+    .filter((userUuid) => !userUuids.includes(userUuid));
+
+  const replacedLabels = replacedUserUuids.length > 0
+    ? await input.db
+      .select({ id: labels.id })
+      .from(labels)
+      .where(and(
+        eq(labels.scopeType, SCOPE_TYPE),
+        eq(labels.scopeId, input.spaceId),
+        inArray(labels.systemKey, replacedUserUuids.map(getSessionUserLabelSystemKey)),
+      ))
+    : [];
+  if (replacedLabels.length > 0) {
+    await input.db.delete(labelAssignments).where(and(
+      eq(labelAssignments.scopeType, SCOPE_TYPE),
+      eq(labelAssignments.scopeId, input.spaceId),
+      eq(labelAssignments.resourceType, "session"),
+      eq(labelAssignments.resourceRef, input.sessionId),
+      inArray(labelAssignments.labelId, replacedLabels.map((label) => label.id)),
+    ));
+  }
 
   const rootLabel = await getOrCreateSystemLabel(input.db, {
     spaceId: input.spaceId,
@@ -201,5 +224,5 @@ export async function assignSessionParticipantSystemLabels(input: SessionUserLab
     }));
 
   if (rows.length > 0) await input.db.insert(labelAssignments).values(rows).onConflictDoNothing();
-  return labelIds;
+  return [...new Set([...labelIds, ...replacedLabels.map((label) => label.id)])];
 }

--- a/packages/core/src/labels/user-labels.ts
+++ b/packages/core/src/labels/user-labels.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, max, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, max, sql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { labelAssignments, labels } from "@cohub/db";
 import type { LabelResourceType } from "./resource-events.js";
@@ -13,6 +13,16 @@ import type { LabelResourceType } from "./resource-events.js";
  */
 
 type LabelsDb = PostgresJsDatabase<Record<string, unknown>>;
+export type UserLabelIdentity = string | { uuid: string; aliases?: readonly string[] };
+
+const userLabelIdentity = (identity: UserLabelIdentity) => {
+  const uuid = (typeof identity === "string" ? identity : identity.uuid).trim();
+  const aliases = typeof identity === "string" ? [] : identity.aliases ?? [];
+  return {
+    uuid,
+    keys: [...new Set([uuid, ...aliases].map((value) => value.trim()).filter(Boolean))],
+  };
+};
 
 export type UserLabelAssignment = typeof labelAssignments.$inferSelect & {
   labelSystemKey: string | null;
@@ -45,103 +55,105 @@ export function slugifyLabelName(name: string) {
   return slug || "label";
 }
 
-async function findUserLabelByName(db: LabelsDb, userUuid: string, name: string) {
-  const [row] = await db
+async function findUserLabelByName(db: LabelsDb, identity: UserLabelIdentity, name: string) {
+  const rows = await db
     .select()
     .from(labels)
     .where(and(
       eq(labels.scopeType, USER_LABEL_SCOPE_TYPE),
-      eq(labels.scopeId, userUuid),
+      inArray(labels.scopeId, userLabelIdentity(identity).keys),
       sql`lower(${labels.name}) = lower(${name})`,
     ))
-    .limit(1);
-  return row ?? null;
+  if (rows.length > 1) throw new Error("user label identity conflict requires repair");
+  return rows[0] ?? null;
 }
 
-async function findUserLabelBySystemKey(db: LabelsDb, userUuid: string, systemKey: string) {
-  const [row] = await db
+async function findUserLabelBySystemKey(db: LabelsDb, identity: UserLabelIdentity, systemKey: string) {
+  const rows = await db
     .select()
     .from(labels)
     .where(and(
       eq(labels.scopeType, USER_LABEL_SCOPE_TYPE),
-      eq(labels.scopeId, userUuid),
+      inArray(labels.scopeId, userLabelIdentity(identity).keys),
       eq(labels.systemKey, systemKey),
     ))
-    .limit(1);
-  return row ?? null;
+  if (rows.length > 1) throw new Error("user label identity conflict requires repair");
+  return rows[0] ?? null;
 }
 
-async function nextUserLabelRank(db: LabelsDb, userUuid: string) {
+async function nextUserLabelRank(db: LabelsDb, identity: UserLabelIdentity) {
   const [{ value } = { value: 0 }] = await db
     .select({ value: max(labels.rank) })
     .from(labels)
-    .where(and(eq(labels.scopeType, USER_LABEL_SCOPE_TYPE), eq(labels.scopeId, userUuid)));
+    .where(and(eq(labels.scopeType, USER_LABEL_SCOPE_TYPE), inArray(labels.scopeId, userLabelIdentity(identity).keys)));
   return Number(value ?? 0) + 10;
 }
 
 /** Get-or-create the user's built-in "Pinned" system label. */
-export async function ensurePinnedLabel(db: LabelsDb, userUuid: string) {
-  const existing = await findUserLabelBySystemKey(db, userUuid, PINNED_LABEL_SYSTEM_KEY);
+export async function ensurePinnedLabel(db: LabelsDb, identity: UserLabelIdentity) {
+  const { uuid } = userLabelIdentity(identity);
+  const existing = await findUserLabelBySystemKey(db, identity, PINNED_LABEL_SYSTEM_KEY);
   if (existing) return existing;
 
   const [created] = await db.insert(labels).values({
     scopeType: USER_LABEL_SCOPE_TYPE,
-    scopeId: userUuid,
+    scopeId: uuid,
     name: PINNED_LABEL_NAME,
     slug: slugifyLabelName(PINNED_LABEL_NAME),
     parentId: null,
     depth: 0,
-    rank: await nextUserLabelRank(db, userUuid),
+    rank: await nextUserLabelRank(db, identity),
     source: "system",
     systemKey: PINNED_LABEL_SYSTEM_KEY,
-    createdBy: userUuid,
+    createdBy: uuid,
   }).onConflictDoNothing().returning();
   if (created) return created;
 
-  const raced = await findUserLabelBySystemKey(db, userUuid, PINNED_LABEL_SYSTEM_KEY);
+  const raced = await findUserLabelBySystemKey(db, identity, PINNED_LABEL_SYSTEM_KEY);
   if (!raced) throw new Error("failed to create pinned label");
   return raced;
 }
 
 /** Resolve a label ref (name) to an existing user-scope label, or null. */
-export async function resolveUserLabelRef(db: LabelsDb, userUuid: string, labelRef: string) {
+export async function resolveUserLabelRef(db: LabelsDb, identity: UserLabelIdentity, labelRef: string) {
   const name = normalizeLabelName(labelRef);
   if (RESERVED_SYSTEM_ROOT_LABELS.has(name.toLowerCase())) {
-    return ensurePinnedLabel(db, userUuid);
+    return ensurePinnedLabel(db, identity);
   }
-  return findUserLabelByName(db, userUuid, name);
+  return findUserLabelByName(db, identity, name);
 }
 
 /** Resolve or create user-scope labels by ref (name). */
-export async function resolveOrCreateUserLabelRefs(db: LabelsDb, userUuid: string, labelRefs: string[]) {
+export async function resolveOrCreateUserLabelRefs(db: LabelsDb, identity: UserLabelIdentity, labelRefs: string[]) {
+  const { uuid } = userLabelIdentity(identity);
   const refs = [...new Set(labelRefs.map((ref) => ref.trim()).filter(Boolean))];
   const labelIds: string[] = [];
   for (const ref of refs) {
     const name = normalizeLabelName(ref);
     if (RESERVED_SYSTEM_ROOT_LABELS.has(name.toLowerCase())) {
-      labelIds.push((await ensurePinnedLabel(db, userUuid)).id);
+      labelIds.push((await ensurePinnedLabel(db, identity)).id);
       continue;
     }
-    const existing = await findUserLabelByName(db, userUuid, name);
+    const existing = await findUserLabelByName(db, identity, name);
     if (existing) {
       labelIds.push(existing.id);
       continue;
     }
     const [created] = await db.insert(labels).values({
       scopeType: USER_LABEL_SCOPE_TYPE,
-      scopeId: userUuid,
+      scopeId: uuid,
       name,
       slug: slugifyLabelName(name),
       parentId: null,
       depth: 0,
-      rank: await nextUserLabelRank(db, userUuid),
+      rank: await nextUserLabelRank(db, identity),
       source: "user",
-      createdBy: userUuid,
+      createdBy: uuid,
     }).onConflictDoNothing().returning();
     if (created) {
       labelIds.push(created.id);
     } else {
-      const raced = await findUserLabelByName(db, userUuid, name);
+      const raced = await findUserLabelByName(db, identity, name);
       if (raced) labelIds.push(raced.id);
     }
   }
@@ -149,23 +161,23 @@ export async function resolveOrCreateUserLabelRefs(db: LabelsDb, userUuid: strin
 }
 
 /** List all labels under the user's scope. */
-export async function listUserLabels(db: LabelsDb, userUuid: string) {
+export async function listUserLabels(db: LabelsDb, identity: UserLabelIdentity) {
   return db
     .select()
     .from(labels)
-    .where(and(eq(labels.scopeType, USER_LABEL_SCOPE_TYPE), eq(labels.scopeId, userUuid)))
+    .where(and(eq(labels.scopeType, USER_LABEL_SCOPE_TYPE), inArray(labels.scopeId, userLabelIdentity(identity).keys)))
     .orderBy(asc(labels.rank), asc(labels.name));
 }
 
 /** Get the set of spaceIds the user has pinned. */
-export async function getPinnedSpaceIds(db: LabelsDb, userUuid: string): Promise<Set<string>> {
-  const label = await ensurePinnedLabel(db, userUuid);
+export async function getPinnedSpaceIds(db: LabelsDb, identity: UserLabelIdentity): Promise<Set<string>> {
+  const label = await ensurePinnedLabel(db, identity);
   const rows = await db
     .select({ resourceRef: labelAssignments.resourceRef })
     .from(labelAssignments)
     .where(and(
       eq(labelAssignments.scopeType, USER_LABEL_SCOPE_TYPE),
-      eq(labelAssignments.scopeId, userUuid),
+      inArray(labelAssignments.scopeId, userLabelIdentity(identity).keys),
       eq(labelAssignments.labelId, label.id),
       eq(labelAssignments.resourceType, "space"),
     ));
@@ -173,7 +185,8 @@ export async function getPinnedSpaceIds(db: LabelsDb, userUuid: string): Promise
 }
 
 /** Attach a label to a resource (idempotent). */
-export async function attachUserLabel(db: LabelsDb, userUuid: string, labelId: string, resourceType: LabelResourceType, resourceRef: string) {
+export async function attachUserLabel(db: LabelsDb, identity: UserLabelIdentity, labelId: string, resourceType: LabelResourceType, resourceRef: string) {
+  const { uuid, keys } = userLabelIdentity(identity);
   const [{ value: maxRank } = { value: 0 }] = await db
     .select({ value: max(labelAssignments.rank) })
     .from(labelAssignments)
@@ -181,12 +194,12 @@ export async function attachUserLabel(db: LabelsDb, userUuid: string, labelId: s
   const [assignment] = await db.insert(labelAssignments).values({
     labelId,
     scopeType: USER_LABEL_SCOPE_TYPE,
-    scopeId: userUuid,
+    scopeId: uuid,
     resourceType,
     resourceRef,
     rank: Number(maxRank ?? 0) + 10,
     source: "user",
-    createdBy: userUuid,
+    createdBy: uuid,
   }).onConflictDoNothing().returning();
   if (assignment) return assignment;
   const [existing] = await db
@@ -194,6 +207,8 @@ export async function attachUserLabel(db: LabelsDb, userUuid: string, labelId: s
     .from(labelAssignments)
     .where(and(
       eq(labelAssignments.labelId, labelId),
+      eq(labelAssignments.scopeType, USER_LABEL_SCOPE_TYPE),
+      inArray(labelAssignments.scopeId, keys),
       eq(labelAssignments.resourceType, resourceType),
       eq(labelAssignments.resourceRef, resourceRef),
     ))
@@ -202,18 +217,18 @@ export async function attachUserLabel(db: LabelsDb, userUuid: string, labelId: s
 }
 
 /** Detach a label from a resource (idempotent). */
-export async function detachUserLabel(db: LabelsDb, userUuid: string, labelId: string, resourceType: LabelResourceType, resourceRef: string) {
+export async function detachUserLabel(db: LabelsDb, identity: UserLabelIdentity, labelId: string, resourceType: LabelResourceType, resourceRef: string) {
   await db.delete(labelAssignments).where(and(
     eq(labelAssignments.labelId, labelId),
     eq(labelAssignments.scopeType, USER_LABEL_SCOPE_TYPE),
-    eq(labelAssignments.scopeId, userUuid),
+    inArray(labelAssignments.scopeId, userLabelIdentity(identity).keys),
     eq(labelAssignments.resourceType, resourceType),
     eq(labelAssignments.resourceRef, resourceRef),
   ));
 }
 
 /** Get all label assignments for a resource under user scope, with label metadata. */
-export async function getUserResourceLabelAssignments(db: LabelsDb, userUuid: string, resourceType: LabelResourceType, resourceRef: string): Promise<UserLabelAssignment[]> {
+export async function getUserResourceLabelAssignments(db: LabelsDb, identity: UserLabelIdentity, resourceType: LabelResourceType, resourceRef: string): Promise<UserLabelAssignment[]> {
   const rows = await db
     .select({
       assignment: labelAssignments,
@@ -224,7 +239,7 @@ export async function getUserResourceLabelAssignments(db: LabelsDb, userUuid: st
     .innerJoin(labels, eq(labels.id, labelAssignments.labelId))
     .where(and(
       eq(labelAssignments.scopeType, USER_LABEL_SCOPE_TYPE),
-      eq(labelAssignments.scopeId, userUuid),
+      inArray(labelAssignments.scopeId, userLabelIdentity(identity).keys),
       eq(labelAssignments.resourceType, resourceType),
       eq(labelAssignments.resourceRef, resourceRef),
     ))
@@ -233,24 +248,24 @@ export async function getUserResourceLabelAssignments(db: LabelsDb, userUuid: st
 }
 
 /** Patch a resource's user-scope labels by ref (add/remove). */
-export async function patchUserResourceLabels(db: LabelsDb, userUuid: string, resourceType: LabelResourceType, resourceRef: string, input: {
+export async function patchUserResourceLabels(db: LabelsDb, identity: UserLabelIdentity, resourceType: LabelResourceType, resourceRef: string, input: {
   addLabelRefs?: string[];
   removeLabelRefs?: string[];
 }) {
   const [addLabelIds, removeLabels] = await Promise.all([
     input.addLabelRefs?.length
-      ? resolveOrCreateUserLabelRefs(db, userUuid, input.addLabelRefs)
+      ? resolveOrCreateUserLabelRefs(db, identity, input.addLabelRefs)
       : Promise.resolve([]),
     input.removeLabelRefs?.length
-      ? Promise.all(input.removeLabelRefs.map((ref) => resolveUserLabelRef(db, userUuid, ref)))
+      ? Promise.all(input.removeLabelRefs.map((ref) => resolveUserLabelRef(db, identity, ref)))
       : Promise.resolve([]),
   ]);
 
   for (const labelId of addLabelIds) {
-    if (labelId) await attachUserLabel(db, userUuid, labelId, resourceType, resourceRef);
+    if (labelId) await attachUserLabel(db, identity, labelId, resourceType, resourceRef);
   }
   for (const label of removeLabels) {
-    if (label) await detachUserLabel(db, userUuid, label.id, resourceType, resourceRef);
+    if (label) await detachUserLabel(db, identity, label.id, resourceType, resourceRef);
   }
-  return getUserResourceLabelAssignments(db, userUuid, resourceType, resourceRef);
+  return getUserResourceLabelAssignments(db, identity, resourceType, resourceRef);
 }

--- a/packages/core/src/permissions/index.ts
+++ b/packages/core/src/permissions/index.ts
@@ -56,6 +56,17 @@ export type Permission = typeof ALL_PERMISSIONS[number];
 
 export type PermissionSubject = {
   uuid?: string | null;
+  legacyUserUuid?: string | null;
+  aliases?: readonly string[];
+};
+
+const subjectKeys = (user: PermissionSubject | null): string[] => {
+  if (!user) return [];
+  return [...new Set([
+    user.uuid,
+    user.legacyUserUuid,
+    ...(user.aliases ?? []),
+  ].filter((value): value is string => typeof value === "string" && Boolean(value.trim())).map((value) => value.trim()))];
 };
 
 export type AccessPolicy = {
@@ -180,8 +191,8 @@ export async function resolvePermissionAccess(input: {
   user: PermissionSubject | null;
   context: { spaceId: string; sessionId?: string };
 }): Promise<PermissionAccess> {
-  if (input.user?.uuid) {
-    const memberRole = await input.store.getSpaceMemberRole(input.context.spaceId, input.user.uuid);
+  for (const key of subjectKeys(input.user)) {
+    const memberRole = await input.store.getSpaceMemberRole(input.context.spaceId, key);
     if (memberRole) {
       return {
         role: memberRole,
@@ -230,8 +241,8 @@ export async function hasPermission(input: {
   permission: Permission;
   context: { spaceId: string; sessionId?: string };
 }): Promise<boolean> {
-  if (input.user?.uuid) {
-    const memberRole = await input.store.getSpaceMemberRole(input.context.spaceId, input.user.uuid);
+  for (const key of subjectKeys(input.user)) {
+    const memberRole = await input.store.getSpaceMemberRole(input.context.spaceId, key);
     if (memberRole) return roleHasPermission(memberRole, input.permission);
   }
 
@@ -266,7 +277,7 @@ export async function filterSessionsByPermission<TSession extends SpaceSessionLi
 }): Promise<TSession[]> {
   if (input.sessions.length === 0) return [];
 
-  if (input.user?.uuid && (await input.store.getSpaceMemberRole(input.spaceId, input.user.uuid)) !== null) {
+  if ((await Promise.all(subjectKeys(input.user).map((key) => input.store.getSpaceMemberRole(input.spaceId, key)))).some((role) => role !== null)) {
     throw new Error(
       "filterSessionsByPermission must not be called for space members. " +
       "Use space-level permission checks instead.",
@@ -344,7 +355,7 @@ export function createBatchDrizzlePermissionStore(db: DrizzlePermissionDb): Perm
     ...store,
     async filterSessionsByPermission<TSession extends SpaceSessionLike>(input: Omit<Parameters<typeof filterSessionsByPermission<TSession>>[0], "store">) {
       if (input.sessions.length === 0) return [];
-      if (input.user?.uuid && (await store.getSpaceMemberRole(input.spaceId, input.user.uuid)) !== null) {
+      if ((await Promise.all(subjectKeys(input.user).map((key) => store.getSpaceMemberRole(input.spaceId, key)))).some((role) => role !== null)) {
         throw new Error(
           "filterSessionsByPermission must not be called for space members. " +
           "Use space-level permission checks instead.",
@@ -379,12 +390,12 @@ export function createBatchDrizzlePermissionStore(db: DrizzlePermissionDb): Perm
       const allowed = new Set<string>();
       const memberSpaceIds = new Set<string>();
 
-      if (input.user?.uuid) {
+      if (subjectKeys(input.user).length > 0) {
         const members = await queryDb
           .select({ spaceId: spaceMembers.spaceId, role: spaceMembers.role })
           .from(spaceMembers)
           .where(
-            and(eq(spaceMembers.userId, input.user.uuid), inArray(spaceMembers.spaceId, unique)),
+            and(inArray(spaceMembers.userId, subjectKeys(input.user)), inArray(spaceMembers.spaceId, unique)),
           );
         for (const member of members) {
           memberSpaceIds.add(member.spaceId);

--- a/packages/core/src/referrals/reward.ts
+++ b/packages/core/src/referrals/reward.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import type { BillingOperations } from "@cohub/billing";
 import { referrals, type ReferralStatus } from "@cohub/db";
-import { and, eq, isNull, lt, or, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 export const REFERRAL_REWARD_LEASE_MS = 5 * 60_000;
@@ -21,14 +21,17 @@ export type RewardQualifiedReferralInput = {
   referral: ReferralRow;
   logger?: ReferralRewardLogger;
   leaseMs?: number;
+  resolveBillingUserId?: (userId: string) => Promise<string>;
 };
 
 export type QualifyAndRewardReferralInput = {
   db: ReferralsDb;
   billing: Pick<BillingOperations, "status" | "grantReferralReward">;
   inviteeUserId: string;
+  inviteeUserAliases?: readonly string[];
   logger?: ReferralRewardLogger;
   leaseMs?: number;
+  resolveBillingUserId?: (userId: string) => Promise<string>;
 };
 
 export type RetryQualifiedReferralRewardsInput = {
@@ -38,18 +41,19 @@ export type RetryQualifiedReferralRewardsInput = {
   cooldownMs?: number;
   logger?: ReferralRewardLogger;
   leaseMs?: number;
+  resolveBillingUserId?: (userId: string) => Promise<string>;
 };
 
 const rewardErrorMessage = (side: "inviter" | "invitee", error: unknown) =>
   `${side}: ${error instanceof Error ? error.message : String(error)}`;
 
-async function loadReferralByInvitee(db: ReferralsDb, inviteeUserId: string) {
-  const [row] = await db
+async function loadReferralByInvitee(db: ReferralsDb, inviteeUserIds: readonly string[]) {
+  const rows = await db
     .select()
     .from(referrals)
-    .where(eq(referrals.inviteeUserId, inviteeUserId))
-    .limit(1);
-  return row ?? null;
+    .where(inArray(referrals.inviteeUserId, [...new Set(inviteeUserIds)]));
+  if (rows.length > 1) throw new Error("referral identity conflict requires repair");
+  return rows[0] ?? null;
 }
 
 async function loadReferralById(db: ReferralsDb, referralId: string) {
@@ -67,9 +71,13 @@ async function grantReferralSide(input: {
   userId: string;
   side: "inviter" | "invitee";
   expectedAmountUsd: number;
+  resolveBillingUserId?: (userId: string) => Promise<string>;
 }) {
+  const userId = input.resolveBillingUserId
+    ? await input.resolveBillingUserId(input.userId)
+    : input.userId;
   return input.billing.grantReferralReward({
-    userId: input.userId,
+    userId,
     referralId: input.referralId,
     side: input.side,
     expectedAmountUsd: input.expectedAmountUsd,
@@ -135,6 +143,7 @@ export async function rewardQualifiedReferral(
         userId: current.inviteeUserId,
         side: "invitee",
         expectedAmountUsd: Number(current.inviteeRewardAmountUsd),
+        resolveBillingUserId: input.resolveBillingUserId,
       });
       const rewardedAt = new Date();
       if (result.amountUsd !== Number(current.inviteeRewardAmountUsd)) {
@@ -174,6 +183,7 @@ export async function rewardQualifiedReferral(
         userId: afterInvitee.inviterUserId,
         side: "inviter",
         expectedAmountUsd: Number(afterInvitee.inviterRewardAmountUsd),
+        resolveBillingUserId: input.resolveBillingUserId,
       });
       const rewardedAt = new Date();
       if (result.amountUsd !== Number(afterInvitee.inviterRewardAmountUsd)) {
@@ -270,12 +280,17 @@ export async function qualifyAndRewardReferral(
   input: QualifyAndRewardReferralInput,
 ): Promise<ReferralRow | null> {
   const { db, inviteeUserId } = input;
+  const inviteeUserIds = [...new Set([inviteeUserId, ...(input.inviteeUserAliases ?? [])])];
+  const existing = await loadReferralByInvitee(db, inviteeUserIds);
+  if (!existing) return null;
   const qualifiedAt = new Date();
-  const [qualified] = await db
-    .update(referrals)
-    .set({ status: "qualified", qualifiedAt, updatedAt: qualifiedAt })
-    .where(and(eq(referrals.inviteeUserId, inviteeUserId), eq(referrals.status, "pending")))
-    .returning();
+  const [qualified] = existing.status === "pending"
+    ? await db
+      .update(referrals)
+      .set({ status: "qualified", qualifiedAt, updatedAt: qualifiedAt })
+      .where(and(eq(referrals.id, existing.id), eq(referrals.status, "pending")))
+      .returning()
+    : [];
 
   if (qualified) {
     return rewardQualifiedReferral({
@@ -284,18 +299,20 @@ export async function qualifyAndRewardReferral(
       referral: qualified,
       logger: input.logger,
       leaseMs: input.leaseMs,
+      resolveBillingUserId: input.resolveBillingUserId,
     });
   }
 
   // Already qualified (or rewarded) — still try to finish incomplete grants.
-  const existing = await loadReferralByInvitee(db, inviteeUserId);
-  if (existing?.status !== "qualified") return existing;
+  const current = qualified ?? await loadReferralByInvitee(db, inviteeUserIds);
+  if (current?.status !== "qualified") return current;
   return rewardQualifiedReferral({
     db,
     billing: input.billing,
-    referral: existing,
+    referral: current,
     logger: input.logger,
     leaseMs: input.leaseMs,
+    resolveBillingUserId: input.resolveBillingUserId,
   });
 }
 
@@ -328,6 +345,7 @@ export async function retryQualifiedReferralRewards(
       referral,
       logger: input.logger,
       leaseMs: input.leaseMs,
+      resolveBillingUserId: input.resolveBillingUserId,
     });
     if (result?.status === "rewarded") rewarded += 1;
   }

--- a/packages/core/src/sessions/service.ts
+++ b/packages/core/src/sessions/service.ts
@@ -101,13 +101,28 @@ export function createSessionServices(input: {
   injectTrace?: () => Record<string, unknown>;
   getRequestId?: () => string | null | undefined;
   logger?: Pick<Console, "warn">;
+  resolvePrincipalIdentity?: (userId: string) => Promise<{ uuid: string; aliases?: readonly string[] }>;
   onSessionActivityUpdated?: (input: { sessionId: string; changed: string[] }) => void | Promise<void>;
-  onSessionParticipantsUpdated?: (input: { spaceId: string; sessionId: string; userUuids: string[] }) => void | Promise<void>;
+  onSessionParticipantsUpdated?: (input: { spaceId: string; sessionId: string; userUuids: string[]; replacedUserUuids?: string[] }) => void | Promise<void>;
 }) {
   const randomUUID = input.randomUUID ?? defaultRandomUUID;
   const injectTrace = input.injectTrace ?? (() => ({}));
   const getRequestId = input.getRequestId ?? (() => null);
   const logger = input.logger ?? console;
+
+  async function resolvePrincipalIdentity(userId: string) {
+    const normalized = userId.trim();
+    if (!normalized) throw new Error("userUuid is required");
+    const resolved = input.resolvePrincipalIdentity
+      ? await input.resolvePrincipalIdentity(normalized)
+      : { uuid: normalized };
+    const uuid = resolved.uuid.trim();
+    if (!uuid) throw new Error("userUuid is required");
+    const aliases = [...new Set((resolved.aliases ?? [])
+      .map((value) => value.trim())
+      .filter((value) => value && value !== uuid))];
+    return { uuid, aliases };
+  }
 
   async function ensureRootSessionTurnSegment(sessionId: string) {
     await input.db.insert(sessionTurnSegments).values({
@@ -122,8 +137,8 @@ export function createSessionServices(input: {
   }
 
   async function registerCronjobSession(spaceId: string, options: { source: string; title?: string | null; userUuid: string }) {
-    const userUuid = options.userUuid.trim();
-    if (!userUuid) throw new Error("userUuid is required");
+    const identity = await resolvePrincipalIdentity(options.userUuid);
+    const userUuid = identity.uuid;
     const [space] = await input.db.select({ id: spaces.id }).from(spaces).where(eq(spaces.id, spaceId)).limit(1);
     if (!space) throw new Error("space not found");
 
@@ -157,6 +172,7 @@ export function createSessionServices(input: {
     intent: SessionTurnIntent;
     meta: Record<string, unknown>;
   }) {
+    const identity = await resolvePrincipalIdentity(turnInput.userUuid);
     const userContent = sanitizePostgresJsonValue(turnInput.userContent);
     const meta = sanitizePostgresJsonValue(turnInput.meta);
     const userText = deriveMessagePreviewText({ content: userContent }) || null;
@@ -177,12 +193,12 @@ export function createSessionServices(input: {
         latestMessageText: userText,
         lastMessageAt: touchedAt,
         updatedAt: touchedAt,
-        meta: sanitizePostgresJsonValue(addSessionParticipantMeta(sessionRow.meta, turnInput.userUuid)),
+        meta: sanitizePostgresJsonValue(addSessionParticipantMeta(sessionRow.meta, identity.uuid, identity.aliases)),
       }).where(eq(spaceSessions.id, turnInput.sessionId));
       const [row] = await tx.insert(sessionTurns).values({
         sessionId: turnInput.sessionId,
         sequence,
-        userUuid: turnInput.userUuid,
+        userUuid: identity.uuid,
         userContent,
         userText,
         intent: turnInput.intent,
@@ -201,7 +217,8 @@ export function createSessionServices(input: {
     await Promise.resolve(input.onSessionParticipantsUpdated?.({
       spaceId,
       sessionId: turnInput.sessionId,
-      userUuids: [turnInput.userUuid],
+      userUuids: [identity.uuid],
+      replacedUserUuids: identity.aliases,
     })).catch((error) => logger.warn("[Session] failed to publish session participant labels", error));
     return row;
   }
@@ -297,11 +314,12 @@ export function createSessionServices(input: {
   }
 
   async function submitPrompt(promptInput: SubmitSessionPromptInput, hooks: SubmitSessionPromptHooks = {}) {
+    const skillService = input.skillService;
     return submitSessionPrompt({
       randomUUID,
       expandPromptTemplate: ({ text, userId, spaceId }) => input.promptTemplateService.expand(text, { userId, spaceId }),
-      expandSkillCommand: input.skillService
-        ? ({ text, userId, spaceId }) => input.skillService!.expand(text, { userId, spaceId })
+      expandSkillCommand: skillService
+        ? ({ text, userId, spaceId }) => skillService.expand(text, { userId, spaceId })
         : undefined,
       createSessionTurn,
       enqueueSpacePrompt,
@@ -315,10 +333,11 @@ export function createSessionServices(input: {
     userId: string;
     spaceId: string;
   }) {
+    const skillService = input.skillService;
     return expandPromptContent({
       expandPromptTemplate: ({ text, userId, spaceId }) => input.promptTemplateService.expand(text, { userId, spaceId }),
-      expandSkillCommand: input.skillService
-        ? ({ text, userId, spaceId }) => input.skillService!.expand(text, { userId, spaceId })
+      expandSkillCommand: skillService
+        ? ({ text, userId, spaceId }) => skillService.expand(text, { userId, spaceId })
         : undefined,
     }, promptInput);
   }

--- a/packages/core/src/sessions/session-meta.test.ts
+++ b/packages/core/src/sessions/session-meta.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  addSessionParticipantMeta,
+  readSessionParticipantUserUuids,
+} from "./session-meta.js";
+
+describe("session participant identity migration", () => {
+  it("replaces a legacy alias with canonical sub", () => {
+    const meta = {
+      participants: {
+        version: 1,
+        userUuids: ["legacy-uuid", "other-user"],
+      },
+    };
+
+    const updated = addSessionParticipantMeta(meta, "logto-sub", ["legacy-uuid"]);
+    assert.deepEqual(readSessionParticipantUserUuids(updated), ["other-user", "logto-sub"]);
+  });
+
+  it("does not duplicate an existing canonical participant", () => {
+    const updated = addSessionParticipantMeta(
+      { participants: { userUuids: ["logto-sub"] } },
+      "logto-sub",
+      ["legacy-uuid"],
+    );
+    assert.deepEqual(readSessionParticipantUserUuids(updated), ["logto-sub"]);
+  });
+});

--- a/packages/core/src/sessions/session-meta.ts
+++ b/packages/core/src/sessions/session-meta.ts
@@ -47,5 +47,10 @@ export const initializeSessionParticipantsMeta = (
 export const addSessionParticipantMeta = (
   meta: unknown,
   userUuid: string | null | undefined,
+  replacedUserUuids: Array<string | null | undefined> = [],
   now = new Date(),
-): Record<string, unknown> => setSessionParticipantsMeta(meta, [...readSessionParticipantUserUuids(meta), userUuid], now);
+): Record<string, unknown> => {
+  const replaced = new Set(normalizeUserUuids(replacedUserUuids));
+  const current = readSessionParticipantUserUuids(meta).filter((value) => !replaced.has(value));
+  return setSessionParticipantsMeta(meta, [...current, userUuid], now);
+};

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "test": "node ../../scripts/test/run.mjs 'src/**/*.test.ts'",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/identity/src/index.test.ts
+++ b/packages/identity/src/index.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  BillingIdentityUnavailableError,
+  IdentityMappingConflictError,
+  UnresolvedLegacyIdentityError,
+  getIdentityKeys,
+  isStorageSafePrincipalId,
+  resolveLegacyBillingIdentity,
+  resolveStoredPrincipalIdentity,
+  resolveStoredPrincipalIdentityForRead,
+  resolveVerifiedPrincipalIdentity,
+  resolveVerifiedPrincipalIdentityWithPersistence,
+} from "./index.js";
+
+const legacyUuid = "5d4ac7d3-1f50-4af4-8d75-6df54d5edc6a";
+const sub = "abc123logtosub";
+const mapping = [{ userUuid: legacyUuid, logtoUserId: sub }];
+
+describe("principal identity migration", () => {
+  it("uses verified sub as canonical and keeps the stored UUID as an alias", () => {
+    const identity = resolveVerifiedPrincipalIdentity({ sub, mappings: mapping });
+    assert.deepEqual(identity, { uuid: sub, legacyUserUuid: legacyUuid });
+    assert.deepEqual(getIdentityKeys(identity), [sub, legacyUuid]);
+  });
+
+  it("persists a missing verified mapping before async consumers receive only sub", async () => {
+    const rows: Array<{ userUuid: string; logtoUserId: string }> = [];
+    const identity = await resolveVerifiedPrincipalIdentityWithPersistence({
+      sub,
+      legacyUserUuid: legacyUuid,
+      loadMappings: async () => rows,
+      persistMapping: async (resolved) => {
+        rows.push({ userUuid: resolved.legacyUserUuid ?? resolved.uuid, logtoUserId: resolved.uuid });
+      },
+    });
+    assert.deepEqual(identity, { uuid: sub, legacyUserUuid: legacyUuid });
+    assert.deepEqual(rows, mapping);
+  });
+
+  it("fails closed when a verified mapping cannot be persisted", async () => {
+    await assert.rejects(
+      resolveVerifiedPrincipalIdentityWithPersistence({
+        sub,
+        legacyUserUuid: legacyUuid,
+        loadMappings: async () => [],
+        persistMapping: async () => undefined,
+      }),
+      IdentityMappingConflictError,
+    );
+  });
+
+  it("upgrades a sub-only profile row when the verified legacy UUID becomes available", async () => {
+    const rows = [{ userUuid: sub, logtoUserId: sub }];
+    const identity = await resolveVerifiedPrincipalIdentityWithPersistence({
+      sub,
+      legacyUserUuid: legacyUuid,
+      loadMappings: async () => rows,
+      persistMapping: async (resolved) => {
+        rows[0] = { userUuid: resolved.legacyUserUuid ?? resolved.uuid, logtoUserId: resolved.uuid };
+      },
+    });
+    assert.deepEqual(identity, { uuid: sub, legacyUserUuid: legacyUuid });
+    assert.deepEqual(rows, mapping);
+  });
+
+  it("resolves an old signed UUID to canonical sub", () => {
+    assert.deepEqual(resolveStoredPrincipalIdentity({ principalId: legacyUuid, mappings: mapping }), {
+      uuid: sub,
+      legacyUserUuid: legacyUuid,
+    });
+  });
+
+  it("rejects unresolved UUID principals and conflicting mappings", () => {
+    assert.throws(
+      () => resolveStoredPrincipalIdentity({ principalId: legacyUuid, mappings: [] }),
+      UnresolvedLegacyIdentityError,
+    );
+    assert.throws(
+      () => resolveVerifiedPrincipalIdentity({
+        sub,
+        mappings: [...mapping, { userUuid: "59dad1f7-807d-4ac6-8a95-747f475f84b1", logtoUserId: sub }],
+      }),
+      IdentityMappingConflictError,
+    );
+  });
+
+  it("falls back only for an unresolved legacy read and never hides conflicts", () => {
+    assert.deepEqual(
+      resolveStoredPrincipalIdentityForRead({ principalId: legacyUuid, mappings: [] }),
+      { uuid: legacyUuid },
+    );
+    assert.throws(
+      () => resolveStoredPrincipalIdentityForRead({
+        principalId: legacyUuid,
+        mappings: [
+          ...mapping,
+          { userUuid: legacyUuid, logtoUserId: "different-sub" },
+        ],
+      }),
+      IdentityMappingConflictError,
+    );
+  });
+
+  it("never uses sub as the legacy Billing external user id", () => {
+    assert.equal(
+      resolveLegacyBillingIdentity({ identity: { uuid: sub, legacyUserUuid: legacyUuid }, mappings: mapping }),
+      legacyUuid,
+    );
+    assert.throws(
+      () => resolveLegacyBillingIdentity({ identity: { uuid: sub }, mappings: [] }),
+      BillingIdentityUnavailableError,
+    );
+  });
+
+  it("accepts Logto subjects for storage without allowing path traversal", () => {
+    assert.equal(isStorageSafePrincipalId(sub), true);
+    assert.equal(isStorageSafePrincipalId(legacyUuid), true);
+    assert.equal(isStorageSafePrincipalId("../escape"), false);
+    assert.equal(isStorageSafePrincipalId("user/child"), false);
+  });
+});

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -15,7 +15,10 @@ export type AuthEnv = keyof typeof DEFAULT_LOGTO_ENDPOINT_BY_ENV;
 
 export type AuthUserProfile = {
   id?: number;
+  /** Canonical verified Logto subject for the current issuer. */
   uuid: string;
+  /** Legacy Cohub/TalesofAI UUID accepted only for migration reads. */
+  legacyUserUuid?: string;
   nick_name?: string;
   phone_num?: string;
   avatar_url?: string;
@@ -26,6 +29,198 @@ export type AuthUserProfile = {
   audience?: string[];
   [key: string]: unknown;
 };
+
+export type PrincipalIdentity = Pick<AuthUserProfile, "uuid" | "legacyUserUuid">;
+
+export type IdentityMappingRow = {
+  userUuid: string;
+  logtoUserId: string;
+};
+
+export class IdentityMappingConflictError extends Error {
+  override name = "IdentityMappingConflictError";
+}
+
+export class UnresolvedLegacyIdentityError extends Error {
+  override name = "UnresolvedLegacyIdentityError";
+}
+
+export class BillingIdentityUnavailableError extends Error {
+  override name = "BillingIdentityUnavailableError";
+}
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SHORT_UUID_REGEX = /^[0-9a-f]{32}$/i;
+const STORAGE_SAFE_PRINCIPAL_ID_REGEX = /^[A-Za-z0-9_-]{1,255}$/;
+
+const normalizeIdentityValue = (value: string | null | undefined) => value?.trim() || null;
+
+export const isLegacyUserUuid = (value: string | null | undefined): value is string => {
+  const normalized = normalizeIdentityValue(value);
+  return Boolean(normalized && (UUID_REGEX.test(normalized) || SHORT_UUID_REGEX.test(normalized)));
+};
+
+export const isStorageSafePrincipalId = (value: string | null | undefined): value is string => {
+  const normalized = normalizeIdentityValue(value);
+  return Boolean(normalized && STORAGE_SAFE_PRINCIPAL_ID_REGEX.test(normalized));
+};
+
+export const getIdentityKeys = (
+  identity: { uuid?: string | null; legacyUserUuid?: string | null } | null | undefined,
+): string[] => {
+  if (!identity) return [];
+  return [...new Set([identity.uuid, identity.legacyUserUuid]
+    .map(normalizeIdentityValue)
+    .filter((value): value is string => Boolean(value)))];
+};
+
+export const identityEquals = (
+  identity: { uuid?: string | null; legacyUserUuid?: string | null } | null | undefined,
+  storedId: string | null | undefined,
+) => {
+  const normalized = normalizeIdentityValue(storedId);
+  return Boolean(normalized && getIdentityKeys(identity).includes(normalized));
+};
+
+const singleMapping = (rows: readonly IdentityMappingRow[]): IdentityMappingRow | null => {
+  const unique = new Map<string, IdentityMappingRow>();
+  for (const row of rows) {
+    const userUuid = normalizeIdentityValue(row.userUuid);
+    const logtoUserId = normalizeIdentityValue(row.logtoUserId);
+    if (!userUuid || !logtoUserId) continue;
+    unique.set(`${userUuid}\u0000${logtoUserId}`, { userUuid, logtoUserId });
+  }
+  if (unique.size > 1) {
+    throw new IdentityMappingConflictError("identity aliases resolve to different profile rows");
+  }
+  return unique.values().next().value ?? null;
+};
+
+export function resolveVerifiedPrincipalIdentity(input: {
+  sub: string;
+  legacyUserUuid?: string | null;
+  mappings: readonly IdentityMappingRow[];
+}): PrincipalIdentity {
+  const sub = normalizeIdentityValue(input.sub);
+  if (!sub) throw new IdentityMappingConflictError("verified principal sub is empty");
+  const claimedLegacyUserUuid = normalizeIdentityValue(input.legacyUserUuid);
+  const mapping = singleMapping(input.mappings);
+  if (mapping && mapping.logtoUserId !== sub) {
+    throw new IdentityMappingConflictError("verified principal conflicts with the stored Logto subject");
+  }
+  if (
+    mapping
+    && mapping.userUuid !== sub
+    && claimedLegacyUserUuid
+    && mapping.userUuid !== claimedLegacyUserUuid
+  ) {
+    throw new IdentityMappingConflictError("verified principal legacy UUID conflicts with the stored alias");
+  }
+  const legacyUserUuid = claimedLegacyUserUuid
+    ?? (mapping?.userUuid !== sub ? mapping?.userUuid : undefined);
+  return legacyUserUuid && legacyUserUuid !== sub
+    ? { uuid: sub, legacyUserUuid }
+    : { uuid: sub };
+}
+
+export async function resolveVerifiedPrincipalIdentityWithPersistence(input: {
+  sub: string;
+  legacyUserUuid?: string | null;
+  loadMappings: (keys: readonly string[]) => Promise<readonly IdentityMappingRow[]>;
+  persistMapping: (identity: PrincipalIdentity) => Promise<void>;
+}): Promise<PrincipalIdentity> {
+  const claimedIdentity = {
+    uuid: input.sub,
+    legacyUserUuid: input.legacyUserUuid ?? undefined,
+  };
+  let mappings = await input.loadMappings(getIdentityKeys(claimedIdentity));
+  let identity = resolveVerifiedPrincipalIdentity({
+    sub: input.sub,
+    legacyUserUuid: input.legacyUserUuid,
+    mappings,
+  });
+  const expectedStorageUserId = identity.legacyUserUuid ?? identity.uuid;
+  const isPersisted = () => mappings.some((row) =>
+    normalizeIdentityValue(row.userUuid) === expectedStorageUserId
+    && normalizeIdentityValue(row.logtoUserId) === identity.uuid);
+  if (isPersisted()) return identity;
+
+  await input.persistMapping(identity);
+  mappings = await input.loadMappings(getIdentityKeys(identity));
+  if (!isPersisted()) {
+    throw new IdentityMappingConflictError("verified principal mapping was not persisted");
+  }
+  identity = resolveVerifiedPrincipalIdentity({
+    sub: input.sub,
+    legacyUserUuid: input.legacyUserUuid,
+    mappings,
+  });
+  return identity;
+}
+
+export function resolveStoredPrincipalIdentity(input: {
+  principalId: string;
+  mappings: readonly IdentityMappingRow[];
+  requireLegacyMapping?: boolean;
+}): PrincipalIdentity {
+  const principalId = normalizeIdentityValue(input.principalId);
+  if (!principalId) throw new UnresolvedLegacyIdentityError("signed principal identity is empty");
+  const mapping = singleMapping(input.mappings);
+  if (mapping) {
+    return mapping.userUuid !== mapping.logtoUserId
+      ? { uuid: mapping.logtoUserId, legacyUserUuid: mapping.userUuid }
+      : { uuid: mapping.logtoUserId };
+  }
+  if (input.requireLegacyMapping !== false && isLegacyUserUuid(principalId)) {
+    throw new UnresolvedLegacyIdentityError("legacy UUID has no canonical Logto subject mapping");
+  }
+  return { uuid: principalId };
+}
+
+/**
+ * Read-only compatibility for legacy namespaces. A UUID with no mapping may
+ * still name an existing UUID-backed directory/cache, but mapping conflicts
+ * and invalid principals remain hard failures.
+ */
+export function resolveStoredPrincipalIdentityForRead(input: {
+  principalId: string;
+  mappings: readonly IdentityMappingRow[];
+}): PrincipalIdentity {
+  try {
+    return resolveStoredPrincipalIdentity(input);
+  } catch (error) {
+    if (error instanceof UnresolvedLegacyIdentityError && isLegacyUserUuid(input.principalId)) {
+      return { uuid: input.principalId.trim() };
+    }
+    throw error;
+  }
+}
+
+export function resolveLegacyBillingIdentity(input: {
+  identity: PrincipalIdentity;
+  mappings: readonly IdentityMappingRow[];
+}): string {
+  const mapping = singleMapping(input.mappings);
+  if (mapping && mapping.logtoUserId !== input.identity.uuid) {
+    throw new IdentityMappingConflictError("billing identity conflicts with the stored Logto subject");
+  }
+  const claimed = isLegacyUserUuid(input.identity.legacyUserUuid)
+    ? input.identity.legacyUserUuid.trim()
+    : null;
+  const stored = mapping
+    && mapping.userUuid !== mapping.logtoUserId
+    && isLegacyUserUuid(mapping.userUuid)
+    ? mapping.userUuid
+    : null;
+  if (claimed && stored && claimed !== stored) {
+    throw new IdentityMappingConflictError("billing UUID conflicts with the stored legacy alias");
+  }
+  const resolved = claimed ?? stored;
+  if (!resolved) {
+    throw new BillingIdentityUnavailableError("legacy billing UUID is unavailable");
+  }
+  return resolved;
+}
 
 export class AuthorizationError extends Error {
   override name = "AuthorizationError";
@@ -115,10 +310,7 @@ export async function verifyUserAccessToken(input: {
     throw new AuthorizationError("Jwt client_id is missing", 401);
   }
 
-  const uuid = stringClaim(payload, "talesofai_uuid");
-  if (!uuid) {
-    throw new AuthorizationError("Jwt talesofai_uuid is missing", 401);
-  }
+  const legacyUserUuid = stringClaim(payload, "talesofai_uuid");
 
   const nickName = stringClaim(payload, "nick_name") ?? stringClaim(payload, "name") ?? stringClaim(payload, "username");
   const avatarUrl = stringClaim(payload, "avatar_url") ?? stringClaim(payload, "picture");
@@ -126,7 +318,8 @@ export async function verifyUserAccessToken(input: {
 
   return {
     id: numberIdClaim(payload, "talesofai_id"),
-    uuid,
+    uuid: payload.sub,
+    legacyUserUuid,
     nick_name: nickName,
     phone_num: phoneNumber,
     avatar_url: avatarUrl,

--- a/packages/infra/src/config-runtime/generation-declarations.ts
+++ b/packages/infra/src/config-runtime/generation-declarations.ts
@@ -110,7 +110,7 @@ export function createGenerationDeclarationLoader(input: {
     }
   }
 
-  async function loadGenerationDeclarations(userId: string): Promise<GenerationModelDeclaration[]> {
+  async function loadGenerationDeclarations(userId: string, userAliases: readonly string[] = []): Promise<GenerationModelDeclaration[]> {
     const platformGenerations = await loadCachedGenerations({
       redisKey: PLATFORM_GENERATIONS_REDIS_KEY,
       dir: platformGenerationsDir(),
@@ -118,24 +118,28 @@ export function createGenerationDeclarationLoader(input: {
     });
     if (!platformGenerations) throw new Error("Generation declarations directory not found");
 
-    const userGenerations = await loadCachedGenerations({
-      redisKey: getUserGenerationsRedisKey(userId),
-      dir: userGenerationsDir(userId),
+    const userIds = [...new Set([
+      ...userAliases.map((value) => value.trim()).filter((value) => value && value !== userId),
+      userId,
+    ])];
+    const userGenerations = await Promise.all(userIds.map((resolvedUserId) => loadCachedGenerations({
+      redisKey: getUserGenerationsRedisKey(resolvedUserId),
+      dir: userGenerationsDir(resolvedUserId),
       allowMissing: true,
-    });
+    })));
 
-    return mergeGenerationsConfigs(platformGenerations, userGenerations).declarations;
+    return mergeGenerationsConfigs(platformGenerations, ...userGenerations).declarations;
   }
 
   return {
     loadGenerationDeclarations,
-    async loadGenerationDeclaration(userId: string, model: string): Promise<GenerationModelDeclaration | null> {
-      const declarations = await loadGenerationDeclarations(userId);
+    async loadGenerationDeclaration(userId: string, model: string, userAliases: readonly string[] = []): Promise<GenerationModelDeclaration | null> {
+      const declarations = await loadGenerationDeclarations(userId, userAliases);
       return declarations.find((declaration) => declaration.model === model) ?? null;
     },
-    async loadPublicGenerationModels(userId: string): Promise<ListGenerationModelsResponse> {
+    async loadPublicGenerationModels(userId: string, userAliases: readonly string[] = []): Promise<ListGenerationModelsResponse> {
       return {
-        models: (await loadGenerationDeclarations(userId)).map(toPublicGenerationDeclaration),
+        models: (await loadGenerationDeclarations(userId, userAliases)).map(toPublicGenerationDeclaration),
       };
     },
   };

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -148,6 +148,7 @@ export type SpacePresenceSnapshot = {
 
 export type MeResponse = {
   uuid: string;
+  legacyUserUuid?: string;
   profile: UserProfile;
   email: string | null;
 };

--- a/packages/sdk/src/work-bridge-core.ts
+++ b/packages/sdk/src/work-bridge-core.ts
@@ -64,6 +64,9 @@ export type WorkBridgeGetAccessToken = (
  */
 export type WorkBridgeGetViewerUuid = () => Promise<string | null>;
 
+/** Resolves canonical and migration aliases, ordered with canonical first. */
+export type WorkBridgeGetViewerIdentityKeys = () => Promise<string[]>;
+
 /**
  * Requests the host to start a sign-in flow, redirecting back to the given
  * path afterward. The core calls this when an API request fails due to missing
@@ -93,6 +96,8 @@ export type WorkBridgeCoreConfig = {
 	getAccessToken: WorkBridgeGetAccessToken;
 	/** Resolves the current viewer's user UUID. */
 	getViewerUuid: WorkBridgeGetViewerUuid;
+	/** Resolves canonical and legacy viewer IDs for migration-safe comparisons. */
+	getViewerIdentityKeys?: WorkBridgeGetViewerIdentityKeys;
 	/** Starts a sign-in flow with a post-login redirect path. */
 	requestSignIn: WorkBridgeRequestSignIn;
 	/** Called whenever the dialog state changes, for reactive UI binding. */
@@ -161,9 +166,15 @@ export function createWorkBridgeCore(
 
 	const pendingPurchaseStorageKey = `cohub-work-purchase:${work.id}`;
 
+	async function resolveViewerIdentityKeys() {
+		const keys = config.getViewerIdentityKeys
+			? await config.getViewerIdentityKeys()
+			: [await getViewerUuid()];
+		return [...new Set(keys.map((value) => value?.trim()).filter((value): value is string => Boolean(value)))];
+	}
+
 	async function isCurrentViewerWorkOwner() {
-		const viewerUuid = await getViewerUuid();
-		return Boolean(viewerUuid && viewerUuid === work.userUuid);
+		return (await resolveViewerIdentityKeys()).includes(work.userUuid);
 	}
 
 	async function ensureBaseToken(forceRefresh = false) {
@@ -387,11 +398,9 @@ export function createWorkBridgeCore(
 				}
 				// Returning viewers who previously granted the requested scopes are
 				// re-authorized silently with a fresh token — no consent dialog.
-				const viewerUuid = await getViewerUuid();
-				if (
-					viewerUuid &&
-					hasGrantedWorkScopes(viewerUuid, work.id, scopes)
-				) {
+				const viewerUuid = (await resolveViewerIdentityKeys())
+					.find((candidate) => hasGrantedWorkScopes(candidate, work.id, scopes));
+				if (viewerUuid) {
 					try {
 						const token = await authorize(scopes);
 						reply(data.requestId, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@cohub/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@cohub/identity':
+        specifier: workspace:*
+        version: link:../../packages/identity
       '@cohub/infra':
         specifier: workspace:*
         version: link:../../packages/infra
@@ -165,7 +168,7 @@ importers:
         version: link:../../packages/sandbox-controller
       '@earendil-works/pi-ai':
         specifier: 0.81.1
-        version: 0.81.1(ws@8.21.1)(zod@4.4.3)
+        version: 0.81.1(ws@8.21.0)(zod@4.4.3)
       '@hono/node-server':
         specifier: 2.0.9
         version: 2.0.9(hono@4.12.30)
@@ -512,6 +515,9 @@ importers:
       '@cohub/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@cohub/identity':
+        specifier: workspace:*
+        version: link:../../packages/identity
       '@cohub/infra':
         specifier: workspace:*
         version: link:../../packages/infra
@@ -8393,6 +8399,27 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-ai@0.81.1(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-ai@0.81.1(ws@8.21.1)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
@@ -12007,6 +12034,11 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  openai@6.26.0(ws@8.21.0)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 4.4.3
 
   openai@6.26.0(ws@8.21.1)(zod@4.4.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Make the verified Logto `sub` the canonical Cohub principal across API, Agent, Worker, Gateway, Web, and SDK paths.
- Keep the legacy TalesofAI UUID as a read-only migration alias so existing rows, grants, namespaces, and realtime rooms remain accessible.
- Write canonical `sub` values for new business data, queue payloads, sandbox identities, cron reschedules, config publication, and provenance.
- Keep Phase 1 Billing calls on the existing legacy UUID customer key through a dedicated resolver; never fall back to `sub` and create a second customer.
- Add migration-safe SDK identity keys and a minor `@neta-art/cohub` changeset.

## Safety properties

- Conflicting or unresolved mappings fail closed on signed principal, mutation, sandbox, cron, and Billing boundaries.
- Sandbox actor/owner identities are canonicalized before Pod lifecycle or config-mount side effects.
- Old cron rows are canonicalized before DB, BullMQ repeat payload, rollback, and restore writes.
- Existing UUID-backed data remains dual-readable while all new Cohub writes converge on `sub`.
- This PR does not run a data backfill, rekey Billing customers, or remove the Logto `talesofai_uuid` claim.

## Validation

- `PUBLIC_API_ORIGIN=http://localhost:8787 PUBLIC_GATEWAY_ORIGIN=ws://localhost:8788 PUBLIC_COHUB_ENV=dev pnpm typecheck` (15 workspaces)
- `pnpm lint`
- Biome check on all 102 changed code/config files
- 950 tests across all 13 test workspaces, including 23 `@cohub/billing` tests with `@talesofai-billing/sdk@1.12.0`
- `git diff origin/main...HEAD --check`
- Changesets status: `@neta-art/cohub` minor, dependent CLI patch

## Rollout

1. Merge and deploy Cohub to dev first.
2. Deploy the corresponding Studio identity bridge PR after Cohub dev is ready.
3. Run joint smoke tests for legacy UUID reads, new `sub` writes, execution grants, Gateway/realtime, sandbox/cron identities, and unchanged Billing customers.
4. Keep the legacy JWT claim and Billing UUID key until the later backfill and controlled Billing rekey phases.
