### PR TITLE
fix: bind Work recovery to the authorized viewer

### DIFF
--- a/.changeset/tidy-viewer-recovery.md
+++ b/.changeset/tidy-viewer-recovery.md
@@ -1,0 +1,5 @@
+---
+"@neta-art/cohub": patch
+---
+
+Bind Work recovery, realtime subscriptions, and viewer-facing response types to the active Cohub viewer grant.

--- a/apps/agent/src/redis.ts
+++ b/apps/agent/src/redis.ts
@@ -3,7 +3,15 @@ import { context, trace, type Span } from "@opentelemetry/api";
 import { Redis } from "ioredis";
 import { z } from "zod";
 import type { ContentBlock } from "@cohub/protocol/core";
-import { AGENT_REALTIME_PATCH_CHANNEL, REALTIME_OUTBOUND_CHANNEL, type RealtimeEnvelope, type RealtimeRoom, type SessionStreamError, type SessionStreamEvent, type SessionTurnLifecycleOutput } from "@cohub/protocol/realtime";
+import {
+  AGENT_REALTIME_PATCH_CHANNEL,
+  REALTIME_OUTBOUND_CHANNEL,
+  type RealtimeEnvelope,
+  type RealtimeRoom,
+  type SessionStreamError,
+  type SessionStreamEvent,
+  type SessionTurnLifecycleOutput,
+} from "@cohub/protocol/realtime";
 import type { SpaceFsChangedPayload } from "@cohub/protocol/fs";
 import type { SpacePortsChangedPayload } from "@cohub/protocol/ports";
 import { injectTrace } from "@cohub/infra/tracing/propagator";
@@ -12,6 +20,7 @@ import { env } from "./env.js";
 import { enqueueSpaceHookFromEvent } from "./space-hooks.js";
 import { buildPatchOpsForContentDelta, getAppendPathForStreamEvent } from "./stream/patch-delta.js";
 import { createLogger } from "@cohub/infra/logging";
+import { getSessionEventRooms } from "./session-event-rooms.js";
 
 
 const logger = createLogger({ serviceName: "cohub-agent" });
@@ -470,6 +479,10 @@ export async function sendOutput(data: SessionStreamEvent | SessionStreamError |
 
   const activeSpan = trace.getActiveSpan();
   const event = parsed.data as SessionStreamEvent | SessionStreamError | SessionTurnLifecycleOutput;
+  if (!event.sessionId) {
+    logger.warn("[Redis] Skipping session output without sessionId");
+    return;
+  }
 
   try {
     const traceCarrier = injectTrace();
@@ -537,7 +550,11 @@ export async function sendOutput(data: SessionStreamEvent | SessionStreamError |
       };
     }
 
-    const payload = JSON.stringify({ ...envelope, ...traceCarrier });
+    const payload = JSON.stringify({
+      ...envelope,
+      rooms: getSessionEventRooms(event.spaceId, event.sessionId),
+      ...traceCarrier,
+    });
     const span = trace.getActiveSpan();
     await redis.publish(AGENT_REALTIME_PATCH_CHANNEL, payload).catch((err) => {
       if (span) recordStreamPublishFailure(span, err);

--- a/apps/agent/src/session-event-rooms.ts
+++ b/apps/agent/src/session-event-rooms.ts
@@ -1,0 +1,12 @@
+import {
+  getRealtimeSessionRoom,
+  getRealtimeSpaceRoom,
+  type RealtimeRoom,
+} from "@cohub/protocol/realtime";
+
+export function getSessionEventRooms(
+  spaceId: string,
+  sessionId: string,
+): RealtimeRoom[] {
+  return [getRealtimeSpaceRoom(spaceId), getRealtimeSessionRoom(sessionId)];
+}

--- a/apps/agent/src/tests/session-event-rooms.test.ts
+++ b/apps/agent/src/tests/session-event-rooms.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { getSessionEventRooms } from "../session-event-rooms.js";
+
+test("Agent session events reach both the Space aggregate and Session subscribers", () => {
+  assert.deepEqual(getSessionEventRooms("space-1", "session-1"), [
+    "space:space-1",
+    "session:session-1",
+  ]);
+});

--- a/apps/api/src/board-events.ts
+++ b/apps/api/src/board-events.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { BoardOperation, BoardPlaybackSnapshot } from "@cohub/protocol";
+import { getRealtimeBoardRoom, getRealtimeBoardSpaceRoom } from "@cohub/protocol/realtime";
 import { dispatchRealtimeEvent } from "./channels.js";
 
 export async function dispatchBoardTransactionApplied(input: {
@@ -18,6 +19,7 @@ export async function dispatchBoardTransactionApplied(input: {
     type: "board.transaction.applied",
     spaceId: input.spaceId,
     sessionId: null,
+    rooms: [getRealtimeBoardRoom(input.boardId), getRealtimeBoardSpaceRoom(input.spaceId)],
     payload: {
       boardId: input.boardId,
       actorId: input.actorId,
@@ -40,6 +42,7 @@ export async function dispatchBoardPlaybackChanged(input: {
     type: "board.playback.changed",
     spaceId: input.spaceId,
     sessionId: null,
+    rooms: [getRealtimeBoardRoom(input.snapshot.boardId), getRealtimeBoardSpaceRoom(input.spaceId)],
     payload: input.snapshot,
   });
 }

--- a/apps/api/src/channels.ts
+++ b/apps/api/src/channels.ts
@@ -4,7 +4,6 @@ import { createHash, randomUUID } from "node:crypto";
 import type { ContentBlock } from "@cohub/protocol/core";
 import type { ChannelConfig, ChannelProvider, GatewayChannelCommandEvent, GatewayInboundEvent, GatewayOutboundCommand } from "@cohub/protocol/gateway";
 import type { RealtimeEnvelope, RealtimeRoom, RealtimeServerEvent } from "@cohub/protocol/realtime";
-import { getRealtimeSpaceRoom, getRealtimeUserRoom, normalizeRealtimeRooms } from "@cohub/protocol/realtime";
 import { executeChannelCommand } from "./channel-commands.js";
 import { db } from "./db/index.js";
 import { providerMessageRefs, spaceChannels, spaceSessionBindings, userChannels } from "@cohub/db";
@@ -21,6 +20,7 @@ import { buildSessionSourceChannel } from "./lib/session-source-channel.js";
 import { assignSessionChannelSystemLabel } from "@cohub/core/labels/session-channel";
 import { assignSessionSourceSystemLabel } from "@cohub/core/labels/session-source";
 import { dispatchLabelAssignmentsUpdated } from "./realtime-events.js";
+import { resolveRealtimeEventRooms } from "./realtime-event-rooms.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -361,22 +361,6 @@ export async function dispatchOutboundMessage(input: {
   await xaddWithMaxlen(redisCommandClient, getGatewayNodeOutboundStreamKey(nodeId), "*", "payload", JSON.stringify(command));
 }
 
-const resolveRealtimeEventRooms = (input: {
-  spaceId?: string | null;
-  rooms?: string[];
-  userIds?: string[];
-}): RealtimeRoom[] => {
-  const rooms = normalizeRealtimeRooms(input.rooms ?? []);
-  if (rooms.length > 0) return rooms;
-  const userIds = Array.from(new Set(
-    (input.userIds ?? [])
-      .map((value) => value.trim())
-      .filter(Boolean),
-  ));
-  if (userIds.length > 0) return userIds.map(getRealtimeUserRoom);
-  return input.spaceId ? [getRealtimeSpaceRoom(input.spaceId)] : [];
-};
-
 export async function dispatchRealtimeEvent(input: (RealtimeServerEvent | RealtimeEnvelope) & { rooms?: RealtimeRoom[] }) {
   const payload = input.payload as Record<string, unknown>;
   const task = payload.task && typeof payload.task === "object" ? payload.task as { userId?: unknown } : null;
@@ -385,8 +369,10 @@ export async function dispatchRealtimeEvent(input: (RealtimeServerEvent | Realti
     : typeof task?.userId === "string"
       ? task.userId
       : undefined;
-  const rooms = input.rooms?.length ? input.rooms : resolveRealtimeEventRooms({
+  const rooms = resolveRealtimeEventRooms({
     spaceId: input.spaceId,
+    sessionId: input.sessionId,
+    rooms: input.rooms,
     userIds: userId ? [userId] : undefined,
   });
   if (rooms.length === 0) return;

--- a/apps/api/src/generations/declarations.ts
+++ b/apps/api/src/generations/declarations.ts
@@ -9,4 +9,6 @@ const loader = createGenerationDeclarationLoader({
 
 export const loadGenerationDeclarations = loader.loadGenerationDeclarations;
 export const loadGenerationDeclaration = loader.loadGenerationDeclaration;
+export const loadPlatformGenerationDeclaration = loader.loadPlatformGenerationDeclaration;
 export const loadPublicGenerationModels = loader.loadPublicGenerationModels;
+export const loadPlatformPublicGenerationModels = loader.loadPlatformPublicGenerationModels;

--- a/apps/api/src/internal-prompt-auth.test.ts
+++ b/apps/api/src/internal-prompt-auth.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { resolveInternalPromptActor } from "./internal-prompt-auth.js";
+import type { WorkSessionPrincipal } from "./work-sessions.js";
+
+const workSession: WorkSessionPrincipal = {
+  type: "work_session",
+  typ: "work_session",
+  userUuid: "viewer-1",
+  workId: "work-1",
+  spaceId: "space-1",
+  workScopes: [],
+  viewerScopes: ["session.prompt.fullaccess"],
+  scopes: ["session.prompt.fullaccess"],
+  iat: 1,
+  exp: 2,
+};
+
+test("internal Work prompts never downgrade an invalid token into an account", () => {
+  const input = {
+    principalType: "work_session" as const,
+    userId: "viewer-1",
+    authToken: "work-token",
+  };
+  assert.equal(resolveInternalPromptActor(input, () => null), null);
+  assert.equal(resolveInternalPromptActor(
+    input,
+    () => ({ ...workSession, userUuid: "viewer-2" }),
+  ), null);
+  assert.equal(resolveInternalPromptActor(input, () => workSession)?.principal.type, "work_session");
+});
+
+test("internal account prompts retain a real user principal", () => {
+  const resolved = resolveInternalPromptActor({
+    principalType: "user",
+    userId: "viewer-1",
+    authToken: "account-token",
+  }, () => null);
+  assert.deepEqual(resolved?.principal, { type: "user", user: { uuid: "viewer-1" } });
+});

--- a/apps/api/src/internal-prompt-auth.test.ts
+++ b/apps/api/src/internal-prompt-auth.test.ts
@@ -35,6 +35,21 @@ test("internal account prompts retain a real user principal", () => {
     principalType: "user",
     userId: "viewer-1",
     authToken: "account-token",
+    accountUser: { uuid: "viewer-1" },
   }, () => null);
   assert.deepEqual(resolved?.principal, { type: "user", user: { uuid: "viewer-1" } });
+});
+
+test("internal account prompts reject an unverified or mismatched user token", () => {
+  assert.equal(resolveInternalPromptActor({
+    principalType: "user",
+    userId: "viewer-1",
+    authToken: "account-token",
+  }, () => null), null);
+  assert.equal(resolveInternalPromptActor({
+    principalType: "user",
+    userId: "viewer-1",
+    authToken: "account-token",
+    accountUser: { uuid: "viewer-2" },
+  }, () => null), null);
 });

--- a/apps/api/src/internal-prompt-auth.ts
+++ b/apps/api/src/internal-prompt-auth.ts
@@ -8,6 +8,7 @@ export function resolveInternalPromptActor(
     principalType: InternalPromptPrincipalType;
     userId: string;
     authToken: string;
+    accountUser?: { uuid: string } | null;
   },
   verifyWorkToken: (token: string) => WorkSessionPrincipal | null,
 ): {
@@ -17,8 +18,9 @@ export function resolveInternalPromptActor(
 } | null {
   if (!input.authToken) return null;
   if (input.principalType === "user") {
+    if (!input.accountUser || input.accountUser.uuid !== input.userId) return null;
     return {
-      principal: { type: "user", user: { uuid: input.userId } },
+      principal: { type: "user", user: input.accountUser },
       permissionSubject: { uuid: input.userId },
       workSession: null,
     };

--- a/apps/api/src/internal-prompt-auth.ts
+++ b/apps/api/src/internal-prompt-auth.ts
@@ -1,0 +1,34 @@
+import type { OwnerResourcePrincipal } from "./owner-resource-access.js";
+import type { WorkSessionPrincipal } from "./work-sessions.js";
+
+export type InternalPromptPrincipalType = "user" | "work_session";
+
+export function resolveInternalPromptActor(
+  input: {
+    principalType: InternalPromptPrincipalType;
+    userId: string;
+    authToken: string;
+  },
+  verifyWorkToken: (token: string) => WorkSessionPrincipal | null,
+): {
+  principal: Exclude<OwnerResourcePrincipal, null>;
+  permissionSubject: { uuid: string; workSession?: WorkSessionPrincipal };
+  workSession: WorkSessionPrincipal | null;
+} | null {
+  if (!input.authToken) return null;
+  if (input.principalType === "user") {
+    return {
+      principal: { type: "user", user: { uuid: input.userId } },
+      permissionSubject: { uuid: input.userId },
+      workSession: null,
+    };
+  }
+
+  const workSession = verifyWorkToken(input.authToken);
+  if (!workSession || workSession.userUuid !== input.userId) return null;
+  return {
+    principal: { type: "work_session", workSession },
+    permissionSubject: { uuid: input.userId, workSession },
+    workSession,
+  };
+}

--- a/apps/api/src/invitation-acceptance.test.ts
+++ b/apps/api/src/invitation-acceptance.test.ts
@@ -1,0 +1,369 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { SpaceRole } from "@cohub/db";
+import {
+  acceptInvitationMembership,
+  finalizeInvitationUse,
+  invitationUseAvailability,
+  reconcileExpiredInvitationUses,
+  releaseInvitationUse,
+  reserveInvitationUse,
+} from "./invitation-acceptance.js";
+import { invitationMembershipLockId, withInvitationLock } from "./invitation-lock.js";
+
+type InvitationState = {
+  maxUses: number;
+  useCount: number;
+  status: "active" | "exhausted" | "revoked";
+  reservations: Map<string, string>;
+};
+
+const roleRank: Record<SpaceRole, number> = { guest: 0, builder: 1, host: 2 };
+
+class FakeInvitationRedis {
+  readonly invitations = new Map<string, InvitationState>();
+  private readonly locks = new Map<string, string>();
+  now = 1_000;
+
+  async set(
+    key: string,
+    value: string,
+    _mode: "PX",
+    _ttlMs: number,
+    _condition: "NX",
+  ): Promise<"OK" | null> {
+    if (this.locks.has(key)) return null;
+    this.locks.set(key, value);
+    return "OK";
+  }
+
+  async eval(
+    script: string,
+    _numKeys: number,
+    key: string,
+    ...args: string[]
+  ): Promise<unknown> {
+    if (key.startsWith("invite:token-lock:")) {
+      if (this.locks.get(key) !== args[0]) return 0;
+      if (script.includes("pexpire")) return 1;
+      this.locks.delete(key);
+      return 1;
+    }
+
+    const invitation = this.invitations.get(key);
+    if (!invitation) return "missing";
+    const field = args[0];
+    assert.ok(field);
+
+    if (script.includes('return "finalized"')) {
+      const reservation = invitation.reservations.get(field);
+      if (!reservation) return "absent";
+      if (reservation === "committed" || reservation === "1") return "existing";
+      invitation.reservations.set(field, "committed");
+      return "finalized";
+    }
+
+    if (script.includes('return "released"')) {
+      const reservation = invitation.reservations.get(field);
+      if (!reservation) return "absent";
+      if (!reservation.startsWith("pending:")) return "committed";
+      invitation.reservations.delete(field);
+      invitation.useCount = Math.max(0, invitation.useCount - 1);
+      if (
+        invitation.status === "exhausted"
+        && (invitation.maxUses === 0 || invitation.useCount < invitation.maxUses)
+      ) invitation.status = "active";
+      return "released";
+    }
+
+    if (invitation.status === "revoked") return "revoked";
+    const existingReservation = invitation.reservations.get(field);
+    if (existingReservation?.startsWith("pending:")) return "existing";
+    if (existingReservation === "committed" || existingReservation === "1") return "committed";
+    if (
+      invitation.status === "exhausted"
+      || (invitation.maxUses > 0 && invitation.useCount >= invitation.maxUses)
+    ) {
+      invitation.status = "exhausted";
+      return "exhausted";
+    }
+
+    const leaseMs = Number(args[1]);
+    const userUuid = args[2];
+    const role = args[3];
+    invitation.reservations.set(field, `pending:${this.now + leaseMs}:${userUuid}:${role}`);
+    invitation.useCount += 1;
+    if (invitation.maxUses > 0 && invitation.useCount >= invitation.maxUses) {
+      invitation.status = "exhausted";
+    }
+    return "reserved";
+  }
+
+  record(key: string): Record<string, string> {
+    const invitation = this.invitations.get(key);
+    assert.ok(invitation);
+    return Object.fromEntries([
+      ["max_uses", String(invitation.maxUses)],
+      ["use_count", String(invitation.useCount)],
+      ["status", invitation.status],
+      ...invitation.reservations,
+    ]);
+  }
+}
+
+function membershipDependencies(input: {
+  invitationKey: string;
+  redis: FakeInvitationRedis;
+  roleByUser: Map<string, SpaceRole>;
+  userUuid: string;
+  role?: SpaceRole;
+  failApply?: () => boolean;
+}) {
+  const invitedRole = input.role ?? "builder";
+  return {
+    getRole: async () => input.roleByUser.get(input.userUuid) ?? null,
+    reserveUse: () => reserveInvitationUse(
+      input.invitationKey,
+      input.userUuid,
+      invitedRole,
+      input.redis,
+      1_000,
+    ),
+    applyRole: async () => {
+      if (input.failApply?.()) throw new Error("database unavailable");
+      const current = input.roleByUser.get(input.userUuid);
+      const role = current && roleRank[current] >= roleRank[invitedRole] ? current : invitedRole;
+      input.roleByUser.set(input.userUuid, role);
+      return role;
+    },
+    finalizeUse: () => finalizeInvitationUse(input.invitationKey, input.userUuid, input.redis),
+    releaseUse: () => releaseInvitationUse(input.invitationKey, input.userUuid, input.redis),
+  };
+}
+
+describe("invitation use reservations", () => {
+  it("serializes concurrent accepts and never exceeds maxUses", async () => {
+    const token = "single-use-token";
+    const invitationKey = `invite:${token}`;
+    const redis = new FakeInvitationRedis();
+    redis.invitations.set(invitationKey, {
+      maxUses: 1,
+      useCount: 0,
+      status: "active",
+      reservations: new Map(),
+    });
+    const roleByUser = new Map<string, SpaceRole>();
+    const accept = (userUuid: string) => withInvitationLock(
+      token,
+      () => acceptInvitationMembership("builder", membershipDependencies({
+        invitationKey,
+        redis,
+        roleByUser,
+        userUuid,
+      })),
+      redis,
+    );
+
+    const results = await Promise.all([accept("user-1"), accept("user-2")]);
+    assert.equal(results.filter((result) => result.state === "accepted").length, 1);
+    assert.equal(results.filter((result) => result.state === "exhausted").length, 1);
+    assert.equal(roleByUser.size, 1);
+    assert.equal(redis.invitations.get(invitationKey)?.useCount, 1);
+  });
+
+  it("releases a failed database write so another user can accept", async () => {
+    const invitationKey = "invite:database-failure";
+    const redis = new FakeInvitationRedis();
+    redis.invitations.set(invitationKey, {
+      maxUses: 1,
+      useCount: 0,
+      status: "active",
+      reservations: new Map(),
+    });
+    const roleByUser = new Map<string, SpaceRole>();
+
+    await assert.rejects(
+      acceptInvitationMembership("builder", membershipDependencies({
+        invitationKey,
+        redis,
+        roleByUser,
+        userUuid: "failed-user",
+        failApply: () => true,
+      })),
+      /database unavailable/,
+    );
+    assert.equal(redis.invitations.get(invitationKey)?.useCount, 0);
+    assert.equal(invitationUseAvailability(redis.record(invitationKey), "next-user"), "active");
+    assert.deepEqual(
+      await acceptInvitationMembership("builder", membershipDependencies({
+        invitationKey,
+        redis,
+        roleByUser,
+        userUuid: "next-user",
+      })),
+      { state: "accepted", role: "builder" },
+    );
+  });
+
+  it("reclaims an expired reservation when the membership write never happened", async () => {
+    const invitationKey = "invite:crashed-before-database";
+    const redis = new FakeInvitationRedis();
+    redis.invitations.set(invitationKey, {
+      maxUses: 1,
+      useCount: 0,
+      status: "active",
+      reservations: new Map(),
+    });
+    assert.equal(await reserveInvitationUse(invitationKey, "crashed-user", "builder", redis, 1_000), "reserved");
+    assert.equal(invitationUseAvailability(redis.record(invitationKey)), "pending");
+    redis.now += 1_001;
+
+    await reconcileExpiredInvitationUses(
+      invitationKey,
+      redis.record(invitationKey),
+      async () => null,
+      redis,
+      redis.now,
+    );
+    assert.equal(redis.invitations.get(invitationKey)?.useCount, 0);
+    assert.equal(await reserveInvitationUse(invitationKey, "next-user", "builder", redis), "reserved");
+  });
+
+  it("finalizes an expired reservation when the membership write committed before a crash", async () => {
+    const invitationKey = "invite:crashed-after-database";
+    const redis = new FakeInvitationRedis();
+    redis.invitations.set(invitationKey, {
+      maxUses: 1,
+      useCount: 0,
+      status: "active",
+      reservations: new Map(),
+    });
+    assert.equal(await reserveInvitationUse(invitationKey, "committed-user", "builder", redis, 1_000), "reserved");
+    redis.now += 1_001;
+
+    await reconcileExpiredInvitationUses(
+      invitationKey,
+      redis.record(invitationKey),
+      async (userUuid) => userUuid === "committed-user" ? "builder" : null,
+      redis,
+      redis.now,
+    );
+    assert.equal(redis.invitations.get(invitationKey)?.useCount, 1);
+    assert.equal(await reserveInvitationUse(invitationKey, "next-user", "builder", redis), "exhausted");
+  });
+
+  it("serializes different invitation tokens and keeps the highest role", async () => {
+    const spaceId = "space-1";
+    const userUuid = "user-1";
+    const redis = new FakeInvitationRedis();
+    const roleByUser = new Map<string, SpaceRole>();
+    for (const token of ["host-token", "builder-token"]) {
+      redis.invitations.set(`invite:${token}`, {
+        maxUses: 1,
+        useCount: 0,
+        status: "active",
+        reservations: new Map(),
+      });
+    }
+    const accept = (token: string, role: SpaceRole) => withInvitationLock(
+      token,
+      () => withInvitationLock(
+        invitationMembershipLockId(spaceId, userUuid),
+        () => acceptInvitationMembership(role, membershipDependencies({
+          invitationKey: `invite:${token}`,
+          redis,
+          roleByUser,
+          userUuid,
+          role,
+        })),
+        redis,
+      ),
+      redis,
+    );
+
+    await Promise.all([accept("host-token", "host"), accept("builder-token", "builder")]);
+    assert.equal(roleByUser.get(userUuid), "host");
+  });
+
+  it("does not write membership when Redis reservation fails", async () => {
+    let applied = false;
+    await assert.rejects(
+      acceptInvitationMembership("builder", {
+        getRole: async () => null,
+        reserveUse: () => reserveInvitationUse("invite:offline", "user-1", "builder", {
+          eval: async () => { throw new Error("redis unavailable"); },
+        }),
+        applyRole: async () => {
+          applied = true;
+          return "builder";
+        },
+        finalizeUse: async () => "finalized",
+        releaseUse: async () => undefined,
+      }),
+      /redis unavailable/,
+    );
+    assert.equal(applied, false);
+  });
+
+  it("rejects an acceptance when its reservation disappears before commit", async () => {
+    let applied = false;
+    await assert.rejects(
+      acceptInvitationMembership("builder", {
+        getRole: async () => null,
+        reserveUse: async () => "reserved",
+        applyRole: async () => {
+          applied = true;
+          return "builder";
+        },
+        finalizeUse: async () => "absent",
+        releaseUse: async () => undefined,
+      }),
+      /reservation was lost/,
+    );
+    assert.equal(applied, true);
+  });
+
+  it("does not let an existing reservation bypass a later revoke", async () => {
+    const invitationKey = "invite:revoked";
+    const userUuid = "reserved-user";
+    const redis = new FakeInvitationRedis();
+    const invitation: InvitationState = {
+      maxUses: 1,
+      useCount: 0,
+      status: "active",
+      reservations: new Map(),
+    };
+    redis.invitations.set(invitationKey, invitation);
+
+    assert.equal(await reserveInvitationUse(invitationKey, userUuid, "builder", redis), "reserved");
+    invitation.status = "revoked";
+    assert.equal(invitationUseAvailability(redis.record(invitationKey), userUuid), "revoked");
+    assert.equal(await reserveInvitationUse(invitationKey, userUuid, "builder", redis), "revoked");
+  });
+
+  it("does not restore a removed or downgraded membership from a consumed invitation", async () => {
+    const invitationKey = "invite:consumed";
+    const redis = new FakeInvitationRedis();
+    redis.invitations.set(invitationKey, {
+      maxUses: 0,
+      useCount: 0,
+      status: "active",
+      reservations: new Map(),
+    });
+    const roleByUser = new Map<string, SpaceRole>();
+    const accept = (userUuid: string, role: SpaceRole) => acceptInvitationMembership(
+      role,
+      membershipDependencies({ invitationKey, redis, roleByUser, userUuid, role }),
+    );
+
+    assert.deepEqual(await accept("removed-user", "builder"), { state: "accepted", role: "builder" });
+    roleByUser.delete("removed-user");
+    assert.deepEqual(await accept("removed-user", "builder"), { state: "used" });
+    assert.equal(roleByUser.has("removed-user"), false);
+
+    assert.deepEqual(await accept("downgraded-user", "host"), { state: "accepted", role: "host" });
+    roleByUser.set("downgraded-user", "guest");
+    assert.deepEqual(await accept("downgraded-user", "host"), { state: "used" });
+    assert.equal(roleByUser.get("downgraded-user"), "guest");
+  });
+});

--- a/apps/api/src/invitation-acceptance.test.ts
+++ b/apps/api/src/invitation-acceptance.test.ts
@@ -4,6 +4,7 @@ import type { SpaceRole } from "@cohub/db";
 import {
   acceptInvitationMembership,
   finalizeInvitationUse,
+  hasInvitationUseReservation,
   invitationUseAvailability,
   reconcileExpiredInvitationUses,
   releaseInvitationUse,
@@ -122,6 +123,7 @@ function membershipDependencies(input: {
   const invitedRole = input.role ?? "builder";
   return {
     getRole: async () => input.roleByUser.get(input.userUuid) ?? null,
+    hasReservedUse: async () => hasInvitationUseReservation(input.redis.record(input.invitationKey), input.userUuid),
     reserveUse: () => reserveInvitationUse(
       input.invitationKey,
       input.userUuid,
@@ -141,6 +143,18 @@ function membershipDependencies(input: {
   };
 }
 
+async function acceptAndFinalize(
+  invitedRole: SpaceRole,
+  dependencies: ReturnType<typeof membershipDependencies>,
+) {
+  const result = await acceptInvitationMembership(invitedRole, dependencies);
+  if (result.state === "accepted" && result.pendingFinalization) {
+    const finalization = await dependencies.finalizeUse();
+    assert.ok(finalization === "finalized" || finalization === "existing");
+  }
+  return result;
+}
+
 describe("invitation use reservations", () => {
   it("serializes concurrent accepts and never exceeds maxUses", async () => {
     const token = "single-use-token";
@@ -155,7 +169,7 @@ describe("invitation use reservations", () => {
     const roleByUser = new Map<string, SpaceRole>();
     const accept = (userUuid: string) => withInvitationLock(
       token,
-      () => acceptInvitationMembership("builder", membershipDependencies({
+      () => acceptAndFinalize("builder", membershipDependencies({
         invitationKey,
         redis,
         roleByUser,
@@ -195,13 +209,13 @@ describe("invitation use reservations", () => {
     assert.equal(redis.invitations.get(invitationKey)?.useCount, 0);
     assert.equal(invitationUseAvailability(redis.record(invitationKey), "next-user"), "active");
     assert.deepEqual(
-      await acceptInvitationMembership("builder", membershipDependencies({
+      await acceptAndFinalize("builder", membershipDependencies({
         invitationKey,
         redis,
         roleByUser,
         userUuid: "next-user",
       })),
-      { state: "accepted", role: "builder" },
+      { state: "accepted", role: "builder", pendingFinalization: true },
     );
   });
 
@@ -269,7 +283,7 @@ describe("invitation use reservations", () => {
       token,
       () => withInvitationLock(
         invitationMembershipLockId(spaceId, userUuid),
-        () => acceptInvitationMembership(role, membershipDependencies({
+        () => acceptAndFinalize(role, membershipDependencies({
           invitationKey: `invite:${token}`,
           redis,
           roleByUser,
@@ -290,6 +304,7 @@ describe("invitation use reservations", () => {
     await assert.rejects(
       acceptInvitationMembership("builder", {
         getRole: async () => null,
+        hasReservedUse: async () => false,
         reserveUse: () => reserveInvitationUse("invite:offline", "user-1", "builder", {
           eval: async () => { throw new Error("redis unavailable"); },
         }),
@@ -297,7 +312,6 @@ describe("invitation use reservations", () => {
           applied = true;
           return "builder";
         },
-        finalizeUse: async () => "finalized",
         releaseUse: async () => undefined,
       }),
       /redis unavailable/,
@@ -305,22 +319,15 @@ describe("invitation use reservations", () => {
     assert.equal(applied, false);
   });
 
-  it("rejects an acceptance when its reservation disappears before commit", async () => {
-    let applied = false;
-    await assert.rejects(
-      acceptInvitationMembership("builder", {
-        getRole: async () => null,
-        reserveUse: async () => "reserved",
-        applyRole: async () => {
-          applied = true;
-          return "builder";
-        },
-        finalizeUse: async () => "absent",
-        releaseUse: async () => undefined,
-      }),
-      /reservation was lost/,
-    );
-    assert.equal(applied, true);
+  it("leaves the reservation pending until the membership transaction commits", async () => {
+    const result = await acceptInvitationMembership("builder", {
+      getRole: async () => null,
+      hasReservedUse: async () => false,
+      reserveUse: async () => "reserved",
+      applyRole: async () => "builder",
+      releaseUse: async () => undefined,
+    });
+    assert.deepEqual(result, { state: "accepted", role: "builder", pendingFinalization: true });
   });
 
   it("does not let an existing reservation bypass a later revoke", async () => {
@@ -351,17 +358,17 @@ describe("invitation use reservations", () => {
       reservations: new Map(),
     });
     const roleByUser = new Map<string, SpaceRole>();
-    const accept = (userUuid: string, role: SpaceRole) => acceptInvitationMembership(
+    const accept = (userUuid: string, role: SpaceRole) => acceptAndFinalize(
       role,
       membershipDependencies({ invitationKey, redis, roleByUser, userUuid, role }),
     );
 
-    assert.deepEqual(await accept("removed-user", "builder"), { state: "accepted", role: "builder" });
+    assert.deepEqual(await accept("removed-user", "builder"), { state: "accepted", role: "builder", pendingFinalization: true });
     roleByUser.delete("removed-user");
     assert.deepEqual(await accept("removed-user", "builder"), { state: "used" });
     assert.equal(roleByUser.has("removed-user"), false);
 
-    assert.deepEqual(await accept("downgraded-user", "host"), { state: "accepted", role: "host" });
+    assert.deepEqual(await accept("downgraded-user", "host"), { state: "accepted", role: "host", pendingFinalization: true });
     roleByUser.set("downgraded-user", "guest");
     assert.deepEqual(await accept("downgraded-user", "host"), { state: "used" });
     assert.equal(roleByUser.get("downgraded-user"), "guest");

--- a/apps/api/src/invitation-acceptance.test.ts
+++ b/apps/api/src/invitation-acceptance.test.ts
@@ -5,6 +5,7 @@ import {
   acceptInvitationMembership,
   finalizeInvitationUse,
   hasInvitationUseReservation,
+  invitationLimitError,
   invitationUseAvailability,
   reconcileExpiredInvitationUses,
   releaseInvitationUse,
@@ -156,6 +157,14 @@ async function acceptAndFinalize(
 }
 
 describe("invitation use reservations", () => {
+  it("rejects non-integer invitation limits", () => {
+    assert.match(invitationLimitError("3600", 1) ?? "", /ttlSeconds/);
+    assert.match(invitationLimitError(3600.5, 1) ?? "", /ttlSeconds/);
+    assert.match(invitationLimitError(3600, "1") ?? "", /maxUses/);
+    assert.match(invitationLimitError(3600, 1.5) ?? "", /maxUses/);
+    assert.equal(invitationLimitError(3600, 0), null);
+  });
+
   it("serializes concurrent accepts and never exceeds maxUses", async () => {
     const token = "single-use-token";
     const invitationKey = `invite:${token}`;

--- a/apps/api/src/invitation-acceptance.ts
+++ b/apps/api/src/invitation-acceptance.ts
@@ -88,6 +88,16 @@ return "released"
 
 const INVITATION_USE_LEASE_MS = 60_000;
 
+export function invitationLimitError(ttlSeconds: unknown, maxUses: unknown): string | null {
+  if (!Number.isSafeInteger(ttlSeconds) || (ttlSeconds as number) <= 0 || (ttlSeconds as number) > 30 * 24 * 60 * 60) {
+    return "ttlSeconds must be an integer between 1 and 30 days";
+  }
+  if (!Number.isSafeInteger(maxUses) || (maxUses as number) < 0) {
+    return "maxUses must be a non-negative integer";
+  }
+  return null;
+}
+
 export type InvitationUseReservationState =
   | "reserved"
   | "existing"

--- a/apps/api/src/invitation-acceptance.ts
+++ b/apps/api/src/invitation-acceptance.ts
@@ -1,0 +1,298 @@
+import { createHash } from "node:crypto";
+import { isRoleHigherThan } from "@cohub/core/permissions";
+import type { SpaceRole } from "@cohub/db";
+
+const RESERVE_INVITATION_USE_SCRIPT = `
+if redis.call("exists", KEYS[1]) == 0 then
+  return "missing"
+end
+
+local status = redis.call("hget", KEYS[1], "status")
+if status == "revoked" then
+  return "revoked"
+end
+
+local existing_reservation = redis.call("hget", KEYS[1], ARGV[1])
+if existing_reservation then
+  if string.sub(existing_reservation, 1, 8) == "pending:" then
+    return "existing"
+  end
+  if existing_reservation == "committed" or existing_reservation == "1" then
+    return "committed"
+  end
+  return "committed"
+end
+
+if status == "exhausted" then
+  return "exhausted"
+end
+
+local max_uses = tonumber(redis.call("hget", KEYS[1], "max_uses") or "0") or 0
+local use_count = tonumber(redis.call("hget", KEYS[1], "use_count") or "0") or 0
+if max_uses > 0 and use_count >= max_uses then
+  redis.call("hset", KEYS[1], "status", "exhausted")
+  return "exhausted"
+end
+
+local now = redis.call("TIME")
+local expires_at = (tonumber(now[1]) * 1000) + math.floor(tonumber(now[2]) / 1000) + tonumber(ARGV[2])
+local reservation = "pending:" .. tostring(expires_at) .. ":" .. ARGV[3] .. ":" .. ARGV[4]
+local new_count = use_count + 1
+if max_uses > 0 and new_count >= max_uses then
+  redis.call("hset", KEYS[1], ARGV[1], reservation, "use_count", tostring(new_count), "status", "exhausted")
+else
+  redis.call("hset", KEYS[1], ARGV[1], reservation, "use_count", tostring(new_count))
+end
+return "reserved"
+`;
+
+const FINALIZE_INVITATION_USE_SCRIPT = `
+if redis.call("exists", KEYS[1]) == 0 then
+  return "missing"
+end
+local reservation = redis.call("hget", KEYS[1], ARGV[1])
+if not reservation then
+  return "absent"
+end
+if reservation == "committed" or reservation == "1" then
+  return "existing"
+end
+if string.sub(reservation, 1, 8) ~= "pending:" then
+  return "invalid"
+end
+redis.call("hset", KEYS[1], ARGV[1], "committed")
+return "finalized"
+`;
+
+const RELEASE_INVITATION_USE_SCRIPT = `
+if redis.call("exists", KEYS[1]) == 0 then
+  return "missing"
+end
+local reservation = redis.call("hget", KEYS[1], ARGV[1])
+if not reservation then
+  return "absent"
+end
+if string.sub(reservation, 1, 8) ~= "pending:" then
+  return "committed"
+end
+redis.call("hdel", KEYS[1], ARGV[1])
+local use_count = math.max(0, (tonumber(redis.call("hget", KEYS[1], "use_count") or "0") or 0) - 1)
+local max_uses = tonumber(redis.call("hget", KEYS[1], "max_uses") or "0") or 0
+local status = redis.call("hget", KEYS[1], "status")
+redis.call("hset", KEYS[1], "use_count", tostring(use_count))
+if status == "exhausted" and (max_uses == 0 or use_count < max_uses) then
+  redis.call("hset", KEYS[1], "status", "active")
+end
+return "released"
+`;
+
+const INVITATION_USE_LEASE_MS = 60_000;
+
+export type InvitationUseReservationState =
+  | "reserved"
+  | "existing"
+  | "committed"
+  | "missing"
+  | "revoked"
+  | "exhausted";
+
+export type InvitationUseFinalizationState =
+  | "finalized"
+  | "existing"
+  | "absent"
+  | "missing";
+
+export type InvitationUseReservationClient = {
+  eval: (
+    script: string,
+    numKeys: number,
+    invitationKey: string,
+    ...args: string[]
+  ) => Promise<unknown>;
+};
+
+type PendingInvitationUse = {
+  userUuid: string;
+  role: SpaceRole;
+  expiresAt: number;
+};
+
+export function invitationUseReservationField(userUuid: string): string {
+  const userHash = createHash("sha256").update(userUuid).digest("hex");
+  return `use_reservation:${userHash}`;
+}
+
+export function hasInvitationUseReservation(
+  invitation: Record<string, string>,
+  userUuid: string,
+): boolean {
+  return invitation[invitationUseReservationField(userUuid)] !== undefined;
+}
+
+export function invitationUseAvailability(
+  invitation: Record<string, string>,
+  userUuid?: string,
+): "active" | "pending" | "revoked" | "exhausted" {
+  if (invitation.status === "revoked") return "revoked";
+  if (userUuid && hasInvitationUseReservation(invitation, userUuid)) return "active";
+
+  const maxUses = Number.parseInt(invitation.max_uses ?? "0", 10);
+  const useCount = Number.parseInt(invitation.use_count ?? "0", 10);
+  if (invitation.status === "exhausted" || (maxUses > 0 && useCount >= maxUses)) {
+    if (Object.entries(invitation).some(([field, value]) => (
+      field.startsWith("use_reservation:") && value.startsWith("pending:")
+    ))) return "pending";
+    return "exhausted";
+  }
+  return "active";
+}
+
+export async function reserveInvitationUse(
+  invitationKey: string,
+  userUuid: string,
+  invitedRole: SpaceRole,
+  client: InvitationUseReservationClient,
+  leaseMs = INVITATION_USE_LEASE_MS,
+): Promise<InvitationUseReservationState> {
+  const result = await client.eval(
+    RESERVE_INVITATION_USE_SCRIPT,
+    1,
+    invitationKey,
+    invitationUseReservationField(userUuid),
+    String(leaseMs),
+    userUuid,
+    invitedRole,
+  );
+  if (
+    result === "reserved"
+    || result === "existing"
+    || result === "committed"
+    || result === "missing"
+    || result === "revoked"
+    || result === "exhausted"
+  ) {
+    return result;
+  }
+  throw new Error("invalid invitation reservation response");
+}
+
+export async function finalizeInvitationUse(
+  invitationKey: string,
+  userUuid: string,
+  client: InvitationUseReservationClient,
+): Promise<InvitationUseFinalizationState> {
+  const result = await client.eval(
+    FINALIZE_INVITATION_USE_SCRIPT,
+    1,
+    invitationKey,
+    invitationUseReservationField(userUuid),
+  );
+  if (result === "finalized" || result === "existing" || result === "absent" || result === "missing") {
+    return result;
+  }
+  throw new Error("invalid invitation finalization response");
+}
+
+export async function releaseInvitationUse(
+  invitationKey: string,
+  userUuid: string,
+  client: InvitationUseReservationClient,
+): Promise<void> {
+  const result = await client.eval(
+    RELEASE_INVITATION_USE_SCRIPT,
+    1,
+    invitationKey,
+    invitationUseReservationField(userUuid),
+  );
+  if (result === "released" || result === "committed" || result === "absent" || result === "missing") return;
+  throw new Error("invalid invitation release response");
+}
+
+export function expiredInvitationUses(
+  invitation: Record<string, string>,
+  now = Date.now(),
+): PendingInvitationUse[] {
+  const roles = new Set<SpaceRole>(["host", "builder", "guest"]);
+  const pending: PendingInvitationUse[] = [];
+  for (const [field, value] of Object.entries(invitation)) {
+    if (!field.startsWith("use_reservation:") || !value.startsWith("pending:")) continue;
+    const [kind, rawExpiresAt, userUuid, rawRole, ...extra] = value.split(":");
+    const expiresAt = Number(rawExpiresAt);
+    if (
+      kind !== "pending"
+      || extra.length > 0
+      || !Number.isSafeInteger(expiresAt)
+      || expiresAt > now
+      || !userUuid
+      || !roles.has(rawRole as SpaceRole)
+    ) continue;
+    pending.push({ userUuid, role: rawRole as SpaceRole, expiresAt });
+  }
+  return pending;
+}
+
+export async function reconcileExpiredInvitationUses(
+  invitationKey: string,
+  invitation: Record<string, string>,
+  getRole: (userUuid: string) => Promise<SpaceRole | null>,
+  client: InvitationUseReservationClient,
+  now = Date.now(),
+): Promise<void> {
+  for (const pending of expiredInvitationUses(invitation, now)) {
+    const currentRole = await getRole(pending.userUuid);
+    if (currentRole && !isRoleHigherThan(pending.role, currentRole)) {
+      await finalizeInvitationUse(invitationKey, pending.userUuid, client);
+    } else {
+      await releaseInvitationUse(invitationKey, pending.userUuid, client);
+    }
+  }
+}
+
+type InvitationMembershipDependencies = {
+  getRole: () => Promise<SpaceRole | null>;
+  reserveUse: () => Promise<InvitationUseReservationState>;
+  applyRole: () => Promise<SpaceRole>;
+  finalizeUse: () => Promise<InvitationUseFinalizationState>;
+  releaseUse: () => Promise<void>;
+};
+
+export type InvitationMembershipAcceptance =
+  | { state: "accepted"; role: SpaceRole }
+  | { state: "missing" | "revoked" | "exhausted" | "used" };
+
+export async function acceptInvitationMembership(
+  invitedRole: SpaceRole,
+  dependencies: InvitationMembershipDependencies,
+): Promise<InvitationMembershipAcceptance> {
+  const existingRole = await dependencies.getRole();
+  if (existingRole && !isRoleHigherThan(invitedRole, existingRole)) {
+    await dependencies.finalizeUse();
+    return { state: "accepted", role: existingRole };
+  }
+
+  const reservation = await dependencies.reserveUse();
+  if (reservation === "missing" || reservation === "revoked" || reservation === "exhausted") {
+    return { state: reservation };
+  }
+  if (reservation === "committed") return { state: "used" };
+
+  let role: SpaceRole;
+  try {
+    role = await dependencies.applyRole();
+  } catch (error) {
+    await dependencies.releaseUse().catch(() => undefined);
+    throw error;
+  }
+  let finalization: InvitationUseFinalizationState;
+  try {
+    finalization = await dependencies.finalizeUse();
+  } catch (error) {
+    await dependencies.releaseUse().catch(() => undefined);
+    throw error;
+  }
+  if (finalization === "absent" || finalization === "missing") {
+    await dependencies.releaseUse().catch(() => undefined);
+    throw new Error("invitation reservation was lost before membership committed");
+  }
+  return { state: "accepted", role };
+}

--- a/apps/api/src/invitation-acceptance.ts
+++ b/apps/api/src/invitation-acceptance.ts
@@ -250,14 +250,14 @@ export async function reconcileExpiredInvitationUses(
 
 type InvitationMembershipDependencies = {
   getRole: () => Promise<SpaceRole | null>;
+  hasReservedUse: () => Promise<boolean>;
   reserveUse: () => Promise<InvitationUseReservationState>;
   applyRole: () => Promise<SpaceRole>;
-  finalizeUse: () => Promise<InvitationUseFinalizationState>;
   releaseUse: () => Promise<void>;
 };
 
 export type InvitationMembershipAcceptance =
-  | { state: "accepted"; role: SpaceRole }
+  | { state: "accepted"; role: SpaceRole; pendingFinalization: boolean }
   | { state: "missing" | "revoked" | "exhausted" | "used" };
 
 export async function acceptInvitationMembership(
@@ -266,8 +266,11 @@ export async function acceptInvitationMembership(
 ): Promise<InvitationMembershipAcceptance> {
   const existingRole = await dependencies.getRole();
   if (existingRole && !isRoleHigherThan(invitedRole, existingRole)) {
-    await dependencies.finalizeUse();
-    return { state: "accepted", role: existingRole };
+    return {
+      state: "accepted",
+      role: existingRole,
+      pendingFinalization: await dependencies.hasReservedUse(),
+    };
   }
 
   const reservation = await dependencies.reserveUse();
@@ -283,16 +286,5 @@ export async function acceptInvitationMembership(
     await dependencies.releaseUse().catch(() => undefined);
     throw error;
   }
-  let finalization: InvitationUseFinalizationState;
-  try {
-    finalization = await dependencies.finalizeUse();
-  } catch (error) {
-    await dependencies.releaseUse().catch(() => undefined);
-    throw error;
-  }
-  if (finalization === "absent" || finalization === "missing") {
-    await dependencies.releaseUse().catch(() => undefined);
-    throw new Error("invitation reservation was lost before membership committed");
-  }
-  return { state: "accepted", role };
+  return { state: "accepted", role, pendingFinalization: true };
 }

--- a/apps/api/src/invitation-lock.test.ts
+++ b/apps/api/src/invitation-lock.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  invitationLockKey,
+  withInvitationLock,
+} from "./invitation-lock.js";
+
+test("accept and revoke derive the same opaque invitation lock key", () => {
+  assert.equal(invitationLockKey("invite-token"), invitationLockKey("invite-token"));
+  assert.notEqual(invitationLockKey("invite-token"), invitationLockKey("other-token"));
+  assert.equal(invitationLockKey("invite-token").startsWith("invite:token-lock:"), true);
+  assert.equal(invitationLockKey("invite-token").includes("invite-token"), false);
+});
+
+test("invitation lock releases after the guarded operation", async () => {
+  const calls: string[] = [];
+  const client = {
+    async set(key: string, _value: string, _mode: "PX", _ttlMs: number, _condition: "NX") {
+      calls.push(`set:${key}`);
+      return "OK" as const;
+    },
+    async eval(_script: string, _numKeys: number, lockKey: string, _lockToken: string) {
+      calls.push(`eval:${lockKey}`);
+      return 1;
+    },
+  };
+  const result = await withInvitationLock("invite-token", async () => "accepted", client);
+  assert.equal(result, "accepted");
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0]?.startsWith("set:invite:token-lock:"), true);
+  assert.equal(calls[1]?.startsWith("eval:"), true);
+});
+
+test("accept and revoke operations for one token cannot overlap", async () => {
+  const locks = new Map<string, string>();
+  const client = {
+    async set(key: string, value: string, _mode: "PX", _ttlMs: number, _condition: "NX") {
+      if (locks.has(key)) return null;
+      locks.set(key, value);
+      return "OK" as const;
+    },
+    async eval(script: string, _numKeys: number, lockKey: string, lockToken: string) {
+      if (locks.get(lockKey) !== lockToken) return 0;
+      if (script.includes("pexpire")) return 1;
+      locks.delete(lockKey);
+      return 1;
+    },
+  };
+  const events: string[] = [];
+  let finishAccept: (() => void) | undefined;
+  const acceptFinished = new Promise<void>((resolve) => {
+    finishAccept = resolve;
+  });
+  const accept = withInvitationLock("invite-token", async () => {
+    events.push("accept:start");
+    await acceptFinished;
+    events.push("accept:end");
+  }, client);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  const revoke = withInvitationLock("invite-token", async () => {
+    events.push("revoke");
+  }, client);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.deepEqual(events, ["accept:start"]);
+
+  finishAccept?.();
+  await Promise.all([accept, revoke]);
+  assert.deepEqual(events, ["accept:start", "accept:end", "revoke"]);
+});
+
+test("invitation lock renews while a guarded database write is running", async () => {
+  const locks = new Map<string, string>();
+  let refreshes = 0;
+  const client = {
+    async set(key: string, value: string, _mode: "PX", _ttlMs: number, _condition: "NX") {
+      if (locks.has(key)) return null;
+      locks.set(key, value);
+      return "OK" as const;
+    },
+    async eval(script: string, _numKeys: number, lockKey: string, lockToken: string) {
+      if (locks.get(lockKey) !== lockToken) return 0;
+      if (script.includes("pexpire")) {
+        refreshes += 1;
+        return 1;
+      }
+      locks.delete(lockKey);
+      return 1;
+    },
+  };
+
+  await withInvitationLock(
+    "slow-invite",
+    () => new Promise<void>((resolve) => setTimeout(resolve, 35)),
+    client,
+    { ttlMs: 15 },
+  );
+  assert.equal(refreshes >= 2, true);
+  assert.equal(locks.size, 0);
+});

--- a/apps/api/src/invitation-lock.ts
+++ b/apps/api/src/invitation-lock.ts
@@ -1,0 +1,113 @@
+import { createHash, randomUUID } from "node:crypto";
+import { createLogger } from "@cohub/infra/logging";
+import { sql } from "drizzle-orm";
+import { db } from "./db/index.js";
+
+const logger = createLogger({ serviceName: "cohub-api" });
+const INVITE_LOCK_TTL_MS = 30_000;
+const INVITE_LOCK_WAIT_MS = 5_000;
+const INVITE_LOCK_RETRY_MS = 25;
+const REFRESH_INVITE_LOCK_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("pexpire", KEYS[1], ARGV[2])
+end
+return 0
+`;
+const RELEASE_INVITE_LOCK_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+end
+return 0
+`;
+
+export type InvitationLockClient = {
+  set: (key: string, value: string, mode: "PX", ttlMs: number, condition: "NX") => Promise<"OK" | null>;
+  eval: (script: string, numKeys: number, lockKey: string, ...args: string[]) => Promise<unknown>;
+};
+
+export class InvitationLockTimeoutError extends Error {
+  override name = "InvitationLockTimeoutError";
+}
+
+export function invitationLockKey(token: string): string {
+  const tokenHash = createHash("sha256").update(token).digest("hex");
+  return `invite:token-lock:${tokenHash}`;
+}
+
+export function invitationMembershipLockId(spaceId: string, userUuid: string): string {
+  return `membership:${spaceId}:${userUuid}`;
+}
+
+type InvitationTransactionCallback = Parameters<typeof db.transaction>[0];
+export type InvitationTransaction = Parameters<InvitationTransactionCallback>[0];
+
+function invitationAdvisoryLockKeys(token: string): [number, number] {
+  const digest = createHash("sha256").update(token).digest();
+  return [digest.readInt32BE(0), digest.readInt32BE(4)];
+}
+
+export async function withInvitationDatabaseLock<T>(
+  token: string,
+  fn: (transaction: InvitationTransaction) => Promise<T>,
+): Promise<T> {
+  const [firstKey, secondKey] = invitationAdvisoryLockKeys(token);
+  return db.transaction(async (transaction) => {
+    await transaction.execute(
+      sql`select pg_advisory_xact_lock(${firstKey}, ${secondKey})`,
+    );
+    return fn(transaction);
+  });
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export async function withInvitationLock<T>(
+  token: string,
+  fn: () => Promise<T>,
+  client: InvitationLockClient,
+  options: { ttlMs?: number } = {},
+): Promise<T> {
+  const lockKey = invitationLockKey(token);
+  const lockToken = randomUUID();
+  const deadline = Date.now() + INVITE_LOCK_WAIT_MS;
+  const ttlMs = options.ttlMs ?? INVITE_LOCK_TTL_MS;
+
+  while (true) {
+    const acquired = await client.set(lockKey, lockToken, "PX", ttlMs, "NX");
+    if (acquired === "OK") break;
+    if (Date.now() >= deadline) throw new InvitationLockTimeoutError("invitation is busy");
+    await sleep(INVITE_LOCK_RETRY_MS);
+  }
+
+  let lockLost = false;
+  let refreshTail = Promise.resolve();
+  const refresh = () => {
+    refreshTail = refreshTail.then(async () => {
+      const refreshed = await client.eval(
+        REFRESH_INVITE_LOCK_SCRIPT,
+        1,
+        lockKey,
+        lockToken,
+        String(ttlMs),
+      );
+      if (refreshed !== 1) lockLost = true;
+    }).catch((error) => {
+      lockLost = true;
+      logger.warn("[Invite] failed to refresh token lock", { lockKey, error });
+    });
+  };
+  const refreshTimer = setInterval(refresh, Math.max(1, Math.floor(ttlMs / 3)));
+  refreshTimer.unref?.();
+  try {
+    const result = await fn();
+    await refreshTail;
+    if (lockLost) throw new InvitationLockTimeoutError("invitation lock was lost");
+    return result;
+  } finally {
+    clearInterval(refreshTimer);
+    await refreshTail;
+    await client.eval(RELEASE_INVITE_LOCK_SCRIPT, 1, lockKey, lockToken).catch((error) => {
+      logger.warn("[Invite] failed to release token lock", { lockKey, error });
+    });
+  }
+}

--- a/apps/api/src/lib/middleware.account-auth.test.ts
+++ b/apps/api/src/lib/middleware.account-auth.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { accountUserFromPrincipal, type AuthUser, type RequestPrincipal } from "./middleware.js";
+
+const account = { uuid: "viewer-1" } as AuthUser;
+
+describe("account principal isolation", () => {
+  it("accepts only the real account principal", () => {
+    const principals: RequestPrincipal[] = [
+      { type: "user", user: account },
+      {
+        type: "work_session",
+        workSession: {
+          type: "work_session",
+          typ: "work_session",
+          userUuid: account.uuid,
+          workId: "work-1",
+          spaceId: "space-1",
+          workScopes: [],
+          viewerScopes: [],
+          scopes: [],
+          iat: 0,
+          exp: 1,
+        },
+      },
+      {
+        type: "preview_session",
+        previewSession: {
+          type: "preview_session",
+          typ: "preview_session",
+          userUuid: account.uuid,
+          spaceId: "space-1",
+          scopes: [],
+          iat: 0,
+          exp: 1,
+        },
+      },
+      {
+        type: "execution",
+        execution: {
+          type: "execution",
+          actorUserId: account.uuid,
+          spaceId: "space-1",
+          sessionId: null,
+          turnId: null,
+          source: "test",
+          scopes: [],
+          expiresAt: 1,
+        },
+      },
+    ];
+
+    assert.equal(accountUserFromPrincipal(principals[0]), account);
+    assert.equal(accountUserFromPrincipal(principals[1]), null);
+    assert.equal(accountUserFromPrincipal(principals[2]), null);
+    assert.equal(accountUserFromPrincipal(principals[3]), null);
+    assert.equal(accountUserFromPrincipal(null), null);
+  });
+});

--- a/apps/api/src/lib/middleware.ts
+++ b/apps/api/src/lib/middleware.ts
@@ -84,6 +84,22 @@ export const requireAuth = (c: Context): AuthUser | Response => {
  */
 export const useAuth = (c: Context): AuthUser | Response => requireAuth(c);
 
+export const accountUserFromPrincipal = (
+  principal: RequestPrincipal | null | undefined,
+): AuthUser | null => principal?.type === "user" ? principal.user : null;
+
+export const getOptionalAccountAuth = (c: Context): AuthUser | null => (
+  accountUserFromPrincipal(getRequestPrincipal(c))
+);
+
+/** Account APIs must never treat scoped principals as the user's login session. */
+export const useAccountAuth = (c: Context): AuthUser | Response => {
+  const principal = getRequestPrincipal(c);
+  const user = accountUserFromPrincipal(principal);
+  if (user) return user;
+  return principal ? c.json({ message: "forbidden" }, 403) : c.json({ message: "unauthorized" }, 401);
+};
+
 /**
  * Returns the authenticated user when present, otherwise null.
  * Use this for routes whose authorization is fully determined by RBAC
@@ -91,6 +107,10 @@ export const useAuth = (c: Context): AuthUser | Response => requireAuth(c);
  */
 export const getOptionalAuth = (c: Context): AuthUser | null => {
   return principalToAuthUser(c.get("principal") as RequestPrincipal | null | undefined);
+};
+
+export const getRequestPrincipal = (c: Context): RequestPrincipal | null => {
+  return c.get("principal") as RequestPrincipal | null | undefined ?? null;
 };
 
 export const authzDenied = (c: Context) => {

--- a/apps/api/src/owner-resource-access.test.ts
+++ b/apps/api/src/owner-resource-access.test.ts
@@ -13,9 +13,9 @@ import {
 } from "./owner-resource-access.js";
 
 const user = (uuid = "viewer-1"): OwnerResourcePrincipal => ({ type: "user", user: { uuid } });
-const work = (uuid = "viewer-1", spaceId = "space-1"): OwnerResourcePrincipal => ({
+const work = (uuid = "viewer-1", spaceId = "space-1", workId = "work-1"): OwnerResourcePrincipal => ({
   type: "work_session",
-  workSession: { userUuid: uuid, spaceId },
+  workSession: { userUuid: uuid, spaceId, workId },
 });
 const preview = (uuid = "viewer-1", spaceId = "space-1"): OwnerResourcePrincipal => ({
   type: "preview_session",
@@ -58,7 +58,7 @@ describe("owner-bound Work resource access", () => {
     assert.equal(await canBindGenerationToSession(execution(), session, async () => false), false);
   });
 
-  it("binds Work session writes to the viewer owner unless broad read is also granted", async () => {
+  it("never upgrades read access into cross-owner Work writes", async () => {
     const promptOnly = async (permission: string) => permission === "session.prompt.fullaccess";
     const promptAndBroadRead = async (permission: string) => (
       permission === "session.prompt.fullaccess" || permission === "session.view"
@@ -80,11 +80,17 @@ describe("owner-bound Work resource access", () => {
       session,
       "session.prompt.fullaccess",
       promptAndBroadRead,
-    ), true);
+    ), false);
   });
 
   it("reads owner generation tasks only with the active Work generation grant", async () => {
-    const task = { taskType: "generation", spaceId: "space-1", sessionId: "session-1", userUuid: "viewer-1" };
+    const task = {
+      taskType: "generation",
+      spaceId: "space-1",
+      sessionId: "session-1",
+      userUuid: "viewer-1",
+      payload: { data: { workId: "work-1" } },
+    };
     assert.equal(await canReadTaskResource(user(), task, async () => false), true);
     assert.equal(await canReadTaskResource(
       work(),
@@ -93,9 +99,24 @@ describe("owner-bound Work resource access", () => {
     ), true);
     assert.equal(await canReadTaskResource(work(), task, async () => false), false);
     assert.equal(await canReadTaskResource(
+      work("viewer-1", "space-1", "work-2"),
+      task,
+      async (permission) => permission === "generation.create",
+    ), false);
+    assert.equal(await canReadTaskResource(
       work("viewer-1", "space-2"),
       task,
       async (permission) => permission === "generation.create",
+    ), false);
+    assert.equal(await canReadTaskResource(
+      work(),
+      { ...task, taskType: "run_command" },
+      async (permission) => permission === "taskrun.view",
+    ), false);
+    assert.equal(await canReadTaskResource(
+      work(),
+      { ...task, userUuid: "viewer-2" },
+      async (permission) => permission === "taskrun.view",
     ), false);
     assert.equal(await canReadTaskResource(preview(), task, async () => false), false);
     assert.equal(await canReadTaskResource(execution(), task, async () => false), false);
@@ -116,11 +137,13 @@ describe("owner-bound Work resource access", () => {
     assert.deepEqual(accountScope, {
       userUuid: "viewer-1",
       spaceId: null,
+      workId: null,
       requiresGenerationGrant: false,
     });
     assert.deepEqual(workScope, {
       userUuid: "viewer-1",
       spaceId: "space-1",
+      workId: "work-1",
       requiresGenerationGrant: true,
     });
     assert.ok(accountScope);
@@ -159,10 +182,10 @@ describe("owner-bound Work resource access", () => {
       externalSessionId: "external-1",
       meta: { secret: "value" },
     });
-    assert.equal(summary.meta, null);
-    assert.equal(summary.externalSessionId, null);
-    assert.equal(summary.latestMessageText, null);
-    assert.equal(summary.lastMessageId, null);
+    assert.equal("meta" in summary, false);
+    assert.equal("externalSessionId" in summary, false);
+    assert.equal("latestMessageText" in summary, false);
+    assert.equal("lastMessageId" in summary, false);
     assert.deepEqual(summary.participantUserUuids, []);
     assert.deepEqual(summary.participantProfiles, []);
     assert.equal(JSON.stringify(summary).includes("private prompt"), false);

--- a/apps/api/src/owner-resource-access.test.ts
+++ b/apps/api/src/owner-resource-access.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  canBindGenerationToSession,
+  canReadSessionResource,
+  canReadTaskResource,
+  canWriteSessionResource,
+  minimalOwnerSessionSpace,
+  ownerSessionSummary,
+  ownerTaskListScope,
+  ownerTaskListTaskType,
+  type OwnerResourcePrincipal,
+} from "./owner-resource-access.js";
+
+const user = (uuid = "viewer-1"): OwnerResourcePrincipal => ({ type: "user", user: { uuid } });
+const work = (uuid = "viewer-1", spaceId = "space-1"): OwnerResourcePrincipal => ({
+  type: "work_session",
+  workSession: { userUuid: uuid, spaceId },
+});
+const preview = (uuid = "viewer-1", spaceId = "space-1"): OwnerResourcePrincipal => ({
+  type: "preview_session",
+  previewSession: { userUuid: uuid, spaceId },
+});
+const execution = (uuid = "viewer-1", spaceId = "space-1"): OwnerResourcePrincipal => ({
+  type: "execution",
+  execution: { actorUserId: uuid, spaceId },
+});
+const session = { id: "session-1", spaceId: "space-1", userUuid: "viewer-1" };
+
+describe("owner-bound Work resource access", () => {
+  it("lets a real account read its own session without upgrading scoped principals", async () => {
+    assert.equal(await canReadSessionResource(user(), session, async () => false), true);
+    assert.equal(await canReadSessionResource(preview(), session, async () => false), false);
+    assert.equal(await canReadSessionResource(execution(), session, async () => false), false);
+  });
+
+  it("requires an active prompt grant and the exact Work space for owner session reads", async () => {
+    const promptGranted = async (permission: string) => permission === "session.prompt.readonly";
+    assert.equal(await canReadSessionResource(work(), session, promptGranted), true);
+    assert.equal(await canReadSessionResource(work("viewer-1", "space-2"), session, promptGranted), false);
+    assert.equal(await canReadSessionResource(work("viewer-2"), session, promptGranted), false);
+    assert.equal(await canReadSessionResource(work(), session, async () => false), false);
+  });
+
+  it("preserves broad session.view access for explicitly scoped principals", async () => {
+    assert.equal(await canReadSessionResource(
+      preview(),
+      session,
+      async (permission) => permission === "session.view",
+    ), true);
+  });
+
+  it("binds generation only to an account or Work owner in the same space", async () => {
+    assert.equal(await canBindGenerationToSession(user(), session, async () => false), true);
+    assert.equal(await canBindGenerationToSession(work(), session, async () => false), true);
+    assert.equal(await canBindGenerationToSession(work("viewer-1", "space-2"), session, async () => false), false);
+    assert.equal(await canBindGenerationToSession(preview(), session, async () => false), false);
+    assert.equal(await canBindGenerationToSession(execution(), session, async () => false), false);
+  });
+
+  it("binds Work session writes to the viewer owner unless broad read is also granted", async () => {
+    const promptOnly = async (permission: string) => permission === "session.prompt.fullaccess";
+    const promptAndBroadRead = async (permission: string) => (
+      permission === "session.prompt.fullaccess" || permission === "session.view"
+    );
+    assert.equal(await canWriteSessionResource(
+      work(),
+      session,
+      "session.prompt.fullaccess",
+      promptOnly,
+    ), true);
+    assert.equal(await canWriteSessionResource(
+      work("viewer-2"),
+      session,
+      "session.prompt.fullaccess",
+      promptOnly,
+    ), false);
+    assert.equal(await canWriteSessionResource(
+      work("viewer-2"),
+      session,
+      "session.prompt.fullaccess",
+      promptAndBroadRead,
+    ), true);
+  });
+
+  it("reads owner generation tasks only with the active Work generation grant", async () => {
+    const task = { taskType: "generation", spaceId: "space-1", sessionId: "session-1", userUuid: "viewer-1" };
+    assert.equal(await canReadTaskResource(user(), task, async () => false), true);
+    assert.equal(await canReadTaskResource(
+      work(),
+      task,
+      async (permission) => permission === "generation.create",
+    ), true);
+    assert.equal(await canReadTaskResource(work(), task, async () => false), false);
+    assert.equal(await canReadTaskResource(
+      work("viewer-1", "space-2"),
+      task,
+      async (permission) => permission === "generation.create",
+    ), false);
+    assert.equal(await canReadTaskResource(preview(), task, async () => false), false);
+    assert.equal(await canReadTaskResource(execution(), task, async () => false), false);
+  });
+
+  it("keeps taskrun.view as the explicit fallback for non-owner task reads", async () => {
+    const task = { taskType: "generation", spaceId: "space-1", sessionId: "session-1", userUuid: "viewer-1" };
+    assert.equal(await canReadTaskResource(
+      preview("viewer-2"),
+      task,
+      async (permission) => permission === "taskrun.view",
+    ), true);
+  });
+
+  it("limits owner task listing to accounts and the current Work space", () => {
+    const accountScope = ownerTaskListScope(user());
+    const workScope = ownerTaskListScope(work());
+    assert.deepEqual(accountScope, {
+      userUuid: "viewer-1",
+      spaceId: null,
+      requiresGenerationGrant: false,
+    });
+    assert.deepEqual(workScope, {
+      userUuid: "viewer-1",
+      spaceId: "space-1",
+      requiresGenerationGrant: true,
+    });
+    assert.ok(accountScope);
+    assert.ok(workScope);
+    assert.equal(ownerTaskListTaskType(accountScope, "run_command"), "run_command");
+    assert.equal(ownerTaskListTaskType(workScope, undefined), "generation");
+    assert.equal(ownerTaskListTaskType(workScope, "generation"), "generation");
+    assert.equal(ownerTaskListTaskType(workScope, "run_command"), null);
+    assert.equal(ownerTaskListScope(preview()), null);
+    assert.equal(ownerTaskListScope(execution()), null);
+  });
+
+  it("returns no private Space fields without space.view", () => {
+    assert.deepEqual(minimalOwnerSessionSpace({ id: "space-1", name: "Private", meta: { extraEnv: { SECRET: "value" } } }), {
+      id: "space-1",
+      name: "Private",
+      accessLevel: "minimal",
+    });
+  });
+
+  it("projects Work session lists without message or integration data", () => {
+    const summary = ownerSessionSummary({
+      id: "session-1",
+      spaceId: "space-1",
+      userUuid: "viewer-1",
+      userProfile: { userUuid: "viewer-1", displayName: "Viewer" },
+      title: "OpenTap",
+      source: "opentap",
+      status: "active",
+      lastMessageAt: "2026-07-30T00:00:00.000Z",
+      createdAt: "2026-07-30T00:00:00.000Z",
+      updatedAt: "2026-07-30T00:00:00.000Z",
+      space: { id: "space-1", name: "Space" },
+      latestMessageText: "private prompt",
+      lastMessageId: "message-1",
+      externalSessionId: "external-1",
+      meta: { secret: "value" },
+    });
+    assert.equal(summary.meta, null);
+    assert.equal(summary.externalSessionId, null);
+    assert.equal(summary.latestMessageText, null);
+    assert.equal(summary.lastMessageId, null);
+    assert.deepEqual(summary.participantUserUuids, []);
+    assert.deepEqual(summary.participantProfiles, []);
+    assert.equal(JSON.stringify(summary).includes("private prompt"), false);
+    assert.equal(JSON.stringify(summary).includes("external-1"), false);
+    assert.equal(JSON.stringify(summary).includes("secret"), false);
+  });
+});

--- a/apps/api/src/owner-resource-access.test.ts
+++ b/apps/api/src/owner-resource-access.test.ts
@@ -5,6 +5,8 @@ import {
   canReadSessionResource,
   canReadTaskResource,
   canWriteSessionResource,
+  canExposeWorkSessionRecord,
+  canIncludeWorkSessionListRow,
   minimalOwnerSessionSpace,
   ownerSessionSummary,
   ownerTaskListScope,
@@ -53,6 +55,11 @@ describe("owner-bound Work resource access", () => {
   it("binds generation only to an account or Work owner in the same space", async () => {
     assert.equal(await canBindGenerationToSession(user(), session, async () => false), true);
     assert.equal(await canBindGenerationToSession(work(), session, async () => false), true);
+    assert.equal(await canBindGenerationToSession(
+      work("viewer-2"),
+      session,
+      async (permission) => permission === "session.view",
+    ), false);
     assert.equal(await canBindGenerationToSession(work("viewer-1", "space-2"), session, async () => false), false);
     assert.equal(await canBindGenerationToSession(preview(), session, async () => false), false);
     assert.equal(await canBindGenerationToSession(execution(), session, async () => false), false);
@@ -191,5 +198,19 @@ describe("owner-bound Work resource access", () => {
     assert.equal(JSON.stringify(summary).includes("private prompt"), false);
     assert.equal(JSON.stringify(summary).includes("external-1"), false);
     assert.equal(JSON.stringify(summary).includes("secret"), false);
+  });
+
+  it("requires both the bound Space and session.view for a full Work list record", () => {
+    assert.equal(canExposeWorkSessionRecord({ spaceId: "space-1" }, { spaceId: "space-1" }, true), true);
+    assert.equal(canExposeWorkSessionRecord({ spaceId: "space-1" }, { spaceId: "space-1" }, false), false);
+    assert.equal(canExposeWorkSessionRecord({ spaceId: "space-1" }, { spaceId: "space-2" }, true), false);
+  });
+
+  it("lists only Work-owned rows across Spaces and viewed rows in the bound Space", () => {
+    const boundWork = { userUuid: "viewer-1", spaceId: "space-1" };
+    assert.equal(canIncludeWorkSessionListRow(boundWork, { userUuid: "viewer-1", spaceId: "space-2" }, false), true);
+    assert.equal(canIncludeWorkSessionListRow(boundWork, { userUuid: "viewer-2", spaceId: "space-1" }, true), true);
+    assert.equal(canIncludeWorkSessionListRow(boundWork, { userUuid: "viewer-2", spaceId: "space-1" }, false), false);
+    assert.equal(canIncludeWorkSessionListRow(boundWork, { userUuid: "viewer-2", spaceId: "space-2" }, true), false);
   });
 });

--- a/apps/api/src/owner-resource-access.ts
+++ b/apps/api/src/owner-resource-access.ts
@@ -1,0 +1,162 @@
+import type { Permission } from "@cohub/core/permissions";
+import { GENERATION_TASK_TYPE } from "@cohub/protocol/generation";
+
+export type OwnerResourcePrincipal =
+  | { type: "user"; user: { uuid: string } }
+  | { type: "work_session"; workSession: { userUuid: string; spaceId: string } }
+  | { type: "preview_session"; previewSession: { userUuid: string; spaceId: string } }
+  | { type: "execution"; execution: { actorUserId: string | null; spaceId: string } }
+  | null;
+type SessionResource = { id: string; spaceId: string; userUuid: string | null };
+type TaskResource = {
+  taskType: string;
+  spaceId: string | null;
+  sessionId: string | null;
+  userUuid: string | null;
+};
+type PermissionCheck = (
+  permission: Permission,
+  context: { spaceId: string; sessionId?: string },
+) => Promise<boolean>;
+
+function ownsResource(
+  principal: OwnerResourcePrincipal,
+  resource: { spaceId: string | null; userUuid: string | null },
+): boolean {
+  if (!resource.userUuid) return false;
+  if (principal?.type === "user") return principal.user.uuid === resource.userUuid;
+  return Boolean(
+    principal?.type === "work_session"
+    && resource.spaceId
+    && principal.workSession.userUuid === resource.userUuid
+    && principal.workSession.spaceId === resource.spaceId
+  );
+}
+
+export function ownerTaskListScope(principal: OwnerResourcePrincipal): {
+  userUuid: string;
+  spaceId: string | null;
+  requiresGenerationGrant: boolean;
+} | null {
+  if (principal?.type === "user") {
+    return { userUuid: principal.user.uuid, spaceId: null, requiresGenerationGrant: false };
+  }
+  if (principal?.type === "work_session") {
+    return {
+      userUuid: principal.workSession.userUuid,
+      spaceId: principal.workSession.spaceId,
+      requiresGenerationGrant: true,
+    };
+  }
+  return null;
+}
+
+export function ownerTaskListTaskType(
+  scope: NonNullable<ReturnType<typeof ownerTaskListScope>>,
+  requestedTaskType: string | null | undefined,
+): string | undefined | null {
+  const requested = requestedTaskType?.trim() || undefined;
+  if (!scope.requiresGenerationGrant) return requested;
+  if (requested && requested !== GENERATION_TASK_TYPE) return null;
+  return GENERATION_TASK_TYPE;
+}
+
+export function minimalOwnerSessionSpace<T extends { id: string; name: string }>(space: T) {
+  return {
+    id: space.id,
+    name: space.name,
+    accessLevel: "minimal" as const,
+  };
+}
+
+export function ownerSessionSummary<T extends {
+  id: string;
+  spaceId: string;
+  userUuid: string | null;
+  userProfile?: unknown;
+  title: string | null;
+  source: string | null;
+  status: string | null;
+  lastMessageAt: Date | string | null;
+  createdAt: Date | string | null;
+  updatedAt: Date | string | null;
+  space?: unknown;
+}>(session: T) {
+  return {
+    accessLevel: "summary" as const,
+    id: session.id,
+    spaceId: session.spaceId,
+    userUuid: session.userUuid,
+    userProfile: session.userProfile,
+    participantUserUuids: [],
+    participantProfiles: [],
+    title: session.title,
+    source: session.source,
+    status: session.status,
+    externalSessionId: null,
+    meta: null,
+    latestMessageText: null,
+    lastMessageAt: session.lastMessageAt,
+    lastMessageId: null,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+    space: session.space,
+  };
+}
+
+export async function canReadSessionResource(
+  principal: OwnerResourcePrincipal,
+  session: SessionResource,
+  checkPermission: PermissionCheck,
+): Promise<boolean> {
+  if (await checkPermission("session.view", { spaceId: session.spaceId, sessionId: session.id })) return true;
+  if (!ownsResource(principal, session)) return false;
+  if (principal?.type === "user") return true;
+  return await checkPermission("session.prompt.readonly", {
+    spaceId: session.spaceId,
+    sessionId: session.id,
+  }) || await checkPermission("session.prompt.fullaccess", {
+    spaceId: session.spaceId,
+    sessionId: session.id,
+  });
+}
+
+export async function canBindGenerationToSession(
+  principal: OwnerResourcePrincipal,
+  session: SessionResource,
+  checkPermission: PermissionCheck,
+): Promise<boolean> {
+  if (ownsResource(principal, session)) return true;
+  return checkPermission("session.view", { spaceId: session.spaceId, sessionId: session.id });
+}
+
+export async function canWriteSessionResource(
+  principal: OwnerResourcePrincipal,
+  session: SessionResource,
+  permission: Permission,
+  checkPermission: PermissionCheck,
+): Promise<boolean> {
+  if (!(await checkPermission(permission, { spaceId: session.spaceId, sessionId: session.id }))) {
+    return false;
+  }
+  if (principal?.type !== "work_session" || ownsResource(principal, session)) return true;
+  return checkPermission("session.view", { spaceId: session.spaceId, sessionId: session.id });
+}
+
+export async function canReadTaskResource(
+  principal: OwnerResourcePrincipal,
+  task: TaskResource,
+  checkPermission: PermissionCheck,
+): Promise<boolean> {
+  if (ownsResource(principal, task)) {
+    if (principal?.type === "user") return true;
+    if (task.taskType === "generation" && task.spaceId) {
+      return checkPermission("generation.create", { spaceId: task.spaceId });
+    }
+  }
+  if (!task.spaceId) return false;
+  return checkPermission("taskrun.view", {
+    spaceId: task.spaceId,
+    sessionId: task.sessionId ?? undefined,
+  });
+}

--- a/apps/api/src/owner-resource-access.ts
+++ b/apps/api/src/owner-resource-access.ts
@@ -103,12 +103,39 @@ export function ownerSessionSummary<T extends {
   };
 }
 
+/** Work list rows are owner-visible across Spaces, or view-visible in-bound. */
+export function canIncludeWorkSessionListRow(
+  workSession: { userUuid: string; spaceId: string },
+  session: { userUuid: string | null; spaceId: string },
+  hasSessionView: boolean,
+): boolean {
+  return session.userUuid === workSession.userUuid
+    || (hasSessionView && session.spaceId === workSession.spaceId);
+}
+
+/** Full Work list records never escape the token's bound Space. */
+export function canExposeWorkSessionRecord(
+  workSession: { spaceId: string },
+  session: { spaceId: string },
+  hasSessionView: boolean,
+): boolean {
+  return hasSessionView && workSession.spaceId === session.spaceId;
+}
+
 export async function canReadSessionResource(
   principal: OwnerResourcePrincipal,
   session: SessionResource,
   checkPermission: PermissionCheck,
 ): Promise<boolean> {
   if (await checkPermission("session.view", { spaceId: session.spaceId, sessionId: session.id })) return true;
+  return canReadSessionResourceAfterViewDenied(principal, session, checkPermission);
+}
+
+export async function canReadSessionResourceAfterViewDenied(
+  principal: OwnerResourcePrincipal,
+  session: SessionResource,
+  checkPermission: PermissionCheck,
+): Promise<boolean> {
   if (!ownsResource(principal, session)) return false;
   if (principal?.type === "user") return true;
   return await checkPermission("session.prompt.readonly", {

--- a/apps/api/src/owner-resource-access.ts
+++ b/apps/api/src/owner-resource-access.ts
@@ -3,7 +3,7 @@ import { GENERATION_TASK_TYPE } from "@cohub/protocol/generation";
 
 export type OwnerResourcePrincipal =
   | { type: "user"; user: { uuid: string } }
-  | { type: "work_session"; workSession: { userUuid: string; spaceId: string } }
+  | { type: "work_session"; workSession: { userUuid: string; spaceId: string; workId: string } }
   | { type: "preview_session"; previewSession: { userUuid: string; spaceId: string } }
   | { type: "execution"; execution: { actorUserId: string | null; spaceId: string } }
   | null;
@@ -13,6 +13,7 @@ type TaskResource = {
   spaceId: string | null;
   sessionId: string | null;
   userUuid: string | null;
+  payload?: unknown;
 };
 type PermissionCheck = (
   permission: Permission,
@@ -36,15 +37,17 @@ function ownsResource(
 export function ownerTaskListScope(principal: OwnerResourcePrincipal): {
   userUuid: string;
   spaceId: string | null;
+  workId: string | null;
   requiresGenerationGrant: boolean;
 } | null {
   if (principal?.type === "user") {
-    return { userUuid: principal.user.uuid, spaceId: null, requiresGenerationGrant: false };
+    return { userUuid: principal.user.uuid, spaceId: null, workId: null, requiresGenerationGrant: false };
   }
   if (principal?.type === "work_session") {
     return {
       userUuid: principal.workSession.userUuid,
       spaceId: principal.workSession.spaceId,
+      workId: principal.workSession.workId,
       requiresGenerationGrant: true,
     };
   }
@@ -61,7 +64,7 @@ export function ownerTaskListTaskType(
   return GENERATION_TASK_TYPE;
 }
 
-export function minimalOwnerSessionSpace<T extends { id: string; name: string }>(space: T) {
+export function minimalOwnerSessionSpace<T extends { id: string; name: string | null }>(space: T) {
   return {
     id: space.id,
     name: space.name,
@@ -93,11 +96,7 @@ export function ownerSessionSummary<T extends {
     title: session.title,
     source: session.source,
     status: session.status,
-    externalSessionId: null,
-    meta: null,
-    latestMessageText: null,
     lastMessageAt: session.lastMessageAt,
-    lastMessageId: null,
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
     space: session.space,
@@ -126,6 +125,7 @@ export async function canBindGenerationToSession(
   session: SessionResource,
   checkPermission: PermissionCheck,
 ): Promise<boolean> {
+  if (principal?.type === "work_session") return ownsResource(principal, session);
   if (ownsResource(principal, session)) return true;
   return checkPermission("session.view", { spaceId: session.spaceId, sessionId: session.id });
 }
@@ -139,8 +139,15 @@ export async function canWriteSessionResource(
   if (!(await checkPermission(permission, { spaceId: session.spaceId, sessionId: session.id }))) {
     return false;
   }
-  if (principal?.type !== "work_session" || ownsResource(principal, session)) return true;
-  return checkPermission("session.view", { spaceId: session.spaceId, sessionId: session.id });
+  return principal?.type !== "work_session" || ownsResource(principal, session);
+}
+
+function taskWorkId(task: TaskResource): string | null {
+  if (!task.payload || typeof task.payload !== "object" || Array.isArray(task.payload)) return null;
+  const data = (task.payload as { data?: unknown }).data;
+  if (!data || typeof data !== "object" || Array.isArray(data)) return null;
+  const workId = (data as { workId?: unknown }).workId;
+  return typeof workId === "string" && workId.trim() ? workId.trim() : null;
 }
 
 export async function canReadTaskResource(
@@ -148,11 +155,21 @@ export async function canReadTaskResource(
   task: TaskResource,
   checkPermission: PermissionCheck,
 ): Promise<boolean> {
+  if (principal?.type === "work_session") {
+    if (
+      task.taskType !== GENERATION_TASK_TYPE
+      || !task.spaceId
+      || principal.workSession.userUuid !== task.userUuid
+      || principal.workSession.spaceId !== task.spaceId
+      || taskWorkId(task) !== principal.workSession.workId
+    ) {
+      return false;
+    }
+    return checkPermission("generation.create", { spaceId: task.spaceId });
+  }
+
   if (ownsResource(principal, task)) {
     if (principal?.type === "user") return true;
-    if (task.taskType === "generation" && task.spaceId) {
-      return checkPermission("generation.create", { spaceId: task.spaceId });
-    }
   }
   if (!task.spaceId) return false;
   return checkPermission("taskrun.view", {

--- a/apps/api/src/permissions.account-identity.test.ts
+++ b/apps/api/src/permissions.account-identity.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { asAccountIdentity } from "./permissions.js";
+import { asAccountIdentity, hasPermission } from "./permissions.js";
 
 describe("asAccountIdentity", () => {
   it("keeps only the account uuid so work/preview scopes cannot leak into account lists", () => {
@@ -17,6 +17,21 @@ describe("asAccountIdentity", () => {
       Object.keys(asAccountIdentity(workish) as object).join(","),
       "uuid",
     );
+  });
+
+  it("does not upgrade preview or execution principals to account permissions", async () => {
+    const preview = {
+      uuid: "user-1",
+      previewSession: { userUuid: "user-1", spaceId: "space-1", scopes: ["file.view"] },
+    } as Parameters<typeof hasPermission>[0];
+    const execution = {
+      uuid: "user-1",
+      execution: { actorUserId: "user-1", spaceId: "space-1", scopes: ["file.view"] },
+    } as Parameters<typeof hasPermission>[0];
+
+    assert.equal(await hasPermission(preview, "user.session.list", { spaceId: "" }), false);
+    assert.equal(await hasPermission(execution, "user.session.list", { spaceId: "" }), false);
+    assert.equal(await hasPermission({ uuid: "user-1" }, "user.session.list", { spaceId: "" }), true);
   });
 
   it("returns null without a usable uuid", () => {

--- a/apps/api/src/permissions.ts
+++ b/apps/api/src/permissions.ts
@@ -1,14 +1,19 @@
 import { createBatchDrizzlePermissionStore, hasPermission as hasSharedPermission, isUserLevelPermission, normalizePermissionScopes, resolvePermissionAccess as resolveSharedPermissionAccess, scopeListHasPermission } from "@cohub/core/permissions";
 import { db } from "./db/index.js";
 import type { AuthUserProfile } from "./auth.js";
-import { workViewerGrants, type SpaceRole } from "@cohub/db";
+import { works, workViewerGrants, type SpaceRole } from "@cohub/db";
 import type { Permission, AccessPolicy, PermissionAccess } from "@cohub/core/permissions";
 import type { PreviewSessionPrincipal } from "./preview-sessions.js";
 import { hasPreviewSessionPermission } from "./preview-sessions.js";
 import type { WorkSessionPrincipal } from "./work-sessions.js";
 import { and, eq } from "drizzle-orm";
+import {
+  resolveActiveWorkSessionPolicy,
+  type ActiveWorkSessionPolicy,
+} from "./work-session-policy.js";
 
 type CachedWorkSessionPrincipal = WorkSessionPrincipal & {
+  activeWorkPolicy?: Promise<ActiveWorkSessionPolicy | null>;
   activeViewerGrantScopes?: Promise<Permission[]>;
 };
 
@@ -53,8 +58,29 @@ export function asAccountIdentity(user: { uuid?: string | null } | null | undefi
   return uuid ? { uuid } : null;
 }
 
+const loadActiveWorkPolicy = async (workSession: CachedWorkSessionPrincipal) => {
+  const [current] = await db
+    .select({
+      status: works.status,
+      spaceId: works.spaceId,
+      workScopes: works.workScopes,
+      allowedViewerScopes: works.allowedViewerScopes,
+    })
+    .from(works)
+    .where(eq(works.id, workSession.workId))
+    .limit(1);
+  return resolveActiveWorkSessionPolicy(workSession, current ?? null);
+};
+
+const getActiveWorkPolicy = async (workSession: CachedWorkSessionPrincipal) => {
+  workSession.activeWorkPolicy ??= loadActiveWorkPolicy(workSession);
+  return workSession.activeWorkPolicy;
+};
+
 const loadActiveViewerGrantScopes = async (workSession: CachedWorkSessionPrincipal) => {
   if (!workSession.workViewerGrantId) return [] as Permission[];
+  const activeWorkPolicy = await getActiveWorkPolicy(workSession);
+  if (!activeWorkPolicy) return [] as Permission[];
   const [grant] = await db
     .select({ scopes: workViewerGrants.scopes, expiresAt: workViewerGrants.expiresAt, revokedAt: workViewerGrants.revokedAt })
     .from(workViewerGrants)
@@ -67,8 +93,9 @@ const loadActiveViewerGrantScopes = async (workSession: CachedWorkSessionPrincip
     .limit(1);
   if (!grant || grant.revokedAt) return [];
   if (grant.expiresAt && grant.expiresAt.getTime() <= Date.now()) return [];
-  const tokenScopes = new Set(normalizePermissionScopes(workSession.viewerScopes));
-  return normalizePermissionScopes(grant.scopes as string[]).filter((scope) => tokenScopes.has(scope));
+  const allowedScopes = new Set(activeWorkPolicy.allowedViewerScopes);
+  return normalizePermissionScopes(grant.scopes as string[])
+    .filter((scope) => allowedScopes.has(scope));
 };
 
 const getActiveViewerGrantScopes = async (workSession: CachedWorkSessionPrincipal) => {
@@ -82,13 +109,17 @@ const hasActiveViewerGrantPermission = async (workSession: CachedWorkSessionPrin
 };
 
 const resolveWorkSessionScopes = async (workSession: CachedWorkSessionPrincipal) => {
+  const activeWorkPolicy = await getActiveWorkPolicy(workSession);
+  if (!activeWorkPolicy) return [];
   const viewerScopes = await getActiveViewerGrantScopes(workSession);
-  return normalizePermissionScopes([...workSession.workScopes, ...viewerScopes]);
+  return normalizePermissionScopes([...activeWorkPolicy.workScopes, ...viewerScopes]);
 };
 
 const hasWorkSessionScopedPermission = async (workSession: CachedWorkSessionPrincipal, permission: Permission, spaceId: string) => {
   if (workSession.spaceId !== spaceId) return false;
-  if (scopeListHasPermission(workSession.workScopes, permission)) return true;
+  const activeWorkPolicy = await getActiveWorkPolicy(workSession);
+  if (!activeWorkPolicy) return false;
+  if (scopeListHasPermission(activeWorkPolicy.workScopes, permission)) return true;
   return hasActiveViewerGrantPermission(workSession, permission);
 };
 

--- a/apps/api/src/permissions.ts
+++ b/apps/api/src/permissions.ts
@@ -6,7 +6,7 @@ import type { Permission, AccessPolicy, PermissionAccess } from "@cohub/core/per
 import type { PreviewSessionPrincipal } from "./preview-sessions.js";
 import { hasPreviewSessionPermission } from "./preview-sessions.js";
 import type { WorkSessionPrincipal } from "./work-sessions.js";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 type CachedWorkSessionPrincipal = WorkSessionPrincipal & {
   activeViewerGrantScopes?: Promise<Permission[]>;
@@ -58,7 +58,12 @@ const loadActiveViewerGrantScopes = async (workSession: CachedWorkSessionPrincip
   const [grant] = await db
     .select({ scopes: workViewerGrants.scopes, expiresAt: workViewerGrants.expiresAt, revokedAt: workViewerGrants.revokedAt })
     .from(workViewerGrants)
-    .where(eq(workViewerGrants.id, workSession.workViewerGrantId))
+    .where(and(
+      eq(workViewerGrants.id, workSession.workViewerGrantId),
+      eq(workViewerGrants.workId, workSession.workId),
+      eq(workViewerGrants.spaceId, workSession.spaceId),
+      eq(workViewerGrants.viewerUserUuid, workSession.userUuid),
+    ))
     .limit(1);
   if (!grant || grant.revokedAt) return [];
   if (grant.expiresAt && grant.expiresAt.getTime() <= Date.now()) return [];
@@ -99,6 +104,7 @@ export async function hasPermission(
   if (isUserLevelPermission(permission)) {
     const workSession = getUserWorkSession(user);
     if (workSession) return hasActiveViewerGrantPermission(workSession, permission);
+    if (getUserPreviewSession(user) || getUserExecution(user)) return false;
     return Boolean(user?.uuid);
   }
 

--- a/apps/api/src/public-asset-access.ts
+++ b/apps/api/src/public-asset-access.ts
@@ -10,16 +10,16 @@ export function resolvePublicAssetUploadActor(
     return { userUuid: principal.user.uuid, workSpaceId: null };
   }
   if (
-    principal?.type === "work_session"
-    && input.purpose === "chat_attachment"
-    && (!input.spaceId || input.spaceId === principal.workSession.spaceId)
+    principal?.type !== "work_session"
+    || input.purpose !== "chat_attachment"
+    || (input.spaceId !== undefined && input.spaceId !== principal.workSession.spaceId)
   ) {
-    return {
-      userUuid: principal.workSession.userUuid,
-      workSpaceId: principal.workSession.spaceId,
-    };
+    return null;
   }
-  return null;
+  return {
+    userUuid: principal.workSession.userUuid,
+    workSpaceId: principal.workSession.spaceId,
+  };
 }
 
 export async function canUploadWorkChatAttachment(

--- a/apps/api/src/public-asset-access.ts
+++ b/apps/api/src/public-asset-access.ts
@@ -1,4 +1,5 @@
 import type { RequestPrincipal } from "./lib/middleware.js";
+import type { Permission } from "@cohub/core/permissions";
 import type { CreatePublicAssetUploadInput } from "./public-asset-storage.js";
 
 export function resolvePublicAssetUploadActor(
@@ -11,7 +12,7 @@ export function resolvePublicAssetUploadActor(
   if (
     principal?.type === "work_session"
     && input.purpose === "chat_attachment"
-    && input.spaceId === principal.workSession.spaceId
+    && (!input.spaceId || input.spaceId === principal.workSession.spaceId)
   ) {
     return {
       userUuid: principal.workSession.userUuid,
@@ -19,4 +20,13 @@ export function resolvePublicAssetUploadActor(
     };
   }
   return null;
+}
+
+export async function canUploadWorkChatAttachment(
+  checkPermission: (permission: Permission) => Promise<boolean>,
+  options: { hasBoundSession: boolean },
+): Promise<boolean> {
+  if (await checkPermission("generation.create")) return true;
+  return options.hasBoundSession
+    && await checkPermission("session.prompt.readonly");
 }

--- a/apps/api/src/public-asset-access.ts
+++ b/apps/api/src/public-asset-access.ts
@@ -1,0 +1,22 @@
+import type { RequestPrincipal } from "./lib/middleware.js";
+import type { CreatePublicAssetUploadInput } from "./public-asset-storage.js";
+
+export function resolvePublicAssetUploadActor(
+  principal: RequestPrincipal | null,
+  input: Pick<CreatePublicAssetUploadInput, "purpose" | "spaceId">,
+): { userUuid: string; workSpaceId: string | null } | null {
+  if (principal?.type === "user") {
+    return { userUuid: principal.user.uuid, workSpaceId: null };
+  }
+  if (
+    principal?.type === "work_session"
+    && input.purpose === "chat_attachment"
+    && input.spaceId === principal.workSession.spaceId
+  ) {
+    return {
+      userUuid: principal.workSession.userUuid,
+      workSpaceId: principal.workSession.spaceId,
+    };
+  }
+  return null;
+}

--- a/apps/api/src/realtime-event-rooms.test.ts
+++ b/apps/api/src/realtime-event-rooms.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { resolveRealtimeEventRooms } from "./realtime-event-rooms.js";
+
+test("Session realtime routing reaches both member aggregates and the scoped Session room", () => {
+  assert.deepEqual(resolveRealtimeEventRooms({
+    spaceId: "space-1",
+    sessionId: "session-1",
+  }), ["space:space-1", "session:session-1"]);
+  assert.deepEqual(resolveRealtimeEventRooms({
+    spaceId: "space-1",
+  }), ["space:space-1"]);
+});
+
+test("explicit realtime rooms remain authoritative", () => {
+  assert.deepEqual(resolveRealtimeEventRooms({
+    spaceId: "space-1",
+    sessionId: "session-1",
+    rooms: ["user:user-1"],
+  }), ["user:user-1"]);
+  assert.deepEqual(resolveRealtimeEventRooms({
+    spaceId: "space-1",
+    sessionId: "session-1",
+    rooms: [],
+  }), []);
+});
+
+test("implicit task recipients remain user-only", () => {
+  assert.deepEqual(resolveRealtimeEventRooms({
+    spaceId: "space-1",
+    sessionId: "session-1",
+    userIds: ["user-1", "user-1"],
+  }), ["user:user-1"]);
+});

--- a/apps/api/src/realtime-event-rooms.ts
+++ b/apps/api/src/realtime-event-rooms.ts
@@ -1,0 +1,30 @@
+import type { RealtimeRoom } from "@cohub/protocol/realtime";
+import {
+  getRealtimeSessionRoom,
+  getRealtimeSpaceRoom,
+  getRealtimeUserRoom,
+  normalizeRealtimeRooms,
+} from "@cohub/protocol/realtime";
+
+export function resolveRealtimeEventRooms(input: {
+  spaceId?: string | null;
+  sessionId?: string | null;
+  rooms?: RealtimeRoom[];
+  userIds?: string[];
+}): RealtimeRoom[] {
+  if (input.rooms !== undefined) return normalizeRealtimeRooms(input.rooms);
+
+  const userIds = Array.from(new Set(
+    (input.userIds ?? [])
+      .map((value) => value.trim())
+      .filter(Boolean),
+  ));
+  if (userIds.length > 0) return userIds.map(getRealtimeUserRoom);
+
+  const resourceRooms: RealtimeRoom[] = [];
+  const spaceId = input.spaceId?.trim();
+  const sessionId = input.sessionId?.trim();
+  if (spaceId) resourceRooms.push(getRealtimeSpaceRoom(spaceId));
+  if (sessionId) resourceRooms.push(getRealtimeSessionRoom(sessionId));
+  return resourceRooms;
+}

--- a/apps/api/src/realtime-room-access.test.ts
+++ b/apps/api/src/realtime-room-access.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { AuthUser, RequestPrincipal } from "./lib/middleware.js";
+import { spaceRoomReadPermission } from "./realtime-room-access.js";
+
+test("scoped principals need explicit broad Session access for Space rooms", () => {
+  const account: RequestPrincipal = {
+    type: "user",
+    user: { uuid: "viewer-1" } as AuthUser,
+  };
+  const work: RequestPrincipal = {
+    type: "work_session",
+    workSession: {
+      type: "work_session",
+      typ: "work_session",
+      userUuid: "viewer-1",
+      workId: "work-1",
+      spaceId: "space-1",
+      workScopes: ["space.view"],
+      viewerScopes: [],
+      scopes: ["space.view"],
+      iat: 0,
+      exp: 1,
+    },
+  };
+
+  assert.equal(spaceRoomReadPermission(account), "space.view");
+  assert.equal(spaceRoomReadPermission(work), "session.view");
+  assert.equal(spaceRoomReadPermission(null), "session.view");
+});

--- a/apps/api/src/realtime-room-access.test.ts
+++ b/apps/api/src/realtime-room-access.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 import type { AuthUser, RequestPrincipal } from "./lib/middleware.js";
 import { spaceRoomReadPermission } from "./realtime-room-access.js";
 
-test("scoped principals need explicit broad Session access for Space rooms", () => {
+test("only account principals can subscribe to mixed Space rooms", () => {
   const account: RequestPrincipal = {
     type: "user",
     user: { uuid: "viewer-1" } as AuthUser,
@@ -25,6 +25,6 @@ test("scoped principals need explicit broad Session access for Space rooms", () 
   };
 
   assert.equal(spaceRoomReadPermission(account), "space.view");
-  assert.equal(spaceRoomReadPermission(work), "session.view");
-  assert.equal(spaceRoomReadPermission(null), "session.view");
+  assert.equal(spaceRoomReadPermission(work), null);
+  assert.equal(spaceRoomReadPermission(null), null);
 });

--- a/apps/api/src/realtime-room-access.test.ts
+++ b/apps/api/src/realtime-room-access.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { AuthUser, RequestPrincipal } from "./lib/middleware.js";
-import { spaceRoomReadPermission } from "./realtime-room-access.js";
+import { filterReadableSpaceRoomIds, spaceRoomReadPermission } from "./realtime-room-access.js";
 
 test("only account principals can subscribe to mixed Space rooms", () => {
   const account: RequestPrincipal = {
@@ -27,4 +27,19 @@ test("only account principals can subscribe to mixed Space rooms", () => {
   assert.equal(spaceRoomReadPermission(account), "space.view");
   assert.equal(spaceRoomReadPermission(work), null);
   assert.equal(spaceRoomReadPermission(null), null);
+});
+
+test("account Space rooms use policy-aware space.view authorization", async () => {
+  const account: RequestPrincipal = {
+    type: "user",
+    user: { uuid: "viewer-1" } as AuthUser,
+  };
+  const calls: Array<{ permission: string; spaceIds: string[] }> = [];
+  const allowed = await filterReadableSpaceRoomIds(account, ["public-space", "private-space"], async (permission, spaceIds) => {
+    calls.push({ permission, spaceIds });
+    return ["public-space"];
+  });
+
+  assert.deepEqual(calls, [{ permission: "space.view", spaceIds: ["public-space", "private-space"] }]);
+  assert.deepEqual(allowed, ["public-space"]);
 });

--- a/apps/api/src/realtime-room-access.ts
+++ b/apps/api/src/realtime-room-access.ts
@@ -5,3 +5,12 @@ export function spaceRoomReadPermission(
 ): "space.view" | null {
   return principal?.type === "user" ? "space.view" : null;
 }
+
+export async function filterReadableSpaceRoomIds(
+  principal: RequestPrincipal | null,
+  spaceIds: string[],
+  filterByPermission: (permission: "space.view", spaceIds: string[]) => Promise<string[]>,
+): Promise<string[]> {
+  const permission = spaceRoomReadPermission(principal);
+  return permission ? filterByPermission(permission, spaceIds) : [];
+}

--- a/apps/api/src/realtime-room-access.ts
+++ b/apps/api/src/realtime-room-access.ts
@@ -1,0 +1,7 @@
+import type { RequestPrincipal } from "./lib/middleware.js";
+
+export function spaceRoomReadPermission(
+  principal: RequestPrincipal | null,
+): "space.view" | "session.view" {
+  return principal?.type === "user" ? "space.view" : "session.view";
+}

--- a/apps/api/src/realtime-room-access.ts
+++ b/apps/api/src/realtime-room-access.ts
@@ -2,6 +2,6 @@ import type { RequestPrincipal } from "./lib/middleware.js";
 
 export function spaceRoomReadPermission(
   principal: RequestPrincipal | null,
-): "space.view" | "session.view" {
-  return principal?.type === "user" ? "space.view" : "session.view";
+): "space.view" | null {
+  return principal?.type === "user" ? "space.view" : null;
 }

--- a/apps/api/src/routes/billing.route.ts
+++ b/apps/api/src/routes/billing.route.ts
@@ -3,7 +3,7 @@ import { ApiError, isBillingApiError } from "../lib/billing-api-error.js";
 import { billingOperations, COHUB_BILLING_FEATURES, COHUB_BILLING_TOKEN_TYPES, type CohubBillingFeatureKey } from "@cohub/billing";
 import { config } from "../config.js";
 import { jsonError } from "../lib/json-error.js";
-import { getOptionalAuth, useAuth } from "../lib/middleware.js";
+import { getOptionalAccountAuth, useAccountAuth } from "../lib/middleware.js";
 
 const router = new Hono();
 const BILLING_PAGE_SIZE = 10;
@@ -74,7 +74,7 @@ function resolveBillingFeatureKey(value: string): CohubBillingFeatureKey | null 
 }
 
 router.get("/credits", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const resolved = resolveTokenType(c.req.query("tokenType"));
   if ("error" in resolved) return c.json({ message: resolved.error }, 400);
@@ -86,7 +86,7 @@ router.get("/credits", async (c) => {
 });
 
 router.get("/balance-activities", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const resolved = resolveTokenType(c.req.query("tokenType"));
   if ("error" in resolved) return c.json({ message: resolved.error }, 400);
@@ -100,7 +100,7 @@ router.get("/balance-activities", async (c) => {
 });
 
 router.get("/catalog", async (c) => {
-  const user = getOptionalAuth(c);
+  const user = getOptionalAccountAuth(c);
   try {
     const catalog = await billingOperations.getCatalog(
       user?.uuid ? { userId: user.uuid } : undefined,
@@ -113,7 +113,7 @@ router.get("/catalog", async (c) => {
 });
 
 router.get("/features/:featureKey", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const featureKey = resolveBillingFeatureKey(c.req.param("featureKey"));
   if (!featureKey) return c.json({ message: "unsupported billing feature" }, 400);
@@ -130,7 +130,7 @@ router.get("/features/:featureKey", async (c) => {
 });
 
 router.get("/subscriptions", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   try {
     const subscriptions = await billingOperations.listSubscriptions({
@@ -146,7 +146,7 @@ router.get("/subscriptions", async (c) => {
 });
 
 router.post("/orders", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   try {
     const body = await readCheckoutBody(c);
@@ -168,7 +168,7 @@ router.post("/orders", async (c) => {
 });
 
 router.post("/subscriptions", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   try {
     const body = await readCheckoutBody(c);
@@ -190,7 +190,7 @@ router.post("/subscriptions", async (c) => {
 });
 
 router.delete("/subscriptions/:subscriptionId/checkout", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   try {
     const subscription = await billingOperations.cancelSubscriptionCheckout({
@@ -205,7 +205,7 @@ router.delete("/subscriptions/:subscriptionId/checkout", async (c) => {
 });
 
 router.patch("/subscriptions/:subscriptionId", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   try {
     const body = await readCheckoutBody(c);
@@ -224,7 +224,7 @@ router.patch("/subscriptions/:subscriptionId", async (c) => {
 });
 
 router.post("/redemptions", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   try {
     const body = await readCheckoutBody(c);

--- a/apps/api/src/routes/channels.route.ts
+++ b/apps/api/src/routes/channels.route.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import { db } from "../db/index.js";
 import { userChannels, spaceChannels, spaces } from "@cohub/db";
 import { eq, and, desc, inArray } from "drizzle-orm";
-import { useAuth, requireValidId } from "../lib/middleware.js";
+import { useAccountAuth, requireValidId } from "../lib/middleware.js";
 import { redisCommandClient } from "../redis.js";
 import { deleteChannelResponse, type DeleteChannelResult } from "./channel-delete.js";
 import { fallbackBoundChannelHealth, getChannelHealthMap } from "../channel-health.js";
@@ -144,7 +144,7 @@ async function pollWeChatQrStatus(qrcode: string, baseUrl = WECHAT_LOGIN_BASE_UR
 }
 
 router.post("/wechat/login/start", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const body = (await c.req.json<{ name?: string }>().catch(() => ({}))) as { name?: string };
   const name = body.name?.trim() || "WeChat";
@@ -179,7 +179,7 @@ router.post("/wechat/login/start", async (c) => {
 });
 
 router.post("/wechat/login/wait", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const body = (await c.req.json<{ sessionKey?: string; verifyCode?: string }>().catch(() => ({}))) as { sessionKey?: string; verifyCode?: string };
   const sessionKey = body.sessionKey?.trim();
@@ -273,7 +273,7 @@ router.post("/wechat/login/wait", async (c) => {
   }
 });
 router.get("/", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
 
   const channels = await db
@@ -315,7 +315,7 @@ router.get("/", async (c) => {
 });
 
 router.post("/", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
 
   const body = (await c.req
@@ -349,7 +349,7 @@ router.post("/", async (c) => {
 });
 
 router.delete("/:id", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const channelId = c.req.param("id");
   if (!requireValidId(channelId)) return c.json({ message: "channel not found" }, 404);

--- a/apps/api/src/routes/cron-jobs.route.ts
+++ b/apps/api/src/routes/cron-jobs.route.ts
@@ -59,6 +59,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function isDelegatedWorkPayload(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const data = isRecord(value.data) ? value.data : value;
+  return data.delegatedAuthRequired === true
+    || (isRecord(data.auth) && data.auth.source === "work_session");
+}
+
 async function authorizeCronJobView(
   user: ReturnType<typeof getOptionalAuth>,
   job: CronJobAuthSubject,
@@ -268,6 +275,9 @@ router.patch("/:id", async (c) => {
   }
 
   if ("payload" in body) {
+    if (isDelegatedWorkPayload(job.payload)) {
+      return c.json({ message: "payload cannot be changed for a delegated Work cron job" }, 409);
+    }
     if (!isRecord(body.payload)) return c.json({ message: "payload must be an object" }, 400);
     patch.payload = sanitizePostgresJsonValue(body.payload) as Record<string, unknown>;
   }

--- a/apps/api/src/routes/cron-jobs.route.ts
+++ b/apps/api/src/routes/cron-jobs.route.ts
@@ -4,7 +4,7 @@ import { db } from "../db/index.js";
 import { cronJobs, taskRuns } from "@cohub/db";
 import { eq, and, isNull, desc, lt, or } from "drizzle-orm";
 import { sanitizePostgresJsonValue } from "@cohub/core/content/sanitize";
-import { getOptionalAuth, useAuth, requireValidId, authzDenied } from "../lib/middleware.js";
+import { getOptionalAuth, getRequestPrincipal, useAccountAuth, useAuth, requireValidId, authzDenied } from "../lib/middleware.js";
 import { hasPermission } from "../permissions.js";
 import { disableCronJob, enableCronJob, removeCronJob, updateCronJob } from "../tasks.js";
 import { fallbackPublicUserProfile, getProfilesByUuids } from "../user-profiles.js";
@@ -59,19 +59,31 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
-async function authorizeCronJobView(user: ReturnType<typeof getOptionalAuth>, job: CronJobAuthSubject) {
+async function authorizeCronJobView(
+  user: ReturnType<typeof getOptionalAuth>,
+  job: CronJobAuthSubject,
+  principal: ReturnType<typeof getRequestPrincipal>,
+) {
   if (job.spaceId) return hasPermission(user, "cronjob.view", { spaceId: job.spaceId, sessionId: job.sessionId ?? undefined });
-  return !!user && job.userUuid === user.uuid;
+  return principal?.type === "user" && job.userUuid === principal.user.uuid;
 }
 
-async function authorizeCronJobManage(user: Exclude<ReturnType<typeof useAuth>, Response>, job: CronJobAuthSubject) {
+async function authorizeCronJobManage(
+  user: Exclude<ReturnType<typeof useAuth>, Response>,
+  job: CronJobAuthSubject,
+  principal: ReturnType<typeof getRequestPrincipal>,
+) {
   if (job.spaceId) return hasPermission(user, "cronjob.manage", { spaceId: job.spaceId, sessionId: job.sessionId ?? undefined });
-  return job.userUuid === user.uuid;
+  return principal?.type === "user" && job.userUuid === principal.user.uuid;
 }
 
-async function authorizeTaskRunView(user: ReturnType<typeof getOptionalAuth>, job: CronJobAuthSubject) {
+async function authorizeTaskRunView(
+  user: ReturnType<typeof getOptionalAuth>,
+  job: CronJobAuthSubject,
+  principal: ReturnType<typeof getRequestPrincipal>,
+) {
   if (job.spaceId) return hasPermission(user, "taskrun.view", { spaceId: job.spaceId, sessionId: job.sessionId ?? undefined });
-  return !!user && job.userUuid === user.uuid;
+  return principal?.type === "user" && job.userUuid === principal.user.uuid;
 }
 
 async function loadCronJobAuthSubject(cronJobId: string): Promise<CronJobAuthSubject | null> {
@@ -104,7 +116,7 @@ function buildTaskCursor(run: { createdAt: Date | string | null; id: string } | 
 
 router.get("/", async (c) => {
   const spaceId = c.req.query("spaceId") ?? null;
-  const user = spaceId ? getOptionalAuth(c) : useAuth(c);
+  const user = spaceId ? getOptionalAuth(c) : useAccountAuth(c);
   if (user instanceof Response) return user;
   const userId = user?.uuid;
 
@@ -133,6 +145,7 @@ router.get("/", async (c) => {
 
 router.get("/:id", async (c) => {
   const user = getOptionalAuth(c);
+  const principal = getRequestPrincipal(c);
   const cronJobId = c.req.param("id");
   if (!requireValidId(cronJobId)) return c.json({ message: "not found" }, 404);
 
@@ -142,7 +155,7 @@ router.get("/:id", async (c) => {
     .where(and(eq(cronJobs.id, cronJobId), isNull(cronJobs.deletedAt)))
     .limit(1);
   if (!job) return c.json({ message: "not found" }, 404);
-  if (!(await authorizeCronJobView(user, job))) return authzDenied(c);
+  if (!(await authorizeCronJobView(user, job, principal))) return authzDenied(c);
 
   const [hydrated] = await hydrateCronJobUserProfiles([job]);
   return c.json({ job: hydrated });
@@ -150,13 +163,14 @@ router.get("/:id", async (c) => {
 
 router.get("/:id/runs", async (c) => {
   const user = getOptionalAuth(c);
+  const principal = getRequestPrincipal(c);
 
   const cronJobId = c.req.param("id");
   if (!requireValidId(cronJobId)) return c.json({ message: "not found" }, 404);
 
   const job = await loadCronJobAuthSubject(cronJobId);
   if (!job) return c.json({ message: "not found" }, 404);
-  if (!(await authorizeTaskRunView(user, job))) return authzDenied(c);
+  if (!(await authorizeTaskRunView(user, job, principal))) return authzDenied(c);
 
   const limitParam = Number(c.req.query("limit") ?? 20);
   const limit = Number.isFinite(limitParam) ? Math.min(Math.max(Math.floor(limitParam), 1), MAX_RUNS_LIMIT) : 20;
@@ -193,6 +207,7 @@ router.get("/:id/runs", async (c) => {
 router.delete("/:id", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
+  const principal = getRequestPrincipal(c);
 
   const cronJobId = c.req.param("id");
   if (!requireValidId(cronJobId)) return c.json({ message: "not found" }, 404);
@@ -209,7 +224,7 @@ router.delete("/:id", async (c) => {
     .where(and(eq(cronJobs.id, cronJobId), isNull(cronJobs.deletedAt)))
     .limit(1);
   if (!job) return c.json({ message: "not found" }, 404);
-  if (!(await authorizeCronJobManage(user, job))) return authzDenied(c);
+  if (!(await authorizeCronJobManage(user, job, principal))) return authzDenied(c);
 
   await removeCronJob(cronJobId, job.bullJobKey);
   return c.json({ ok: true });
@@ -218,6 +233,7 @@ router.delete("/:id", async (c) => {
 router.patch("/:id", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
+  const principal = getRequestPrincipal(c);
 
   const cronJobId = c.req.param("id");
   if (!requireValidId(cronJobId)) return c.json({ message: "not found" }, 404);
@@ -228,7 +244,7 @@ router.patch("/:id", async (c) => {
     .where(and(eq(cronJobs.id, cronJobId), isNull(cronJobs.deletedAt)))
     .limit(1);
   if (!job) return c.json({ message: "not found" }, 404);
-  if (!(await authorizeCronJobManage(user, job))) return authzDenied(c);
+  if (!(await authorizeCronJobManage(user, job, principal))) return authzDenied(c);
 
   const body = await c.req.json<Record<string, unknown>>().catch(() => null);
   if (!body || typeof body !== "object" || Array.isArray(body)) return c.json({ message: "invalid json body" }, 400);

--- a/apps/api/src/routes/cron-jobs.route.ts
+++ b/apps/api/src/routes/cron-jobs.route.ts
@@ -193,7 +193,10 @@ router.get("/:id/runs", async (c) => {
     .limit(limit + 1);
   const runs = rows
     .slice(0, limit)
-    .map((run) => sanitizeTaskRunPricingForViewer(run, user?.uuid));
+    .map((run) => sanitizeTaskRunPricingForViewer(
+      run,
+      principal?.type === "user" ? principal.user.uuid : null,
+    ));
 
   return c.json({
     runs,

--- a/apps/api/src/routes/generations.route.ts
+++ b/apps/api/src/routes/generations.route.ts
@@ -15,7 +15,7 @@ import {
   type CreateGenerationTaskResponse,
   type GenerationModelDiscountSnapshot,
 } from "@cohub/protocol/generation";
-import { useAuth, authzDenied } from "../lib/middleware.js";
+import { useAuth, authzDenied, getRequestPrincipal } from "../lib/middleware.js";
 import { billingBlockedResponse } from "../lib/billing-blocked.js";
 import { hasPermission } from "../permissions.js";
 import { loadGenerationDeclaration } from "../generations/declarations.js";
@@ -26,6 +26,7 @@ import { enqueueTask } from "../tasks.js";
 import { defaultJobRetention } from "@cohub/infra/bullmq";
 import { createLogger } from "@cohub/infra/logging";
 import { applyRequestSourceToMeta } from "../lib/request-source.js";
+import { canBindGenerationToSession } from "../owner-resource-access.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -69,7 +70,11 @@ router.post("/", async (c) => {
     if (!session || session.spaceId !== request.spaceId) {
       return generationError(c, 404, "generation_session_not_found", "Generation session not found in this space.");
     }
-    if (!(await hasPermission(user, "session.view", { spaceId: request.spaceId, sessionId }))) return authzDenied(c);
+    if (!(await canBindGenerationToSession(
+      getRequestPrincipal(c),
+      session,
+      (permission, context) => hasPermission(user, permission, context),
+    ))) return authzDenied(c);
   }
   if (turnId) {
     if (!sessionId) {

--- a/apps/api/src/routes/generations.route.ts
+++ b/apps/api/src/routes/generations.route.ts
@@ -60,6 +60,7 @@ router.post("/", async (c) => {
   }
 
   const request = parsed.data;
+  const principal = getRequestPrincipal(c);
   if (!(await hasPermission(user, "generation.create", { spaceId: request.spaceId }))) return authzDenied(c);
 
   const sessionId = request.sessionId?.trim() || null;
@@ -71,7 +72,7 @@ router.post("/", async (c) => {
       return generationError(c, 404, "generation_session_not_found", "Generation session not found in this space.");
     }
     if (!(await canBindGenerationToSession(
-      getRequestPrincipal(c),
+      principal,
       session,
       (permission, context) => hasPermission(user, permission, context),
     ))) return authzDenied(c);
@@ -177,6 +178,7 @@ router.post("/", async (c) => {
         parameters,
         meta,
         modelDiscount,
+        ...(principal?.type === "work_session" ? { workId: principal.workSession.workId } : {}),
       },
     }, {
       attempts: 1,

--- a/apps/api/src/routes/generations.route.ts
+++ b/apps/api/src/routes/generations.route.ts
@@ -15,10 +15,13 @@ import {
   type CreateGenerationTaskResponse,
   type GenerationModelDiscountSnapshot,
 } from "@cohub/protocol/generation";
-import { useAuth, authzDenied, getRequestPrincipal } from "../lib/middleware.js";
+import { useAuth, authzDenied, getRequestPrincipal, getWorkSessionPrincipal } from "../lib/middleware.js";
 import { billingBlockedResponse } from "../lib/billing-blocked.js";
 import { hasPermission } from "../permissions.js";
-import { loadGenerationDeclaration } from "../generations/declarations.js";
+import {
+  loadGenerationDeclaration,
+  loadPlatformGenerationDeclaration,
+} from "../generations/declarations.js";
 import { createGenerationTaskRequestSchema } from "../generations/schema.js";
 import { getSpaceSessionById } from "../space-sessions.js";
 import { getSessionTurnById } from "../session-turns.js";
@@ -27,6 +30,7 @@ import { defaultJobRetention } from "@cohub/infra/bullmq";
 import { createLogger } from "@cohub/infra/logging";
 import { applyRequestSourceToMeta } from "../lib/request-source.js";
 import { canBindGenerationToSession } from "../owner-resource-access.js";
+import { delegatedPromptAuthFromWorkSession } from "../prompt-auth-context.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -87,7 +91,15 @@ router.post("/", async (c) => {
     }
   }
 
-  const declaration = await loadGenerationDeclaration(user.uuid, request.model);
+  const declarationScope = principal?.type === "user" ? "user" : "platform";
+  const delegatedAuth = delegatedPromptAuthFromWorkSession(
+    getWorkSessionPrincipal(c),
+    request.spaceId,
+    user.uuid,
+  );
+  const declaration = declarationScope === "user"
+    ? await loadGenerationDeclaration(user.uuid, request.model)
+    : await loadPlatformGenerationDeclaration(request.model);
   if (!declaration) {
     return generationError(c, 404, "generation_model_not_found", `Generation model not found: ${request.model}`);
   }
@@ -178,7 +190,9 @@ router.post("/", async (c) => {
         parameters,
         meta,
         modelDiscount,
+        declarationScope,
         ...(principal?.type === "work_session" ? { workId: principal.workSession.workId } : {}),
+        ...(delegatedAuth ? { auth: delegatedAuth, delegatedAuthRequired: true } : {}),
       },
     }, {
       attempts: 1,

--- a/apps/api/src/routes/internal/gateway.route.ts
+++ b/apps/api/src/routes/internal/gateway.route.ts
@@ -9,7 +9,7 @@ import { getSpacePresenceSnapshot } from "../../space-presence.js";
 import { Hono } from "hono";
 import { bindAllActiveSpaceChannelsToGateway, handleInboundEvent, resolveChannelInboundForEventWithLock } from "../../channels.js";
 import { hasPermission } from "../../permissions.js";
-import { ensureInternalRequest, getOptionalAuth, requireValidId } from "../../lib/middleware.js";
+import { ensureInternalRequest, getOptionalAuth, getRequestPrincipal, requireValidId } from "../../lib/middleware.js";
 import { getSpaceById } from "../../space-sessions.js";
 import { getSpaceSandboxBySpaceId, updateSpaceSandbox } from "../../space-sandboxes.js";
 import { normalizeSandboxLifecycleStatus, normalizeSandboxRuntimeStatus } from "@cohub/sandbox-controller";
@@ -112,6 +112,7 @@ router.post("/authorize-realtime-rooms", async (c) => {
 
   const user = getOptionalAuth(c);
   if (!user) return c.json({ ok: false, message: "authentication is required" }, 401);
+  const principal = getRequestPrincipal(c);
 
   const body = await c.req.json<{ rooms?: string[] }>().catch(() => null);
   const requestedRooms = Array.isArray(body?.rooms) ? Array.from(new Set(body.rooms.filter((room): room is string => typeof room === "string").map((room) => room.trim()).filter(Boolean))) : [];
@@ -129,7 +130,7 @@ router.post("/authorize-realtime-rooms", async (c) => {
     const normalizedRoom = `${parsed.kind}:${parsed.id}`;
 
     if (parsed.kind === "user") {
-      if (parsed.id === user.uuid) {
+      if (principal?.type === "user" && parsed.id === user.uuid) {
         accepted.push(normalizedRoom);
       } else {
         rejected.push({ room, code: "FORBIDDEN", message: "Cannot subscribe to another user" });

--- a/apps/api/src/routes/internal/gateway.route.ts
+++ b/apps/api/src/routes/internal/gateway.route.ts
@@ -13,7 +13,7 @@ import { filterSessionsByPermission, filterSpaceIdsByPermission, hasPermission }
 import { ensureInternalRequest, getOptionalAuth, getRequestPrincipal, requireValidId } from "../../lib/middleware.js";
 import { getSpaceById } from "../../space-sessions.js";
 import { canReadSessionResourceAfterViewDenied } from "../../owner-resource-access.js";
-import { spaceRoomReadPermission } from "../../realtime-room-access.js";
+import { filterReadableSpaceRoomIds, spaceRoomReadPermission } from "../../realtime-room-access.js";
 import { getSpaceSandboxBySpaceId, updateSpaceSandbox } from "../../space-sandboxes.js";
 import { normalizeSandboxLifecycleStatus, normalizeSandboxRuntimeStatus } from "@cohub/sandbox-controller";
 import {
@@ -234,12 +234,14 @@ router.post("/authorize-realtime-rooms", async (c) => {
     return [];
   }));
   const roomPermission = spaceRoomReadPermission(principal);
-  const allowedSpaceIds = new Set(roomPermission
-    ? spaceIds.filter((spaceId) => {
-      const role = memberRoleBySpace.get(spaceId);
-      return Boolean(role && roleHasPermission(role, "session.view"));
-    })
-    : []);
+  const allowedSpaceIds = new Set(await filterReadableSpaceRoomIds(
+    principal,
+    spaceIds,
+    (permission, ids) => filterSpaceIdsByPermission(user, permission, ids).catch((error) => {
+      logger.warn("[RealtimeRooms] failed to batch authorize Space rooms", { userId: user.uuid, error });
+      return [];
+    }),
+  ));
 
   for (const { room, parsed, normalizedRoom } of parsedRooms) {
     if (parsed.kind === "user") {

--- a/apps/api/src/routes/internal/gateway.route.ts
+++ b/apps/api/src/routes/internal/gateway.route.ts
@@ -10,7 +10,9 @@ import { Hono } from "hono";
 import { bindAllActiveSpaceChannelsToGateway, handleInboundEvent, resolveChannelInboundForEventWithLock } from "../../channels.js";
 import { hasPermission } from "../../permissions.js";
 import { ensureInternalRequest, getOptionalAuth, getRequestPrincipal, requireValidId } from "../../lib/middleware.js";
-import { getSpaceById } from "../../space-sessions.js";
+import { getSpaceById, getSpaceSessionById } from "../../space-sessions.js";
+import { canReadSessionResource } from "../../owner-resource-access.js";
+import { spaceRoomReadPermission } from "../../realtime-room-access.js";
 import { getSpaceSandboxBySpaceId, updateSpaceSandbox } from "../../space-sandboxes.js";
 import { normalizeSandboxLifecycleStatus, normalizeSandboxRuntimeStatus } from "@cohub/sandbox-controller";
 import {
@@ -138,6 +140,23 @@ router.post("/authorize-realtime-rooms", async (c) => {
       continue;
     }
 
+    if (parsed.kind === "session") {
+      const session = await getSpaceSessionById(parsed.id);
+      const allowed = session
+        ? await canReadSessionResource(
+            principal,
+            session,
+            (permission, permissionContext) => hasPermission(user, permission, permissionContext),
+          ).catch((error) => {
+            logger.warn("[RealtimeRooms] failed to authorize Session room", { room, userId: user.uuid, error });
+            return false;
+          })
+        : false;
+      if (allowed) accepted.push(normalizedRoom);
+      else rejected.push({ room, code: "FORBIDDEN", message: "Missing Session view permission" });
+      continue;
+    }
+
     if (parsed.kind === "board") {
       const [board] = await db
         .select({ spaceId: boards.spaceId })
@@ -155,14 +174,18 @@ router.post("/authorize-realtime-rooms", async (c) => {
       continue;
     }
 
-    const allowed = await hasPermission(user, "space.view", { spaceId: parsed.id }).catch((error) => {
+    // Space rooms include Space-wide Session and Turn events. Scoped principals
+    // must opt into that broad read surface explicitly; owner-bound Work reads
+    // use session:<id> rooms instead.
+    const roomPermission = spaceRoomReadPermission(principal);
+    const allowed = await hasPermission(user, roomPermission, { spaceId: parsed.id }).catch((error) => {
       logger.warn("[RealtimeRooms] failed to authorize room", { room, userId: user.uuid, error });
       return false;
     });
     if (allowed) {
       accepted.push(normalizedRoom);
     } else {
-      rejected.push({ room, code: "FORBIDDEN", message: "Missing space.view permission" });
+      rejected.push({ room, code: "FORBIDDEN", message: `Missing ${roomPermission} permission` });
     }
   }
 

--- a/apps/api/src/routes/internal/gateway.route.ts
+++ b/apps/api/src/routes/internal/gateway.route.ts
@@ -1,17 +1,18 @@
 import { context, trace, SpanStatusCode } from "@opentelemetry/api";
-import { boards } from "@cohub/db";
+import { accessPolicies, boards, spaceMembers, spaceSessions } from "@cohub/db";
+import { roleHasPermission } from "@cohub/core/permissions";
 import { createLogger } from "@cohub/infra/logging";
 import { getTracer, extractTrace } from "@cohub/infra/tracing/propagator";
 import { GATEWAY_ATTACHMENT_MAX_BYTES, gatewayInboundEventSchema, type GatewayInboundEvent } from "@cohub/protocol/gateway";
-import { parseRealtimeRoom } from "@cohub/protocol/realtime";
+import { MAX_REALTIME_ROOMS_PER_REQUEST, parseRealtimeRoom } from "@cohub/protocol/realtime";
 import { dispatchSpacePresenceUpdated } from "../../realtime-events.js";
 import { getSpacePresenceSnapshot } from "../../space-presence.js";
 import { Hono } from "hono";
 import { bindAllActiveSpaceChannelsToGateway, handleInboundEvent, resolveChannelInboundForEventWithLock } from "../../channels.js";
-import { hasPermission } from "../../permissions.js";
+import { filterSessionsByPermission, filterSpaceIdsByPermission, hasPermission } from "../../permissions.js";
 import { ensureInternalRequest, getOptionalAuth, getRequestPrincipal, requireValidId } from "../../lib/middleware.js";
-import { getSpaceById, getSpaceSessionById } from "../../space-sessions.js";
-import { canReadSessionResource } from "../../owner-resource-access.js";
+import { getSpaceById } from "../../space-sessions.js";
+import { canReadSessionResourceAfterViewDenied } from "../../owner-resource-access.js";
 import { spaceRoomReadPermission } from "../../realtime-room-access.js";
 import { getSpaceSandboxBySpaceId, updateSpaceSandbox } from "../../space-sandboxes.js";
 import { normalizeSandboxLifecycleStatus, normalizeSandboxRuntimeStatus } from "@cohub/sandbox-controller";
@@ -39,7 +40,7 @@ import {
 } from "../../space-upload-storage.js";
 import { enqueueSandboxUploadFilesJob } from "../../sandbox-bash-queue.js";
 import { db } from "../../db/index.js";
-import { eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 const logger = createLogger({ serviceName: "cohub-api" });
 const tracer = getTracer("cohub-api");
@@ -117,76 +118,159 @@ router.post("/authorize-realtime-rooms", async (c) => {
   const principal = getRequestPrincipal(c);
 
   const body = await c.req.json<{ rooms?: string[] }>().catch(() => null);
+  if (Array.isArray(body?.rooms) && body.rooms.length > MAX_REALTIME_ROOMS_PER_REQUEST) {
+    return c.json({ ok: false, message: "realtime room limit exceeded" }, 400);
+  }
   const requestedRooms = Array.isArray(body?.rooms) ? Array.from(new Set(body.rooms.filter((room): room is string => typeof room === "string").map((room) => room.trim()).filter(Boolean))) : [];
   if (requestedRooms.length === 0) return c.json({ ok: true, rooms: [], rejected: [] });
 
   const accepted: string[] = [];
   const rejected: Array<{ room: string; code: "BAD_ROOM" | "FORBIDDEN"; message: string }> = [];
 
-  for (const room of requestedRooms) {
+  const parsedRooms = requestedRooms.flatMap((room) => {
     const parsed = parseRealtimeRoom(room);
-    if (!parsed) {
+    if (!parsed || (parsed.kind !== "user" && !requireValidId(parsed.id))) {
       rejected.push({ room, code: "BAD_ROOM", message: "Invalid room" });
-      continue;
+      return [];
     }
-    const normalizedRoom = `${parsed.kind}:${parsed.id}`;
+    return [{ room, parsed, normalizedRoom: `${parsed.kind}:${parsed.id}` }];
+  });
+  const sessionIds = parsedRooms.filter(({ parsed }) => parsed.kind === "session").map(({ parsed }) => parsed.id);
+  const boardIds = parsedRooms.filter(({ parsed }) => parsed.kind === "board").map(({ parsed }) => parsed.id);
+  const boardSpaceRoomIds = parsedRooms.filter(({ parsed }) => parsed.kind === "boardspace").map(({ parsed }) => parsed.id);
+  const spaceIds = parsedRooms.filter(({ parsed }) => parsed.kind === "space").map(({ parsed }) => parsed.id);
 
-    if (parsed.kind === "user") {
-      if (principal?.type === "user" && parsed.id === user.uuid) {
-        accepted.push(normalizedRoom);
-      } else {
-        rejected.push({ room, code: "FORBIDDEN", message: "Cannot subscribe to another user" });
-      }
-      continue;
-    }
+  const [sessions, boardRows] = await Promise.all([
+    sessionIds.length > 0
+      ? db.select().from(spaceSessions).where(inArray(spaceSessions.id, sessionIds))
+      : Promise.resolve([]),
+    boardIds.length > 0
+      ? db.select({ id: boards.id, spaceId: boards.spaceId }).from(boards).where(inArray(boards.id, boardIds))
+      : Promise.resolve([]),
+  ]);
+  const sessionById = new Map(sessions.map((session) => [session.id, session]));
+  const boardById = new Map(boardRows.map((board) => [board.id, board]));
+  const sessionsBySpace = new Map<string, typeof sessions>();
+  for (const session of sessions) {
+    const grouped = sessionsBySpace.get(session.spaceId) ?? [];
+    grouped.push(session);
+    sessionsBySpace.set(session.spaceId, grouped);
+  }
 
-    if (parsed.kind === "session") {
-      const session = await getSpaceSessionById(parsed.id);
-      const allowed = session
-        ? await canReadSessionResource(
-            principal,
-            session,
-            (permission, permissionContext) => hasPermission(user, permission, permissionContext),
-          ).catch((error) => {
-            logger.warn("[RealtimeRooms] failed to authorize Session room", { room, userId: user.uuid, error });
-            return false;
+  const sessionSpaceIds = Array.from(sessionsBySpace.keys());
+  const membershipSpaceIds = Array.from(new Set([...sessionSpaceIds, ...spaceIds]));
+  const membershipRows = principal?.type === "user" && membershipSpaceIds.length > 0
+    ? await db
+        .select({ spaceId: spaceMembers.spaceId, role: spaceMembers.role })
+        .from(spaceMembers)
+        .where(and(eq(spaceMembers.userId, user.uuid), inArray(spaceMembers.spaceId, membershipSpaceIds)))
+    : [];
+  const memberRoleBySpace = new Map(membershipRows.map((membership) => [membership.spaceId, membership.role]));
+  const sessionViewIds = new Set<string>();
+  if (principal?.type === "user") {
+    const policyResourceIds = Array.from(new Set([...sessionSpaceIds, ...sessionIds]));
+    const policyRows = policyResourceIds.length > 0
+      ? await db
+          .select({
+            resourceType: accessPolicies.resourceType,
+            resourceId: accessPolicies.resourceId,
+            signedInUserRole: accessPolicies.signedInUserRole,
+            anonymousUserRole: accessPolicies.anonymousUserRole,
           })
-        : false;
+          .from(accessPolicies)
+          .where(inArray(accessPolicies.resourceId, policyResourceIds))
+      : [];
+    const policyByResource = new Map(
+      policyRows.map((policy) => [`${policy.resourceType}:${policy.resourceId}`, policy]),
+    );
+    for (const session of sessions) {
+      const memberRole = memberRoleBySpace.get(session.spaceId);
+      if (memberRole && roleHasPermission(memberRole, "session.view")) {
+        sessionViewIds.add(session.id);
+        continue;
+      }
+      const policy = policyByResource.get(`session:${session.id}`)
+        ?? policyByResource.get(`space:${session.spaceId}`);
+      const role = policy?.signedInUserRole ?? policy?.anonymousUserRole ?? null;
+      if (role && roleHasPermission(role, "session.view")) sessionViewIds.add(session.id);
+    }
+  } else {
+    await Promise.all(Array.from(sessionsBySpace, async ([spaceId, grouped]) => {
+      const visible = await filterSessionsByPermission(user, "session.view", spaceId, grouped).catch((error) => {
+        logger.warn("[RealtimeRooms] failed to authorize scoped Session rooms", { spaceId, userId: user.uuid, error });
+        return [];
+      });
+      for (const session of visible) sessionViewIds.add(session.id);
+    }));
+  }
+
+  const permissionCache = new Map<string, Promise<boolean>>();
+  const checkPermission = (permission: Parameters<typeof hasPermission>[1], permissionContext: { spaceId: string; sessionId?: string }) => {
+    const cacheKey = `${permission}:${permissionContext.spaceId}`;
+    let result = permissionCache.get(cacheKey);
+    if (!result) {
+      result = hasPermission(user, permission, permissionContext).catch((error) => {
+        logger.warn("[RealtimeRooms] failed to authorize scoped Session room", { permission, ...permissionContext, userId: user.uuid, error });
+        return false;
+      });
+      permissionCache.set(cacheKey, result);
+    }
+    return result;
+  };
+  const ownerVisibleSessionIds = new Set<string>();
+  await Promise.all(sessions.filter((session) => !sessionViewIds.has(session.id)).map(async (session) => {
+    if (await canReadSessionResourceAfterViewDenied(principal, session, checkPermission)) {
+      ownerVisibleSessionIds.add(session.id);
+    }
+  }));
+
+  const boardSpaceIds = Array.from(new Set(boardRows.map((board) => board.spaceId)));
+  const allowedBoardSpaceIds = new Set(await filterSpaceIdsByPermission(user, "file.view", boardSpaceIds).catch((error) => {
+    logger.warn("[RealtimeRooms] failed to batch authorize Board rooms", { userId: user.uuid, error });
+    return [];
+  }));
+  const allowedBoardAggregateSpaceIds = new Set(await filterSpaceIdsByPermission(user, "file.view", boardSpaceRoomIds).catch((error) => {
+    logger.warn("[RealtimeRooms] failed to batch authorize Board aggregate rooms", { userId: user.uuid, error });
+    return [];
+  }));
+  const roomPermission = spaceRoomReadPermission(principal);
+  const allowedSpaceIds = new Set(roomPermission
+    ? spaceIds.filter((spaceId) => {
+      const role = memberRoleBySpace.get(spaceId);
+      return Boolean(role && roleHasPermission(role, "session.view"));
+    })
+    : []);
+
+  for (const { room, parsed, normalizedRoom } of parsedRooms) {
+    if (parsed.kind === "user") {
+      if (principal?.type === "user" && parsed.id === user.uuid) accepted.push(normalizedRoom);
+      else rejected.push({ room, code: "FORBIDDEN", message: "Cannot subscribe to another user" });
+      continue;
+    }
+    if (parsed.kind === "session") {
+      const allowed = sessionById.has(parsed.id)
+        && (sessionViewIds.has(parsed.id) || ownerVisibleSessionIds.has(parsed.id));
       if (allowed) accepted.push(normalizedRoom);
       else rejected.push({ room, code: "FORBIDDEN", message: "Missing Session view permission" });
       continue;
     }
-
     if (parsed.kind === "board") {
-      const [board] = await db
-        .select({ spaceId: boards.spaceId })
-        .from(boards)
-        .where(eq(boards.id, parsed.id))
-        .limit(1);
-      const allowed = board
-        ? await hasPermission(user, "file.view", { spaceId: board.spaceId }).catch((error) => {
-            logger.warn("[RealtimeRooms] failed to authorize Board room", { room, userId: user.uuid, error });
-            return false;
-          })
-        : false;
-      if (allowed) accepted.push(normalizedRoom);
+      const board = boardById.get(parsed.id);
+      if (board && allowedBoardSpaceIds.has(board.spaceId)) accepted.push(normalizedRoom);
       else rejected.push({ room, code: "FORBIDDEN", message: "Missing Board view permission" });
       continue;
     }
-
-    // Space rooms include Space-wide Session and Turn events. Scoped principals
-    // must opt into that broad read surface explicitly; owner-bound Work reads
-    // use session:<id> rooms instead.
-    const roomPermission = spaceRoomReadPermission(principal);
-    const allowed = await hasPermission(user, roomPermission, { spaceId: parsed.id }).catch((error) => {
-      logger.warn("[RealtimeRooms] failed to authorize room", { room, userId: user.uuid, error });
-      return false;
-    });
-    if (allowed) {
-      accepted.push(normalizedRoom);
-    } else {
-      rejected.push({ room, code: "FORBIDDEN", message: `Missing ${roomPermission} permission` });
+    if (parsed.kind === "boardspace") {
+      if (allowedBoardAggregateSpaceIds.has(parsed.id)) accepted.push(normalizedRoom);
+      else rejected.push({ room, code: "FORBIDDEN", message: "Missing Board view permission" });
+      continue;
     }
+    if (allowedSpaceIds.has(parsed.id)) accepted.push(normalizedRoom);
+    else rejected.push({
+      room,
+      code: "FORBIDDEN",
+      message: roomPermission ? `Missing ${roomPermission} permission` : "Space rooms require an account principal",
+    });
   }
 
   return c.json({ ok: true, rooms: accepted, rejected });

--- a/apps/api/src/routes/internal/spaces.route.ts
+++ b/apps/api/src/routes/internal/spaces.route.ts
@@ -31,6 +31,8 @@ import {
   isPrivateNetworkAddress,
   requireValidId,
 } from "../../lib/middleware.js";
+import { canWriteSessionResource } from "../../owner-resource-access.js";
+import { resolveInternalPromptActor, type InternalPromptPrincipalType } from "../../internal-prompt-auth.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -384,6 +386,7 @@ router.post("/:spaceId/sessions/:sessionId/prompt", async (c) => {
       content: ContentBlock[];
       userId?: string | null;
       authToken?: string | null;
+      principalType?: InternalPromptPrincipalType | null;
       clientMessageId?: string | null;
       source?: string | null;
       model?: string | null;
@@ -399,6 +402,9 @@ router.post("/:spaceId/sessions/:sessionId/prompt", async (c) => {
   }
   const userId = body.userId?.trim();
   if (!userId) return c.json({ message: "userId is required" }, 400);
+  if (body.principalType !== "user" && body.principalType !== "work_session") {
+    return c.json({ message: "principalType is required" }, 400);
+  }
   const accessMode = body.accessMode ?? "full_access";
   if (accessMode !== "read_only" && accessMode !== "full_access") {
     return c.json({ message: "accessMode must be one of: read_only, full_access" }, 400);
@@ -407,12 +413,21 @@ router.post("/:spaceId/sessions/:sessionId/prompt", async (c) => {
   const promptThinkingLevel = typeof body.thinkingLevel === "string" && body.thinkingLevel.trim() && VALID_THINKING_LEVELS.has(body.thinkingLevel.trim()) ? body.thinkingLevel.trim() : body.thinkingLevel === undefined || body.thinkingLevel === null ? undefined : null;
   if (promptThinkingLevel === null) return c.json({ message: "thinkingLevel must be one of: off, minimal, low, medium, high, xhigh, max" }, 400);
   const promptPermission = accessMode === "read_only" ? "session.prompt.readonly" : "session.prompt.fullaccess";
-  const workSession = body.authToken ? verifyWorkSessionToken(body.authToken) : null;
-  const permissionSubject = workSession && workSession.userUuid === userId
-    ? ({ uuid: userId, workSession } as { uuid: string; workSession: typeof workSession })
-    : { uuid: userId };
-  const promptAuth = workSession?.userUuid === userId ? promptAuthContextFromWorkSession(workSession, spaceId) : null;
-  if (!(await hasPermission(permissionSubject, promptPermission, { spaceId, sessionId }))) {
+  const actor = resolveInternalPromptActor({
+    principalType: body.principalType,
+    userId,
+    authToken: body.authToken?.trim() ?? "",
+  }, verifyWorkSessionToken);
+  if (!actor) return c.json({ message: "forbidden" }, 403);
+  const promptAuth = actor.workSession
+    ? promptAuthContextFromWorkSession(actor.workSession, spaceId)
+    : null;
+  if (!(await canWriteSessionResource(
+    actor.principal,
+    session,
+    promptPermission,
+    (permission, context) => hasPermission(actor.permissionSubject, permission, context),
+  ))) {
     return c.json({ message: "forbidden" }, 403);
   }
   const clientMessageId = body.clientMessageId?.trim();

--- a/apps/api/src/routes/internal/spaces.route.ts
+++ b/apps/api/src/routes/internal/spaces.route.ts
@@ -27,6 +27,7 @@ import { isSandboxReportTokenValid } from "../../crypto.js";
 import { normalizeSandboxLifecycleStatus, normalizeSandboxRuntimeStatus } from "@cohub/sandbox-controller";
 import {
   ensureInternalRequest,
+  getRequestPrincipal,
   getRequestRemoteAddress,
   isPrivateNetworkAddress,
   requireValidId,
@@ -413,10 +414,12 @@ router.post("/:spaceId/sessions/:sessionId/prompt", async (c) => {
   const promptThinkingLevel = typeof body.thinkingLevel === "string" && body.thinkingLevel.trim() && VALID_THINKING_LEVELS.has(body.thinkingLevel.trim()) ? body.thinkingLevel.trim() : body.thinkingLevel === undefined || body.thinkingLevel === null ? undefined : null;
   if (promptThinkingLevel === null) return c.json({ message: "thinkingLevel must be one of: off, minimal, low, medium, high, xhigh, max" }, 400);
   const promptPermission = accessMode === "read_only" ? "session.prompt.readonly" : "session.prompt.fullaccess";
+  const requestPrincipal = getRequestPrincipal(c);
   const actor = resolveInternalPromptActor({
     principalType: body.principalType,
     userId,
     authToken: body.authToken?.trim() ?? "",
+    accountUser: requestPrincipal?.type === "user" ? requestPrincipal.user : null,
   }, verifyWorkSessionToken);
   if (!actor) return c.json({ message: "forbidden" }, 403);
   const promptAuth = actor.workSession

--- a/apps/api/src/routes/invite.route.ts
+++ b/apps/api/src/routes/invite.route.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { createHash, randomUUID } from "node:crypto";
 import { db } from "../db/index.js";
 import { spaceMembers, spaces } from "@cohub/db";
 import type { SpaceRole } from "@cohub/db";
@@ -6,11 +7,61 @@ import { isRoleHigherThan } from "@cohub/core/permissions";
 import { and, eq } from "drizzle-orm";
 import { redisCommandClient } from "../redis.js";
 import { useAccountAuth } from "../lib/middleware.js";
+import { createLogger } from "@cohub/infra/logging";
 
 const INVITE_PREFIX = "invite";
+const logger = createLogger({ serviceName: "cohub-api" });
+const INVITE_LOCK_TTL_MS = 30_000;
+const INVITE_LOCK_WAIT_MS = 5_000;
+const INVITE_LOCK_RETRY_MS = 25;
+const RELEASE_INVITE_LOCK_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+end
+return 0
+`;
 
 function inviteKey(token: string) {
   return `${INVITE_PREFIX}:${token}`;
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+class InviteLockTimeoutError extends Error {
+  override name = "InviteLockTimeoutError";
+}
+
+async function withInviteLock<T>(token: string, fn: () => Promise<T>): Promise<T> {
+  const tokenHash = createHash("sha256").update(token).digest("hex");
+  const lockKey = `${INVITE_PREFIX}:accept-lock:${tokenHash}`;
+  const lockToken = randomUUID();
+  const deadline = Date.now() + INVITE_LOCK_WAIT_MS;
+
+  while (true) {
+    const acquired = await redisCommandClient.set(
+      lockKey,
+      lockToken,
+      "PX",
+      INVITE_LOCK_TTL_MS,
+      "NX",
+    );
+    if (acquired === "OK") break;
+    if (Date.now() >= deadline) throw new InviteLockTimeoutError("invitation is busy");
+    await sleep(INVITE_LOCK_RETRY_MS);
+  }
+
+  try {
+    return await fn();
+  } finally {
+    await redisCommandClient.eval(
+      RELEASE_INVITE_LOCK_SCRIPT,
+      1,
+      lockKey,
+      lockToken,
+    ).catch((error) => {
+      logger.warn("[Invite] failed to release accept lock", { lockKey, error });
+    });
+  }
 }
 
 const router = new Hono();
@@ -64,92 +115,91 @@ router.get("/:token", async (c) => {
 router.post("/:token/accept", async (c) => {
   const user = useAccountAuth(c);
   if (user instanceof Response) return user;
-  if (user instanceof Response) return user;
 
   const token = c.req.param("token");
   const key = inviteKey(token);
+  let accepted: Response | { spaceId: string; role: SpaceRole };
+  try {
+    accepted = await withInviteLock(token, async () => {
+      const exists = await redisCommandClient.exists(key);
+      if (!exists) return c.json({ message: "invitation expired or not found" }, 410);
 
-  // Check invitation exists
-  const exists = await redisCommandClient.exists(key);
-  if (!exists) return c.json({ message: "invitation expired or not found" }, 410);
+      const data = await redisCommandClient.hgetall(key);
+      if (data.status === "revoked") {
+        return c.json({ message: "invitation has been revoked" }, 410);
+      }
 
-  // Use WATCH for optimistic locking to prevent race conditions
-  await redisCommandClient.watch(key);
+      const maxUses = Number.parseInt(data.max_uses ?? "0", 10);
+      const useCount = Number.parseInt(data.use_count ?? "0", 10);
+      if (maxUses > 0 && useCount >= maxUses) {
+        return c.json({ message: "invitation has reached its usage limit" }, 410);
+      }
 
-  const data = await redisCommandClient.hgetall(key);
+      const spaceId = data.space_id;
+      const role = data.role as SpaceRole | undefined;
+      if (!spaceId || !role) {
+        return c.json({ message: "invitation expired or not found" }, 410);
+      }
 
-  if (data.status === "revoked") {
-    await redisCommandClient.unwatch();
-    return c.json({ message: "invitation has been revoked" }, 410);
-  }
+      // Invite links may upgrade an existing lower-role member, but never demote.
+      const [existing] = await db
+        .select({ id: spaceMembers.id, role: spaceMembers.role })
+        .from(spaceMembers)
+        .where(and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, user.uuid)))
+        .limit(1);
 
-  const maxUses = Number.parseInt(data.max_uses ?? "0", 10);
-  const useCount = Number.parseInt(data.use_count ?? "0", 10);
-  if (maxUses > 0 && useCount >= maxUses) {
-    await redisCommandClient.unwatch();
-    return c.json({ message: "invitation has reached its usage limit" }, 410);
-  }
+      let acceptedRole = role;
+      let consumedInviteUse = false;
+      if (existing) {
+        if (isRoleHigherThan(role, existing.role)) {
+          await db
+            .update(spaceMembers)
+            .set({ role, updatedBy: user.uuid, updatedAt: new Date() })
+            .where(and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, user.uuid)));
+          consumedInviteUse = true;
+        } else {
+          acceptedRole = existing.role;
+        }
+      } else {
+        await db.insert(spaceMembers).values({
+          spaceId,
+          userId: user.uuid,
+          role,
+          createdBy: user.uuid,
+          updatedBy: user.uuid,
+        });
+        consumedInviteUse = true;
+      }
 
-  const spaceId = data.space_id;
-  const role = data.role as SpaceRole | undefined;
-  if (!spaceId || !role) return c.json({ message: "invitation expired or not found" }, 410);
+      if (consumedInviteUse) {
+        const newCount = await redisCommandClient.hincrby(key, "use_count", 1);
+        if (maxUses > 0 && newCount >= maxUses) {
+          await redisCommandClient.hset(key, "status", "exhausted");
+        }
+      }
 
-  // Check if user is already a member. Invite links may upgrade an existing
-  // lower-role member, for example guest -> builder, but must never demote.
-  const [existing] = await db
-    .select({ id: spaceMembers.id, role: spaceMembers.role })
-    .from(spaceMembers)
-    .where(and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, user.uuid)))
-    .limit(1);
-
-  let acceptedRole = role;
-  let consumedInviteUse = false;
-
-  if (existing) {
-    if (isRoleHigherThan(role, existing.role)) {
-      await db
-        .update(spaceMembers)
-        .set({ role, updatedBy: user.uuid, updatedAt: new Date() })
-        .where(and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, user.uuid)));
-      consumedInviteUse = true;
-    } else {
-      acceptedRole = existing.role;
-    }
-  } else {
-    await db.insert(spaceMembers).values({
-      spaceId: spaceId,
-      userId: user.uuid,
-      role,
-      createdBy: user.uuid,
-      updatedBy: user.uuid,
+      return { spaceId, role: acceptedRole };
     });
-    consumedInviteUse = true;
-  }
-
-  if (consumedInviteUse) {
-    // Increment use count
-    const newCount = await redisCommandClient.hincrby(key, "use_count", 1);
-
-    // Check if max uses reached
-    if (maxUses > 0 && newCount >= maxUses) {
-      await redisCommandClient.hset(key, "status", "exhausted");
+  } catch (error) {
+    if (error instanceof InviteLockTimeoutError) {
+      return c.json({ message: "invitation is busy, please try again" }, 503);
     }
+    throw error;
   }
-
-  await redisCommandClient.unwatch();
+  if (accepted instanceof Response) return accepted;
 
   // Fetch space info for response
   const [space] = await db
     .select({ id: spaces.id, name: spaces.name })
     .from(spaces)
-    .where(eq(spaces.id, spaceId))
+    .where(eq(spaces.id, accepted.spaceId))
     .limit(1);
 
   return c.json({
     ok: true,
-    spaceId,
+    spaceId: accepted.spaceId,
     spaceName: space?.name ?? "Unknown",
-    role: acceptedRole,
+    role: accepted.role,
   });
 });
 

--- a/apps/api/src/routes/invite.route.ts
+++ b/apps/api/src/routes/invite.route.ts
@@ -5,7 +5,7 @@ import type { SpaceRole } from "@cohub/db";
 import { isRoleHigherThan } from "@cohub/core/permissions";
 import { and, eq } from "drizzle-orm";
 import { redisCommandClient } from "../redis.js";
-import { useAuth } from "../lib/middleware.js";
+import { useAccountAuth } from "../lib/middleware.js";
 
 const INVITE_PREFIX = "invite";
 
@@ -62,7 +62,7 @@ router.get("/:token", async (c) => {
 // Accept an invitation (auth required)
 
 router.post("/:token/accept", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   if (user instanceof Response) return user;
 

--- a/apps/api/src/routes/invite.route.ts
+++ b/apps/api/src/routes/invite.route.ts
@@ -1,67 +1,30 @@
 import { Hono } from "hono";
-import { createHash, randomUUID } from "node:crypto";
 import { db } from "../db/index.js";
 import { spaceMembers, spaces } from "@cohub/db";
 import type { SpaceRole } from "@cohub/db";
-import { isRoleHigherThan } from "@cohub/core/permissions";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { redisCommandClient } from "../redis.js";
-import { useAccountAuth } from "../lib/middleware.js";
-import { createLogger } from "@cohub/infra/logging";
+import { authzDenied, getRequestPrincipal, requireValidId } from "../lib/middleware.js";
+import {
+  invitationMembershipLockId,
+  InvitationLockTimeoutError,
+  withInvitationDatabaseLock,
+  withInvitationLock,
+} from "../invitation-lock.js";
+import {
+  acceptInvitationMembership,
+  finalizeInvitationUse,
+  invitationUseAvailability,
+  reconcileExpiredInvitationUses,
+  releaseInvitationUse,
+  reserveInvitationUse,
+} from "../invitation-acceptance.js";
+import { invitationAccountUser } from "../space-invitation-access.js";
 
 const INVITE_PREFIX = "invite";
-const logger = createLogger({ serviceName: "cohub-api" });
-const INVITE_LOCK_TTL_MS = 30_000;
-const INVITE_LOCK_WAIT_MS = 5_000;
-const INVITE_LOCK_RETRY_MS = 25;
-const RELEASE_INVITE_LOCK_SCRIPT = `
-if redis.call("get", KEYS[1]) == ARGV[1] then
-  return redis.call("del", KEYS[1])
-end
-return 0
-`;
 
 function inviteKey(token: string) {
   return `${INVITE_PREFIX}:${token}`;
-}
-
-const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
-
-class InviteLockTimeoutError extends Error {
-  override name = "InviteLockTimeoutError";
-}
-
-async function withInviteLock<T>(token: string, fn: () => Promise<T>): Promise<T> {
-  const tokenHash = createHash("sha256").update(token).digest("hex");
-  const lockKey = `${INVITE_PREFIX}:accept-lock:${tokenHash}`;
-  const lockToken = randomUUID();
-  const deadline = Date.now() + INVITE_LOCK_WAIT_MS;
-
-  while (true) {
-    const acquired = await redisCommandClient.set(
-      lockKey,
-      lockToken,
-      "PX",
-      INVITE_LOCK_TTL_MS,
-      "NX",
-    );
-    if (acquired === "OK") break;
-    if (Date.now() >= deadline) throw new InviteLockTimeoutError("invitation is busy");
-    await sleep(INVITE_LOCK_RETRY_MS);
-  }
-
-  try {
-    return await fn();
-  } finally {
-    await redisCommandClient.eval(
-      RELEASE_INVITE_LOCK_SCRIPT,
-      1,
-      lockKey,
-      lockToken,
-    ).catch((error) => {
-      logger.warn("[Invite] failed to release accept lock", { lockKey, error });
-    });
-  }
 }
 
 const router = new Hono();
@@ -78,13 +41,11 @@ router.get("/:token", async (c) => {
 
   const data = await redisCommandClient.hgetall(key);
 
-  if (data.status === "revoked") {
+  const availability = invitationUseAvailability(data);
+  if (availability === "revoked") {
     return c.json({ message: "invitation has been revoked" }, 410);
   }
-
-  const maxUses = Number.parseInt(data.max_uses ?? "0", 10);
-  const useCount = Number.parseInt(data.use_count ?? "0", 10);
-  if (maxUses > 0 && useCount >= maxUses) {
+  if (availability === "exhausted") {
     return c.json({ message: "invitation has reached its usage limit" }, 410);
   }
 
@@ -113,75 +74,102 @@ router.get("/:token", async (c) => {
 // Accept an invitation (auth required)
 
 router.post("/:token/accept", async (c) => {
-  const user = useAccountAuth(c);
-  if (user instanceof Response) return user;
+  const user = invitationAccountUser(getRequestPrincipal(c));
+  if (!user) return authzDenied(c);
 
   const token = c.req.param("token");
   const key = inviteKey(token);
   let accepted: Response | { spaceId: string; role: SpaceRole };
   try {
-    accepted = await withInviteLock(token, async () => {
+    accepted = await withInvitationLock(token, () => withInvitationDatabaseLock(token, async (transaction) => {
       const exists = await redisCommandClient.exists(key);
       if (!exists) return c.json({ message: "invitation expired or not found" }, 410);
 
-      const data = await redisCommandClient.hgetall(key);
-      if (data.status === "revoked") {
+      let data = await redisCommandClient.hgetall(key);
+      const spaceId = data.space_id;
+      const role = data.role as SpaceRole | undefined;
+      if (!spaceId || !requireValidId(spaceId) || !role) {
+        return c.json({ message: "invitation expired or not found" }, 410);
+      }
+      await reconcileExpiredInvitationUses(
+        key,
+        data,
+        async (reservedUserUuid) => {
+          const [existing] = await transaction
+            .select({ role: spaceMembers.role })
+            .from(spaceMembers)
+            .where(and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, reservedUserUuid)))
+            .limit(1);
+          return existing?.role ?? null;
+        },
+        redisCommandClient,
+      );
+      data = await redisCommandClient.hgetall(key);
+      const availability = invitationUseAvailability(data, user.uuid);
+      if (availability === "revoked") {
         return c.json({ message: "invitation has been revoked" }, 410);
       }
-
-      const maxUses = Number.parseInt(data.max_uses ?? "0", 10);
-      const useCount = Number.parseInt(data.use_count ?? "0", 10);
-      if (maxUses > 0 && useCount >= maxUses) {
+      if (availability === "pending") {
+        return c.json({ message: "invitation acceptance is still being recovered, please try again" }, 503);
+      }
+      if (availability === "exhausted") {
         return c.json({ message: "invitation has reached its usage limit" }, 410);
       }
 
-      const spaceId = data.space_id;
-      const role = data.role as SpaceRole | undefined;
-      if (!spaceId || !role) {
-        return c.json({ message: "invitation expired or not found" }, 410);
+      const membership = await withInvitationLock(
+        invitationMembershipLockId(spaceId, user.uuid),
+        () => acceptInvitationMembership(role, {
+          getRole: async () => {
+            const [existing] = await transaction
+              .select({ role: spaceMembers.role })
+              .from(spaceMembers)
+              .where(and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, user.uuid)))
+              .limit(1);
+            return existing?.role ?? null;
+          },
+          reserveUse: () => reserveInvitationUse(key, user.uuid, role, redisCommandClient),
+          applyRole: async () => {
+            const [member] = await transaction.insert(spaceMembers).values({
+              spaceId,
+              userId: user.uuid,
+              role,
+              createdBy: user.uuid,
+              updatedBy: user.uuid,
+            }).onConflictDoUpdate({
+              target: [spaceMembers.spaceId, spaceMembers.userId],
+              set: {
+                role: sql<SpaceRole>`CASE
+                  WHEN ${spaceMembers.role} = 'host' OR ${role} = 'host' THEN 'host'
+                  WHEN ${spaceMembers.role} = 'builder' OR ${role} = 'builder' THEN 'builder'
+                  ELSE 'guest'
+                END`,
+                updatedBy: user.uuid,
+                updatedAt: new Date(),
+              },
+            }).returning({ role: spaceMembers.role });
+            if (!member) throw new Error("failed to apply invitation membership");
+            return member.role;
+          },
+          finalizeUse: () => finalizeInvitationUse(key, user.uuid, redisCommandClient),
+          releaseUse: () => releaseInvitationUse(key, user.uuid, redisCommandClient),
+        }),
+        redisCommandClient,
+      );
+      switch (membership.state) {
+        case "missing":
+          return c.json({ message: "invitation expired or not found" }, 410);
+        case "revoked":
+          return c.json({ message: "invitation has been revoked" }, 410);
+        case "exhausted":
+          return c.json({ message: "invitation has reached its usage limit" }, 410);
+        case "used":
+          return c.json({ message: "invitation has already been used" }, 410);
+        case "accepted":
+          return { spaceId, role: membership.role };
       }
-
-      // Invite links may upgrade an existing lower-role member, but never demote.
-      const [existing] = await db
-        .select({ id: spaceMembers.id, role: spaceMembers.role })
-        .from(spaceMembers)
-        .where(and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, user.uuid)))
-        .limit(1);
-
-      let acceptedRole = role;
-      let consumedInviteUse = false;
-      if (existing) {
-        if (isRoleHigherThan(role, existing.role)) {
-          await db
-            .update(spaceMembers)
-            .set({ role, updatedBy: user.uuid, updatedAt: new Date() })
-            .where(and(eq(spaceMembers.spaceId, spaceId), eq(spaceMembers.userId, user.uuid)));
-          consumedInviteUse = true;
-        } else {
-          acceptedRole = existing.role;
-        }
-      } else {
-        await db.insert(spaceMembers).values({
-          spaceId,
-          userId: user.uuid,
-          role,
-          createdBy: user.uuid,
-          updatedBy: user.uuid,
-        });
-        consumedInviteUse = true;
-      }
-
-      if (consumedInviteUse) {
-        const newCount = await redisCommandClient.hincrby(key, "use_count", 1);
-        if (maxUses > 0 && newCount >= maxUses) {
-          await redisCommandClient.hset(key, "status", "exhausted");
-        }
-      }
-
-      return { spaceId, role: acceptedRole };
-    });
+    }), redisCommandClient);
   } catch (error) {
-    if (error instanceof InviteLockTimeoutError) {
+    if (error instanceof InvitationLockTimeoutError) {
       return c.json({ message: "invitation is busy, please try again" }, 503);
     }
     throw error;

--- a/apps/api/src/routes/invite.route.ts
+++ b/apps/api/src/routes/invite.route.ts
@@ -14,6 +14,7 @@ import {
 import {
   acceptInvitationMembership,
   finalizeInvitationUse,
+  hasInvitationUseReservation,
   invitationUseAvailability,
   reconcileExpiredInvitationUses,
   releaseInvitationUse,
@@ -81,7 +82,8 @@ router.post("/:token/accept", async (c) => {
   const key = inviteKey(token);
   let accepted: Response | { spaceId: string; role: SpaceRole };
   try {
-    accepted = await withInvitationLock(token, () => withInvitationDatabaseLock(token, async (transaction) => {
+    accepted = await withInvitationLock(token, async () => {
+      const result = await withInvitationDatabaseLock(token, async (transaction) => {
       const exists = await redisCommandClient.exists(key);
       if (!exists) return c.json({ message: "invitation expired or not found" }, 410);
 
@@ -127,6 +129,7 @@ router.post("/:token/accept", async (c) => {
               .limit(1);
             return existing?.role ?? null;
           },
+          hasReservedUse: async () => hasInvitationUseReservation(data, user.uuid),
           reserveUse: () => reserveInvitationUse(key, user.uuid, role, redisCommandClient),
           applyRole: async () => {
             const [member] = await transaction.insert(spaceMembers).values({
@@ -150,7 +153,6 @@ router.post("/:token/accept", async (c) => {
             if (!member) throw new Error("failed to apply invitation membership");
             return member.role;
           },
-          finalizeUse: () => finalizeInvitationUse(key, user.uuid, redisCommandClient),
           releaseUse: () => releaseInvitationUse(key, user.uuid, redisCommandClient),
         }),
         redisCommandClient,
@@ -165,9 +167,18 @@ router.post("/:token/accept", async (c) => {
         case "used":
           return c.json({ message: "invitation has already been used" }, 410);
         case "accepted":
-          return { spaceId, role: membership.role };
+          return { spaceId, role: membership.role, pendingFinalization: membership.pendingFinalization };
       }
-    }), redisCommandClient);
+      });
+      if (result instanceof Response) return result;
+      if (result.pendingFinalization) {
+        const finalization = await finalizeInvitationUse(key, user.uuid, redisCommandClient);
+        if (finalization === "absent" || finalization === "missing") {
+          throw new Error("invitation reservation was lost after membership committed");
+        }
+      }
+      return { spaceId: result.spaceId, role: result.role };
+    }, redisCommandClient);
   } catch (error) {
     if (error instanceof InvitationLockTimeoutError) {
       return c.json({ message: "invitation is busy, please try again" }, 503);

--- a/apps/api/src/routes/me-labels.route.ts
+++ b/apps/api/src/routes/me-labels.route.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { db } from "../db/index.js";
-import { useAuth, requireValidId } from "../lib/middleware.js";
+import { useAccountAuth, requireValidId } from "../lib/middleware.js";
 import {
   getUserResourceLabelAssignments,
   patchUserResourceLabels,
@@ -36,7 +36,7 @@ function parseLabelRefs(value: unknown): string[] | null {
  * to is harmless (it just won't appear in the space list).
  */
 router.get("/resources/:resourceType/labels", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const resourceType = parseResourceType(c.req.param("resourceType") ?? "");
   const resourceRef = c.req.query("resourceRef")?.trim() ?? "";
@@ -55,7 +55,7 @@ router.get("/resources/:resourceType/labels", async (c) => {
  * cannot see.
  */
 router.patch("/resources/:resourceType/labels", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const resourceType = parseResourceType(c.req.param("resourceType") ?? "");
   const resourceRef = c.req.query("resourceRef")?.trim() ?? "";

--- a/apps/api/src/routes/me.route.ts
+++ b/apps/api/src/routes/me.route.ts
@@ -6,7 +6,7 @@ import * as schema from "@cohub/db";
 import { db } from "../db/index.js";
 import { config } from "../config.js";
 import { getRequestPrincipal, getWorkSessionPrincipal, requireValidId, useAccountAuth, useAuth, authzDenied, type AuthUser } from "../lib/middleware.js";
-import { ensureCurrentUserProfile, publicUserProfile, resolveCurrentUserEmail, updateCurrentUserProfile, LogtoUserRequiredError, UsernameClearError, UsernameConflictError, UsernameReservedError, validateUsername } from "../user-profiles.js";
+import { ensureCurrentUserProfile, fallbackPublicUserProfile, getProfilesByUuids, resolveCurrentUserEmail, updateCurrentUserProfile, LogtoUserRequiredError, UsernameClearError, UsernameConflictError, UsernameReservedError, validateUsername } from "../user-profiles.js";
 import {
   filterSessionsByPermission,
   getSpaceMemberRole,
@@ -90,22 +90,25 @@ router.get("/", async (c) => {
   if (user instanceof Response) return user;
   const principal = getRequestPrincipal(c);
   if (principal?.type !== "user" && principal?.type !== "work_session") return authzDenied(c);
-  const profile = await ensureCurrentUserProfile(user);
   if (principal.type === "work_session") {
+    const profile = (await getProfilesByUuids([user.uuid])).get(user.uuid)
+      ?? fallbackPublicUserProfile(user.uuid);
     return c.json({
       uuid: user.uuid,
-      profile: publicUserProfile(profile),
-      email: null,
+      profile,
       principalType: principal.type,
       spaceId: principal.workSession.spaceId,
+      tokenExpiresAt: principal.workSession.exp,
     });
   }
+  const profile = await ensureCurrentUserProfile(user);
   return c.json({
     uuid: user.uuid,
     profile,
     email: await resolveCurrentUserEmail(user),
     principalType: principal.type,
     spaceId: null,
+    tokenExpiresAt: typeof user.tokenExpiresAt === "number" ? user.tokenExpiresAt : null,
   });
 });
 
@@ -205,8 +208,9 @@ router.get("/rules", async (c) => {
 
 /**
  * Cross-space recent sessions for the account identity.
- * Gate: `user.session.list`. Work sessions always include their own sessions;
- * participant sessions still require the original Work's `session.view` scope.
+ * Gate: `user.session.list`. Work sessions always include their own sessions.
+ * Participant sessions and full list records require `session.view` in each
+ * Session's exact Space.
  * Ordinary account tokens retain membership / access-policy visibility.
  */
 async function listVisibleUserSessions(
@@ -327,8 +331,18 @@ router.get("/sessions", async (c) => {
     const { sessions, pageInfo } = await listVisibleUserSessions(user, { limit, cursor, ownerOnly });
     const hydratedSessions = await hydrateSessionParticipantProfiles(sessions);
     const withSpaces = await attachSessionSpaceSummaries(hydratedSessions);
+    const projectedSessions = workSession
+      ? await Promise.all(withSpaces.map(async (session) => (
+          await hasPermission(user, "session.view", {
+            spaceId: session.spaceId,
+            sessionId: session.id,
+          })
+            ? session
+            : ownerSessionSummary(session)
+        )))
+      : withSpaces;
     return c.json({
-      sessions: workSession ? withSpaces.map(ownerSessionSummary) : withSpaces,
+      sessions: projectedSessions,
       pageInfo,
     });
   } catch (error) {

--- a/apps/api/src/routes/me.route.ts
+++ b/apps/api/src/routes/me.route.ts
@@ -5,8 +5,8 @@ import { and, eq, gte, lte, desc } from "drizzle-orm";
 import * as schema from "@cohub/db";
 import { db } from "../db/index.js";
 import { config } from "../config.js";
-import { requireValidId, useAuth, authzDenied } from "../lib/middleware.js";
-import { ensureCurrentUserProfile, resolveCurrentUserEmail, updateCurrentUserProfile, LogtoUserRequiredError, UsernameClearError, UsernameConflictError, UsernameReservedError, validateUsername } from "../user-profiles.js";
+import { getRequestPrincipal, getWorkSessionPrincipal, requireValidId, useAccountAuth, useAuth, authzDenied, type AuthUser } from "../lib/middleware.js";
+import { ensureCurrentUserProfile, publicUserProfile, resolveCurrentUserEmail, updateCurrentUserProfile, LogtoUserRequiredError, UsernameClearError, UsernameConflictError, UsernameReservedError, validateUsername } from "../user-profiles.js";
 import {
   filterSessionsByPermission,
   getSpaceMemberRole,
@@ -33,6 +33,7 @@ import {
 } from "../usage-aggregation.js";
 import { createLogger } from "@cohub/infra/logging";
 import { getReferralDashboard, rotateReferralCode } from "../referrals.js";
+import { ownerSessionSummary } from "../owner-resource-access.js";
 
 const logger = createLogger({ serviceName: "cohub-api" });
 
@@ -87,13 +88,29 @@ async function readUserRules(userId: string) {
 router.get("/", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
+  const principal = getRequestPrincipal(c);
+  if (principal?.type !== "user" && principal?.type !== "work_session") return authzDenied(c);
   const profile = await ensureCurrentUserProfile(user);
-  const email = await resolveCurrentUserEmail(user);
-  return c.json({ uuid: user.uuid, profile, email });
+  if (principal.type === "work_session") {
+    return c.json({
+      uuid: user.uuid,
+      profile: publicUserProfile(profile),
+      email: null,
+      principalType: principal.type,
+      spaceId: principal.workSession.spaceId,
+    });
+  }
+  return c.json({
+    uuid: user.uuid,
+    profile,
+    email: await resolveCurrentUserEmail(user),
+    principalType: principal.type,
+    spaceId: null,
+  });
 });
 
 router.patch("/profile", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const body = await c.req.json<{ displayName?: unknown; avatarUrl?: unknown; username?: unknown }>().catch(() => ({} as { displayName?: unknown; avatarUrl?: unknown; username?: unknown }));
   const input: { displayName?: string; avatarUrl?: string | null; username?: string | null } = {};
@@ -164,20 +181,20 @@ router.patch("/profile", async (c) => {
 });
 
 router.get("/referrals", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   return c.json(await getReferralDashboard(user.uuid));
 });
 
 router.post("/referrals/code/rotate", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const code = await rotateReferralCode(user.uuid);
   return c.json({ code: code.code });
 });
 
 router.get("/rules", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   try {
     return c.json(await readUserRules(user.uuid));
@@ -188,12 +205,13 @@ router.get("/rules", async (c) => {
 
 /**
  * Cross-space recent sessions for the account identity.
- * Gate: `user.session.list`. Visibility: viewer's own membership / access policy
- * (not work-scoped session.view). Over-fetches after filtering for pagination.
+ * Gate: `user.session.list`. Work sessions always include their own sessions;
+ * participant sessions still require the original Work's `session.view` scope.
+ * Ordinary account tokens retain membership / access-policy visibility.
  */
 async function listVisibleUserSessions(
-  user: { uuid: string },
-  options: { limit: number; cursor: string | null },
+  user: AuthUser,
+  options: { limit: number; cursor: string | null; ownerOnly?: boolean },
 ) {
   const identity = asAccountIdentity(user);
   if (!identity) {
@@ -214,7 +232,7 @@ async function listVisibleUserSessions(
     if (cached !== undefined) return cached;
     const isMember = (await getSpaceMemberRole(spaceId, identity.uuid)) !== null;
     const allowed = isMember
-      ? await hasPermission(identity, "session.view", { spaceId })
+      ? await hasPermission(user, "session.view", { spaceId })
       : false;
     memberViewBySpace.set(spaceId, allowed);
     return allowed;
@@ -223,11 +241,21 @@ async function listVisibleUserSessions(
   while (visible.length < limit && hasMore && guard < 8) {
     guard += 1;
     const batchLimit = Math.min(100, Math.max(limit * 2, limit - visible.length + 4));
-    const batch = await listUserSessions(identity.uuid, { limit: batchLimit, cursor });
+    const batch = await listUserSessions(identity.uuid, {
+      limit: batchLimit,
+      cursor,
+      creatorOnly: options.ownerOnly,
+    });
     hasMore = Boolean(batch.pageInfo.hasMore);
     cursor = batch.pageInfo.nextCursor;
 
     if (batch.sessions.length === 0) break;
+
+    if (options.ownerOnly) {
+      visible.push(...batch.sessions);
+      if (!hasMore) break;
+      continue;
+    }
 
     // Group by space only for permission checks. Re-emit in batch activity order
     // so cross-space recency is not scrambled by Map iteration / space buckets.
@@ -240,15 +268,21 @@ async function listVisibleUserSessions(
 
     const visibleIds = new Set<string>();
     for (const [spaceId, sessions] of bySpace) {
+      const participantSessions = sessions.filter((session) => {
+        if (session.userUuid !== identity.uuid) return true;
+        visibleIds.add(session.id);
+        return false;
+      });
+      if (participantSessions.length === 0) continue;
       if (await canViewAllInSpace(spaceId)) {
-        for (const session of sessions) visibleIds.add(session.id);
+        for (const session of participantSessions) visibleIds.add(session.id);
         continue;
       }
       const filtered = await filterSessionsByPermission(
-        identity,
+        user,
         "session.view",
         spaceId,
-        sessions,
+        participantSessions,
       );
       for (const session of filtered) visibleIds.add(session.id);
     }
@@ -284,11 +318,19 @@ router.get("/sessions", async (c) => {
   const limitParam = Number(c.req.query("limit") ?? 20);
   const limit = Number.isFinite(limitParam) ? limitParam : 20;
   const cursor = c.req.query("cursor") ?? null;
+  const workSession = getWorkSessionPrincipal(c);
+  const ownerOnly = Boolean(
+    workSession
+    && !(await hasPermission(user, "session.view", { spaceId: workSession.spaceId })),
+  );
   try {
-    const { sessions, pageInfo } = await listVisibleUserSessions(user, { limit, cursor });
+    const { sessions, pageInfo } = await listVisibleUserSessions(user, { limit, cursor, ownerOnly });
     const hydratedSessions = await hydrateSessionParticipantProfiles(sessions);
     const withSpaces = await attachSessionSpaceSummaries(hydratedSessions);
-    return c.json({ sessions: withSpaces, pageInfo });
+    return c.json({
+      sessions: workSession ? withSpaces.map(ownerSessionSummary) : withSpaces,
+      pageInfo,
+    });
   } catch (error) {
     if (error instanceof InvalidSessionListCursorError) {
       return c.json({ message: "invalid cursor" }, 400);

--- a/apps/api/src/routes/me.route.ts
+++ b/apps/api/src/routes/me.route.ts
@@ -33,7 +33,7 @@ import {
 } from "../usage-aggregation.js";
 import { createLogger } from "@cohub/infra/logging";
 import { getReferralDashboard, rotateReferralCode } from "../referrals.js";
-import { ownerSessionSummary } from "../owner-resource-access.js";
+import { canExposeWorkSessionRecord, canIncludeWorkSessionListRow, ownerSessionSummary } from "../owner-resource-access.js";
 
 const logger = createLogger({ serviceName: "cohub-api" });
 
@@ -208,14 +208,15 @@ router.get("/rules", async (c) => {
 
 /**
  * Cross-space recent sessions for the account identity.
- * Gate: `user.session.list`. Work sessions always include their own sessions.
- * Participant sessions and full list records require `session.view` in each
- * Session's exact Space.
+ * Gate: `user.session.list`. Work sessions include their own sessions, but
+ * only a row in the bound Space with `session.view` can be a full record.
+ * Viewer-owned rows in other Spaces are projected as summaries; participant
+ * rows outside the bound Space are omitted.
  * Ordinary account tokens retain membership / access-policy visibility.
  */
 async function listVisibleUserSessions(
   user: AuthUser,
-  options: { limit: number; cursor: string | null; ownerOnly?: boolean },
+  options: { limit: number; cursor: string | null; workSpaceId?: string | null },
 ) {
   const identity = asAccountIdentity(user);
   if (!identity) {
@@ -248,15 +249,30 @@ async function listVisibleUserSessions(
     const batch = await listUserSessions(identity.uuid, {
       limit: batchLimit,
       cursor,
-      creatorOnly: options.ownerOnly,
     });
     hasMore = Boolean(batch.pageInfo.hasMore);
     cursor = batch.pageInfo.nextCursor;
 
     if (batch.sessions.length === 0) break;
 
-    if (options.ownerOnly) {
-      visible.push(...batch.sessions);
+    if (options.workSpaceId) {
+      // Work principals are allowed to enumerate their own rows across
+      // Spaces, but participant rows are visible only in the bound Space and
+      // only after a session-level view check.
+      const visibleIds = new Set<string>();
+      for (const session of batch.sessions) {
+        const isOwner = session.userUuid === identity.uuid;
+        const hasSessionView = !isOwner
+          && session.spaceId === options.workSpaceId
+          && await hasPermission(user, "session.view", {
+            spaceId: session.spaceId,
+            sessionId: session.id,
+          });
+        if (canIncludeWorkSessionListRow({ userUuid: identity.uuid, spaceId: options.workSpaceId }, session, hasSessionView)) {
+          visibleIds.add(session.id);
+        }
+      }
+      visible.push(...pickSessionsPreservingOrder(batch.sessions, visibleIds));
       if (!hasMore) break;
       continue;
     }
@@ -323,23 +339,25 @@ router.get("/sessions", async (c) => {
   const limit = Number.isFinite(limitParam) ? limitParam : 20;
   const cursor = c.req.query("cursor") ?? null;
   const workSession = getWorkSessionPrincipal(c);
-  const ownerOnly = Boolean(
-    workSession
-    && !(await hasPermission(user, "session.view", { spaceId: workSession.spaceId })),
-  );
   try {
-    const { sessions, pageInfo } = await listVisibleUserSessions(user, { limit, cursor, ownerOnly });
+    const { sessions, pageInfo } = await listVisibleUserSessions(user, {
+      limit,
+      cursor,
+      workSpaceId: workSession?.spaceId ?? null,
+    });
     const hydratedSessions = await hydrateSessionParticipantProfiles(sessions);
     const withSpaces = await attachSessionSpaceSummaries(hydratedSessions);
     const projectedSessions = workSession
-      ? await Promise.all(withSpaces.map(async (session) => (
-          await hasPermission(user, "session.view", {
-            spaceId: session.spaceId,
-            sessionId: session.id,
-          })
+      ? await Promise.all(withSpaces.map(async (session) => {
+          const hasSessionView = session.spaceId === workSession.spaceId
+            && await hasPermission(user, "session.view", {
+              spaceId: session.spaceId,
+              sessionId: session.id,
+            });
+          return canExposeWorkSessionRecord(workSession, session, hasSessionView)
             ? session
-            : ownerSessionSummary(session)
-        )))
+            : ownerSessionSummary(session);
+        }))
       : withSpaces;
     return c.json({
       sessions: projectedSessions,

--- a/apps/api/src/routes/models.route.ts
+++ b/apps/api/src/routes/models.route.ts
@@ -15,9 +15,12 @@ import {
   type ModelCatalogEntry,
   type ModelsConfig,
 } from "@cohub/infra/config-runtime/models";
-import { loadPublicGenerationModels } from "../generations/declarations.js";
+import {
+  loadPlatformPublicGenerationModels,
+  loadPublicGenerationModels,
+} from "../generations/declarations.js";
 import { config } from "../config.js";
-import { useAuth } from "../lib/middleware.js";
+import { getRequestPrincipal, useAuth } from "../lib/middleware.js";
 import { redisCommandClient } from "../redis.js";
 
 
@@ -94,13 +97,18 @@ async function loadCachedModels(input: {
   }
 }
 
-async function fetchModelsCatalog(userId: string): Promise<ModelCatalogEntry[]> {
+async function loadPlatformModelsConfig(): Promise<ModelsConfig> {
   const platformModels = await loadCachedModels({
     redisKey: PLATFORM_MODELS_REDIS_KEY,
     modelsPath: PLATFORM_MODELS_PATH,
     allowMissing: false,
   });
   if (!platformModels) throw new Error("Models catalog file not found");
+  return platformModels;
+}
+
+async function fetchModelsCatalog(userId: string): Promise<ModelCatalogEntry[]> {
+  const platformModels = await loadPlatformModelsConfig();
 
   const userModels = await loadCachedModels({
     redisKey: getUserModelsRedisKey(userId),
@@ -123,10 +131,16 @@ router.get("/", async (c) => {
   try {
     const modelType = c.req.query("modelType");
     if (modelType === MULTIMODAL_MODEL_TYPE) {
-      return c.json(await loadPublicGenerationModels(user.uuid));
+      return c.json(
+        getRequestPrincipal(c)?.type === "user"
+          ? await loadPublicGenerationModels(user.uuid)
+          : await loadPlatformPublicGenerationModels(),
+      );
     }
 
-    const catalog = await fetchModelsCatalog(user.uuid);
+    const catalog = getRequestPrincipal(c)?.type === "user"
+      ? await fetchModelsCatalog(user.uuid)
+      : flattenModelsCatalog(await loadPlatformModelsConfig());
     const grouped: Record<string, ModelCatalogEntry[]> = {};
     for (const entry of catalog) {
       let list = grouped[entry.provider];

--- a/apps/api/src/routes/prompts.route.ts
+++ b/apps/api/src/routes/prompts.route.ts
@@ -10,6 +10,7 @@ const router = new Hono();
 
 router.get("/", async (c) => {
   const actor = getOptionalAuth(c);
+  // Scoped principals may authorize Space access, never account-private paths.
   const accountUser = getOptionalAccountAuth(c);
   const spaceId = c.req.query("spaceId")?.trim() || null;
 

--- a/apps/api/src/routes/prompts.route.ts
+++ b/apps/api/src/routes/prompts.route.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { hasPermission } from "../permissions.js";
-import { getOptionalAuth, authzDenied } from "../lib/middleware.js";
+import { getOptionalAccountAuth, getOptionalAuth, authzDenied } from "../lib/middleware.js";
 import { listPromptTemplates } from "../prompt-templates.js";
 import { createLogger } from "@cohub/infra/logging";
 
@@ -9,21 +9,22 @@ const logger = createLogger({ serviceName: "cohub-api" });
 const router = new Hono();
 
 router.get("/", async (c) => {
-  const user = getOptionalAuth(c);
+  const actor = getOptionalAuth(c);
+  const accountUser = getOptionalAccountAuth(c);
   const spaceId = c.req.query("spaceId")?.trim() || null;
 
-  if (!user && !spaceId) {
+  if (!accountUser && !spaceId) {
     return c.json({ prompts: [] });
   }
 
-  if (spaceId && !(await hasPermission(user, "space.view", { spaceId }))) {
+  if (spaceId && !(await hasPermission(actor, "space.view", { spaceId }))) {
     return authzDenied(c);
   }
 
   try {
     return c.json({
       prompts: await listPromptTemplates({
-        userId: user?.uuid ?? null,
+        userId: accountUser?.uuid ?? null,
         spaceId,
       }),
     });

--- a/apps/api/src/routes/public-assets.access.test.ts
+++ b/apps/api/src/routes/public-assets.access.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { AuthUser, RequestPrincipal } from "../lib/middleware.js";
-import { resolvePublicAssetUploadActor } from "../public-asset-access.js";
+import { canUploadWorkChatAttachment, resolvePublicAssetUploadActor } from "../public-asset-access.js";
 
 const account = { uuid: "viewer-1" } as AuthUser;
 const work: RequestPrincipal = {
@@ -38,9 +38,28 @@ describe("public asset upload principal isolation", () => {
       resolvePublicAssetUploadActor(work, { purpose: "chat_attachment", spaceId: "space-1" }),
       { userUuid: account.uuid, workSpaceId: "space-1" },
     );
+    assert.deepEqual(
+      resolvePublicAssetUploadActor(work, { purpose: "chat_attachment" }),
+      { userUuid: account.uuid, workSpaceId: "space-1" },
+    );
     assert.equal(resolvePublicAssetUploadActor(work, { purpose: "user_avatar", spaceId: "space-1" }), null);
     assert.equal(resolvePublicAssetUploadActor(work, { purpose: "chat_attachment", spaceId: "space-2" }), null);
-    assert.equal(resolvePublicAssetUploadActor(work, { purpose: "chat_attachment" }), null);
+  });
+
+  it("accepts either prompt or generation consent for Work chat attachments", async () => {
+    assert.equal(await canUploadWorkChatAttachment(async () => false, { hasBoundSession: true }), false);
+    assert.equal(await canUploadWorkChatAttachment(
+      async (permission) => permission === "session.prompt.readonly",
+      { hasBoundSession: true },
+    ), true);
+    assert.equal(await canUploadWorkChatAttachment(
+      async (permission) => permission === "generation.create",
+      { hasBoundSession: false },
+    ), true);
+    assert.equal(await canUploadWorkChatAttachment(
+      async (permission) => permission === "session.prompt.readonly",
+      { hasBoundSession: false },
+    ), false);
   });
 
   it("rejects preview and execution principals even when their UUID matches", () => {

--- a/apps/api/src/routes/public-assets.access.test.ts
+++ b/apps/api/src/routes/public-assets.access.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { AuthUser, RequestPrincipal } from "../lib/middleware.js";
+import { resolvePublicAssetUploadActor } from "../public-asset-access.js";
+
+const account = { uuid: "viewer-1" } as AuthUser;
+const work: RequestPrincipal = {
+  type: "work_session",
+  workSession: {
+    type: "work_session",
+    typ: "work_session",
+    userUuid: account.uuid,
+    workId: "work-1",
+    spaceId: "space-1",
+    workScopes: [],
+    viewerScopes: [],
+    scopes: [],
+    iat: 0,
+    exp: 1,
+  },
+};
+
+describe("public asset upload principal isolation", () => {
+  it("keeps every upload purpose available to the real account", () => {
+    const principal: RequestPrincipal = { type: "user", user: account };
+    assert.deepEqual(
+      resolvePublicAssetUploadActor(principal, { purpose: "user_avatar" }),
+      { userUuid: account.uuid, workSpaceId: null },
+    );
+    assert.deepEqual(
+      resolvePublicAssetUploadActor(principal, { purpose: "chat_attachment", spaceId: "space-2" }),
+      { userUuid: account.uuid, workSpaceId: null },
+    );
+  });
+
+  it("allows a Work to request only chat attachments in its bound Space", () => {
+    assert.deepEqual(
+      resolvePublicAssetUploadActor(work, { purpose: "chat_attachment", spaceId: "space-1" }),
+      { userUuid: account.uuid, workSpaceId: "space-1" },
+    );
+    assert.equal(resolvePublicAssetUploadActor(work, { purpose: "user_avatar", spaceId: "space-1" }), null);
+    assert.equal(resolvePublicAssetUploadActor(work, { purpose: "chat_attachment", spaceId: "space-2" }), null);
+    assert.equal(resolvePublicAssetUploadActor(work, { purpose: "chat_attachment" }), null);
+  });
+
+  it("rejects preview and execution principals even when their UUID matches", () => {
+    const preview: RequestPrincipal = {
+      type: "preview_session",
+      previewSession: {
+        type: "preview_session",
+        typ: "preview_session",
+        userUuid: account.uuid,
+        spaceId: "space-1",
+        scopes: [],
+        iat: 0,
+        exp: 1,
+      },
+    };
+    const execution: RequestPrincipal = {
+      type: "execution",
+      execution: {
+        type: "execution",
+        actorUserId: account.uuid,
+        spaceId: "space-1",
+        sessionId: null,
+        turnId: null,
+        source: "test",
+        scopes: [],
+        expiresAt: 1,
+      },
+    };
+    const input = { purpose: "chat_attachment" as const, spaceId: "space-1" };
+    assert.equal(resolvePublicAssetUploadActor(preview, input), null);
+    assert.equal(resolvePublicAssetUploadActor(execution, input), null);
+    assert.equal(resolvePublicAssetUploadActor(null, input), null);
+  });
+});

--- a/apps/api/src/routes/public-assets.access.test.ts
+++ b/apps/api/src/routes/public-assets.access.test.ts
@@ -43,6 +43,7 @@ describe("public asset upload principal isolation", () => {
       { userUuid: account.uuid, workSpaceId: "space-1" },
     );
     assert.equal(resolvePublicAssetUploadActor(work, { purpose: "user_avatar", spaceId: "space-1" }), null);
+    assert.equal(resolvePublicAssetUploadActor(work, { purpose: "space_avatar", spaceId: "space-1" }), null);
     assert.equal(resolvePublicAssetUploadActor(work, { purpose: "chat_attachment", spaceId: "space-2" }), null);
   });
 

--- a/apps/api/src/routes/public-assets.route.ts
+++ b/apps/api/src/routes/public-assets.route.ts
@@ -1,7 +1,13 @@
 import { createLogger } from "@cohub/infra/logging";
 import { Hono } from "hono";
 import { hasPermission } from "../permissions.js";
-import { authzDenied, requireValidId, useAuth } from "../lib/middleware.js";
+import {
+  authzDenied,
+  getRequestPrincipal,
+  requireValidId,
+  useAuth,
+} from "../lib/middleware.js";
+import { resolvePublicAssetUploadActor } from "../public-asset-access.js";
 import {
   consumePublicAssetUploadQuota,
   createPublicAssetUploadPlan,
@@ -27,25 +33,34 @@ router.post("/uploads", async (c) => {
     return c.json({ message: "invalid upload protocol" }, 400);
   }
 
+  const actor = resolvePublicAssetUploadActor(getRequestPrincipal(c), body);
+  if (!actor) return authzDenied(c);
+  if (
+    actor.workSpaceId
+    && !(await hasPermission(user, "generation.create", { spaceId: actor.workSpaceId }))
+  ) {
+    return authzDenied(c);
+  }
+
   if (body.purpose === "space_avatar") {
     if (!body.spaceId || !requireValidId(body.spaceId)) return c.json({ message: "space not found" }, 404);
     if (!(await hasPermission(user, "space.edit", { spaceId: body.spaceId }))) return authzDenied(c);
   }
 
-  // chat_attachment is user-scoped: authenticated is enough.
-  // Optional spaceId/sessionId are association hints only and do not gate upload.
+  // Account spaceId/sessionId fields are association hints. Work uploads are
+  // restricted to their bound Space and an active generation viewer grant.
   // Rate limits: avatar 60/h; chat image specialization 300/h (demotes to file on failure).
 
   try {
     const plan = createPublicAssetUploadPlan({
       purpose: body.purpose,
       uploadProtocol: body.uploadProtocol,
-      userUuid: user.uuid,
+      userUuid: actor.userUuid,
       spaceId: body.spaceId,
       sessionId: body.sessionId,
       file: body.file,
     });
-    await consumePublicAssetUploadQuota(user.uuid, body.purpose);
+    await consumePublicAssetUploadQuota(actor.userUuid, body.purpose);
     return c.json(plan);
   } catch (error) {
     if (error instanceof PublicAssetValidationError) {

--- a/apps/api/src/routes/public-assets.route.ts
+++ b/apps/api/src/routes/public-assets.route.ts
@@ -7,7 +7,9 @@ import {
   requireValidId,
   useAuth,
 } from "../lib/middleware.js";
-import { resolvePublicAssetUploadActor } from "../public-asset-access.js";
+import { canUploadWorkChatAttachment, resolvePublicAssetUploadActor } from "../public-asset-access.js";
+import { canBindGenerationToSession } from "../owner-resource-access.js";
+import { getSpaceSessionById } from "../space-sessions.js";
 import {
   consumePublicAssetUploadQuota,
   createPublicAssetUploadPlan,
@@ -35,9 +37,31 @@ router.post("/uploads", async (c) => {
 
   const actor = resolvePublicAssetUploadActor(getRequestPrincipal(c), body);
   if (!actor) return authzDenied(c);
+  const workSpaceId = actor.workSpaceId;
+  const spaceId = body.spaceId ?? workSpaceId ?? undefined;
+  let hasBoundSession = false;
+  if (workSpaceId && body.sessionId) {
+    if (!requireValidId(body.sessionId)) return c.json({ message: "session not found" }, 404);
+    const session = await getSpaceSessionById(body.sessionId);
+    if (
+      !session
+      || session.spaceId !== workSpaceId
+      || !(await canBindGenerationToSession(
+        getRequestPrincipal(c),
+        session,
+        (permission, context) => hasPermission(user, permission, context),
+      ))
+    ) {
+      return c.json({ message: "session not found" }, 404);
+    }
+    hasBoundSession = true;
+  }
   if (
-    actor.workSpaceId
-    && !(await hasPermission(user, "generation.create", { spaceId: actor.workSpaceId }))
+    workSpaceId
+    && !(await canUploadWorkChatAttachment(
+      (permission) => hasPermission(user, permission, { spaceId: workSpaceId }),
+      { hasBoundSession },
+    ))
   ) {
     return authzDenied(c);
   }
@@ -48,7 +72,8 @@ router.post("/uploads", async (c) => {
   }
 
   // Account spaceId/sessionId fields are association hints. Work uploads are
-  // restricted to their bound Space and an active generation viewer grant.
+  // restricted to their bound Space, owner sessions, and an active prompt or
+  // generation viewer grant.
   // Rate limits: avatar 60/h; chat image specialization 300/h (demotes to file on failure).
 
   try {
@@ -56,7 +81,7 @@ router.post("/uploads", async (c) => {
       purpose: body.purpose,
       uploadProtocol: body.uploadProtocol,
       userUuid: actor.userUuid,
-      spaceId: body.spaceId,
+      spaceId,
       sessionId: body.sessionId,
       file: body.file,
     });

--- a/apps/api/src/routes/referrals.route.ts
+++ b/apps/api/src/routes/referrals.route.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { claimReferral, getPublicReferral, REFERRAL_REWARD_USD } from "../referrals.js";
-import { useAuth } from "../lib/middleware.js";
+import { useAccountAuth } from "../lib/middleware.js";
 
 const router = new Hono();
 const CODE_PATTERN = /^[A-Za-z0-9_-]{8,32}$/;
@@ -27,7 +27,7 @@ router.get("/:code", async (c) => {
 });
 
 router.post("/:code/claim", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const code = c.req.param("code");
   if (!CODE_PATTERN.test(code)) return c.json({ message: "referral not found" }, 404);

--- a/apps/api/src/routes/search-session-visibility.test.ts
+++ b/apps/api/src/routes/search-session-visibility.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { sql as drizzleSql } from "drizzle-orm";
+import { searchSessionVisibilitySql } from "./search-session-visibility.js";
+
+const normalizeSql = (value: string) => value.replace(/\s+/g, " ").trim();
+const VIEWER_USER_UUID = "viewer-user-id";
+
+test("private Session policy blocks public Space inheritance in session and turn search", () => {
+  const { sql, params } = new PgDialect().sqlToQuery(
+    searchSessionVisibilitySql(VIEWER_USER_UUID),
+  );
+
+  assert.deepEqual(params, [VIEWER_USER_UUID]);
+  assert.equal(
+    normalizeSql(sql),
+    normalizeSql(`
+      (
+        sp.viewer_has_member_access
+        OR sess.user_uuid = $1
+        OR EXISTS (
+          SELECT 1
+          FROM v2.access_policies session_policy
+          WHERE session_policy.resource_type = 'session'
+            AND session_policy.resource_id = sess.id
+            AND (
+              session_policy.signed_in_user_role IS NOT NULL
+              OR session_policy.anonymous_user_role IS NOT NULL
+            )
+        )
+        OR (
+          NOT EXISTS (
+            SELECT 1
+            FROM v2.access_policies session_policy
+            WHERE session_policy.resource_type = 'session'
+              AND session_policy.resource_id = sess.id
+          )
+          AND EXISTS (
+            SELECT 1
+            FROM v2.access_policies space_policy
+            WHERE space_policy.resource_type = 'space'
+              AND space_policy.resource_id = sess.space_id
+              AND (
+                space_policy.signed_in_user_role IS NOT NULL
+                OR space_policy.anonymous_user_role IS NOT NULL
+              )
+          )
+        )
+      )
+    `),
+  );
+});
+
+test(
+  "public Space search excludes an explicitly private Session and its turns",
+  { skip: Number(process.versions.node.split(".")[0]) < 22 },
+  async () => {
+    const { DatabaseSync } = await import("node:sqlite");
+    const database = new DatabaseSync(":memory:");
+    try {
+      database.exec(`
+        ATTACH DATABASE ':memory:' AS v2;
+        CREATE TABLE v2.spaces (
+          id TEXT PRIMARY KEY,
+          user_uuid TEXT NOT NULL
+        );
+        CREATE TABLE v2.space_members (
+          space_id TEXT NOT NULL,
+          user_id TEXT NOT NULL
+        );
+        CREATE TABLE v2.space_sessions (
+          id TEXT PRIMARY KEY,
+          space_id TEXT NOT NULL,
+          user_uuid TEXT,
+          title TEXT
+        );
+        CREATE TABLE v2.session_turns (
+          id TEXT PRIMARY KEY,
+          session_id TEXT NOT NULL,
+          user_text TEXT
+        );
+        CREATE TABLE v2.access_policies (
+          resource_type TEXT NOT NULL,
+          resource_id TEXT NOT NULL,
+          signed_in_user_role TEXT,
+          anonymous_user_role TEXT
+        );
+
+        INSERT INTO v2.spaces (id, user_uuid) VALUES
+          ('public-space', 'space-owner'),
+          ('member-space', 'other-space-owner');
+        INSERT INTO v2.space_members (space_id, user_id)
+        VALUES ('member-space', 'viewer-user-id');
+        INSERT INTO v2.access_policies (
+          resource_type,
+          resource_id,
+          signed_in_user_role,
+          anonymous_user_role
+        ) VALUES ('space', 'public-space', 'guest', 'guest');
+
+        INSERT INTO v2.space_sessions (id, space_id, user_uuid, title) VALUES
+          ('private-session', 'public-space', 'session-owner', 'private needle title'),
+          ('inherited-session', 'public-space', 'session-owner', 'public needle title'),
+          ('owned-session', 'public-space', 'viewer-user-id', 'owner needle title'),
+          ('member-session', 'member-space', 'session-owner', 'member needle title');
+        INSERT INTO v2.access_policies (
+          resource_type,
+          resource_id,
+          signed_in_user_role,
+          anonymous_user_role
+        ) VALUES
+          ('session', 'private-session', NULL, NULL),
+          ('session', 'owned-session', NULL, NULL),
+          ('session', 'member-session', NULL, NULL);
+        INSERT INTO v2.session_turns (id, session_id, user_text) VALUES
+          ('private-turn', 'private-session', 'private needle body'),
+          ('inherited-turn', 'inherited-session', 'public needle body'),
+          ('owned-turn', 'owned-session', 'owner needle body'),
+          ('member-turn', 'member-session', 'member needle body');
+      `);
+
+      const search = (needle: string) => {
+        const query = new PgDialect().sqlToQuery(drizzleSql`
+          WITH visible_spaces AS (
+            SELECT
+              s.*,
+              (s.user_uuid = ${VIEWER_USER_UUID} OR sm.user_id IS NOT NULL) AS viewer_has_member_access
+            FROM v2.spaces s
+            LEFT JOIN v2.space_members sm
+              ON sm.space_id = s.id AND sm.user_id = ${VIEWER_USER_UUID}
+            WHERE
+              s.user_uuid = ${VIEWER_USER_UUID}
+              OR sm.user_id IS NOT NULL
+              OR EXISTS (
+                SELECT 1
+                FROM v2.access_policies space_policy
+                WHERE space_policy.resource_type = 'space'
+                  AND space_policy.resource_id = s.id
+                  AND (
+                    space_policy.signed_in_user_role IS NOT NULL
+                    OR space_policy.anonymous_user_role IS NOT NULL
+                  )
+              )
+          ),
+          visible_sessions AS (
+            SELECT sess.*
+            FROM v2.space_sessions sess
+            JOIN visible_spaces sp ON sp.id = sess.space_id
+            WHERE ${searchSessionVisibilitySql(VIEWER_USER_UUID)}
+          ),
+          session_results AS (
+            SELECT 'session' AS type, sess.id
+            FROM visible_sessions sess
+            WHERE sess.title LIKE ${`%${needle}%`}
+          ),
+          turn_results AS (
+            SELECT 'turn' AS type, turn.id
+            FROM v2.session_turns turn
+            JOIN visible_sessions sess ON sess.id = turn.session_id
+            WHERE turn.user_text LIKE ${`%${needle}%`}
+          )
+          SELECT * FROM session_results
+          UNION ALL
+          SELECT * FROM turn_results
+          ORDER BY type, id
+        `);
+        const sqliteQuery = query.sql.replace(/\$\d+/g, "?");
+        const params = query.params.map((param) => {
+          if (typeof param !== "string") throw new TypeError("search SQL test expected string parameters");
+          return param;
+        });
+        return database.prepare(sqliteQuery).all(...params).map((row) => ({ ...row }));
+      };
+
+      assert.deepEqual(search("private needle"), []);
+      assert.deepEqual(search("public needle"), [
+        { type: "session", id: "inherited-session" },
+        { type: "turn", id: "inherited-turn" },
+      ]);
+      assert.deepEqual(search("owner needle"), [
+        { type: "session", id: "owned-session" },
+        { type: "turn", id: "owned-turn" },
+      ]);
+      assert.deepEqual(search("member needle"), [
+        { type: "session", id: "member-session" },
+        { type: "turn", id: "member-turn" },
+      ]);
+    } finally {
+      database.close();
+    }
+  },
+);

--- a/apps/api/src/routes/search-session-visibility.ts
+++ b/apps/api/src/routes/search-session-visibility.ts
@@ -1,0 +1,36 @@
+import { sql } from "drizzle-orm";
+
+export function searchSessionVisibilitySql(viewerUserUuid: string) {
+  return sql`(
+    sp.viewer_has_member_access
+    OR sess.user_uuid = ${viewerUserUuid}
+    OR EXISTS (
+      SELECT 1
+      FROM v2.access_policies session_policy
+      WHERE session_policy.resource_type = 'session'
+        AND session_policy.resource_id = sess.id
+        AND (
+          session_policy.signed_in_user_role IS NOT NULL
+          OR session_policy.anonymous_user_role IS NOT NULL
+        )
+    )
+    OR (
+      NOT EXISTS (
+        SELECT 1
+        FROM v2.access_policies session_policy
+        WHERE session_policy.resource_type = 'session'
+          AND session_policy.resource_id = sess.id
+      )
+      AND EXISTS (
+        SELECT 1
+        FROM v2.access_policies space_policy
+        WHERE space_policy.resource_type = 'space'
+          AND space_policy.resource_id = sess.space_id
+          AND (
+            space_policy.signed_in_user_role IS NOT NULL
+            OR space_policy.anonymous_user_role IS NOT NULL
+          )
+      )
+    )
+  )`;
+}

--- a/apps/api/src/routes/search.route.ts
+++ b/apps/api/src/routes/search.route.ts
@@ -194,7 +194,8 @@ router.get("/", async (c) => {
         CASE
           WHEN s.user_uuid = ${user.uuid} OR sm.user_id IS NOT NULL THEN 1.0::double precision
           ELSE 0.0::double precision
-        END AS membership_priority_score
+        END AS membership_priority_score,
+        (s.user_uuid = ${user.uuid} OR sm.user_id IS NOT NULL) AS viewer_has_member_access
       FROM v2.spaces s
       LEFT JOIN v2.space_members sm
         ON sm.space_id = s.id AND sm.user_id = ${user.uuid}
@@ -221,6 +222,37 @@ router.get("/", async (c) => {
         sp.membership_priority_score
       FROM v2.space_sessions sess
       JOIN visible_spaces sp ON sp.id = sess.space_id
+      WHERE
+        sp.viewer_has_member_access
+        OR sess.user_uuid = ${user.uuid}
+        OR EXISTS (
+          SELECT 1
+          FROM v2.access_policies session_policy
+          WHERE session_policy.resource_type = 'session'
+            AND session_policy.resource_id = sess.id
+            AND (
+              session_policy.signed_in_user_role IS NOT NULL
+              OR session_policy.anonymous_user_role IS NOT NULL
+            )
+        )
+        OR (
+          NOT EXISTS (
+            SELECT 1
+            FROM v2.access_policies session_policy
+            WHERE session_policy.resource_type = 'session'
+              AND session_policy.resource_id = sess.id
+          )
+          AND EXISTS (
+            SELECT 1
+            FROM v2.access_policies space_policy
+            WHERE space_policy.resource_type = 'space'
+              AND space_policy.resource_id = sess.space_id
+              AND (
+                space_policy.signed_in_user_role IS NOT NULL
+                OR space_policy.anonymous_user_role IS NOT NULL
+              )
+          )
+        )
     ),
     space_results AS (
       SELECT

--- a/apps/api/src/routes/search.route.ts
+++ b/apps/api/src/routes/search.route.ts
@@ -4,6 +4,7 @@ import { db } from "../db/index.js";
 import { fallbackPublicUserProfile, getProfilesByUuids } from "../user-profiles.js";
 import { normalizePublicAvatarUrl, useAccountAuth } from "../lib/middleware.js";
 import { createLogger } from "@cohub/infra/logging";
+import { searchSessionVisibilitySql } from "./search-session-visibility.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -222,37 +223,7 @@ router.get("/", async (c) => {
         sp.membership_priority_score
       FROM v2.space_sessions sess
       JOIN visible_spaces sp ON sp.id = sess.space_id
-      WHERE
-        sp.viewer_has_member_access
-        OR sess.user_uuid = ${user.uuid}
-        OR EXISTS (
-          SELECT 1
-          FROM v2.access_policies session_policy
-          WHERE session_policy.resource_type = 'session'
-            AND session_policy.resource_id = sess.id
-            AND (
-              session_policy.signed_in_user_role IS NOT NULL
-              OR session_policy.anonymous_user_role IS NOT NULL
-            )
-        )
-        OR (
-          NOT EXISTS (
-            SELECT 1
-            FROM v2.access_policies session_policy
-            WHERE session_policy.resource_type = 'session'
-              AND session_policy.resource_id = sess.id
-          )
-          AND EXISTS (
-            SELECT 1
-            FROM v2.access_policies space_policy
-            WHERE space_policy.resource_type = 'space'
-              AND space_policy.resource_id = sess.space_id
-              AND (
-                space_policy.signed_in_user_role IS NOT NULL
-                OR space_policy.anonymous_user_role IS NOT NULL
-              )
-          )
-        )
+      WHERE ${searchSessionVisibilitySql(user.uuid)}
     ),
     space_results AS (
       SELECT

--- a/apps/api/src/routes/search.route.ts
+++ b/apps/api/src/routes/search.route.ts
@@ -2,7 +2,7 @@ import { sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { db } from "../db/index.js";
 import { fallbackPublicUserProfile, getProfilesByUuids } from "../user-profiles.js";
-import { normalizePublicAvatarUrl, useAuth } from "../lib/middleware.js";
+import { normalizePublicAvatarUrl, useAccountAuth } from "../lib/middleware.js";
 import { createLogger } from "@cohub/infra/logging";
 
 
@@ -149,7 +149,7 @@ function mapRow(row: SearchResultRow, profiles?: Awaited<ReturnType<typeof getPr
 }
 
 router.get("/", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const q = normalizeQuery(c.req.query("q"));
   const escapedQ = escapeLikePattern(q);

--- a/apps/api/src/routes/sessions.route.ts
+++ b/apps/api/src/routes/sessions.route.ts
@@ -2,7 +2,7 @@ import { createLogger } from "@cohub/infra/logging";
 import { randomUUID } from "node:crypto";
 import { Hono } from "hono";
 import { hasPermission } from "../permissions.js";
-import { getOptionalAuth, useAuth, requireValidId, authzDenied } from "../lib/middleware.js";
+import { getOptionalAuth, getRequestPrincipal, useAuth, requireValidId, authzDenied } from "../lib/middleware.js";
 import {
   getSpaceById,
   getSpaceSessionById,
@@ -19,10 +19,33 @@ import { clearSessionStreamSnapshot, getSessionStreamSnapshot } from "../session
 import { createSessionFork, listSessionForksForSessions } from "../session-forks.js";
 import { dispatchLabelAssignmentsUpdated } from "../realtime-events.js";
 import { buildSessionTurnResponse } from "../session-turn-response.js";
+import { canReadSessionResource, canWriteSessionResource, minimalOwnerSessionSpace } from "../owner-resource-access.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
 const router = new Hono();
+
+const canReadSession = (
+  principal: ReturnType<typeof getRequestPrincipal>,
+  user: ReturnType<typeof getOptionalAuth>,
+  session: NonNullable<Awaited<ReturnType<typeof getSpaceSessionById>>>,
+) => canReadSessionResource(
+  principal,
+  session,
+  (permission, context) => hasPermission(user, permission, context),
+);
+
+const canWriteSession = (
+  principal: ReturnType<typeof getRequestPrincipal>,
+  user: ReturnType<typeof getOptionalAuth>,
+  session: NonNullable<Awaited<ReturnType<typeof getSpaceSessionById>>>,
+  permission: Parameters<typeof canWriteSessionResource>[2],
+) => canWriteSessionResource(
+  principal,
+  session,
+  permission,
+  (requestedPermission, context) => hasPermission(user, requestedPermission, context),
+);
 
 router.post("/:id/turns/:turnId/fork", async (c) => {
   const user = useAuth(c);
@@ -34,7 +57,7 @@ router.post("/:id/turns/:turnId/fork", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session) return c.json({ message: "session not found" }, 404);
-  if (!(await hasPermission(user, "session.edit", { spaceId: session.spaceId, sessionId: session.id }))) {
+  if (!(await canWriteSession(getRequestPrincipal(c), user, session, "session.edit"))) {
     return authzDenied(c);
   }
 
@@ -100,15 +123,18 @@ router.get("/:id", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session) return c.json({ message: "session not found" }, 404);
-  if (!(await hasPermission(user, "session.view", { spaceId: session.spaceId, sessionId: session.id }))) {
+  if (!(await canReadSession(getRequestPrincipal(c), user, session))) {
     return authzDenied(c);
   }
 
   const space = await getSpaceById(session.spaceId);
   if (!space) return c.json({ message: "session not found" }, 404);
 
+  const spaceResponse = await hasPermission(user, "space.view", { spaceId: session.spaceId })
+    ? space
+    : minimalOwnerSessionSpace(space);
   const [hydratedSession] = await hydrateSessionParticipantProfiles([session]);
-  return c.json({ space, session: hydratedSession ?? session, user });
+  return c.json({ space: spaceResponse, session: hydratedSession ?? session, user });
 });
 
 // ── PATCH /api/sessions/:id (rename) ─────────────────────────────────────────
@@ -121,7 +147,7 @@ router.patch("/:id", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session) return c.json({ message: "session not found" }, 404);
-  if (!(await hasPermission(user, "session.edit", { spaceId: session.spaceId, sessionId: session.id }))) {
+  if (!(await canWriteSession(getRequestPrincipal(c), user, session, "session.edit"))) {
     return authzDenied(c);
   }
 
@@ -148,7 +174,7 @@ router.get("/:id/turns", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session) return c.json({ message: "session not found" }, 404);
-  if (!(await hasPermission(user, "session.view", { spaceId: session.spaceId, sessionId: session.id }))) {
+  if (!(await canReadSession(getRequestPrincipal(c), user, session))) {
     return authzDenied(c);
   }
 
@@ -186,7 +212,7 @@ router.get("/:id/turns/index", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session) return c.json({ message: "session not found" }, 404);
-  if (!(await hasPermission(user, "session.view", { spaceId: session.spaceId, sessionId: session.id }))) {
+  if (!(await canReadSession(getRequestPrincipal(c), user, session))) {
     return authzDenied(c);
   }
 
@@ -208,7 +234,7 @@ router.get("/:id/turns/window", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session) return c.json({ message: "session not found" }, 404);
-  if (!(await hasPermission(user, "session.view", { spaceId: session.spaceId, sessionId: session.id }))) {
+  if (!(await canReadSession(getRequestPrincipal(c), user, session))) {
     return authzDenied(c);
   }
 
@@ -236,7 +262,7 @@ router.get("/:id/turns/stream-snapshot", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session) return c.json({ message: "session not found" }, 404);
-  if (!(await hasPermission(user, "session.view", { spaceId: session.spaceId, sessionId: session.id }))) {
+  if (!(await canReadSession(getRequestPrincipal(c), user, session))) {
     return authzDenied(c);
   }
 
@@ -261,7 +287,7 @@ router.get("/:id/turns/:turnId", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session) return c.json({ message: "session not found" }, 404);
-  if (!(await hasPermission(user, "session.view", { spaceId: session.spaceId, sessionId: session.id }))) {
+  if (!(await canReadSession(getRequestPrincipal(c), user, session))) {
     return authzDenied(c);
   }
 
@@ -279,7 +305,7 @@ router.post("/:id/turns/:turnId/signed-urls", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session) return c.json({ message: "session not found" }, 404);
-  if (!(await hasPermission(user, "session.view", { spaceId: session.spaceId, sessionId: session.id }))) {
+  if (!(await canReadSession(getRequestPrincipal(c), user, session))) {
     return authzDenied(c);
   }
   const turn = await getSessionTurnById(session.id, turnId);
@@ -304,7 +330,7 @@ router.get("/:id/messages", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session) return c.json({ message: "session not found" }, 404);
-  if (!(await hasPermission(user, "session.view", { spaceId: session.spaceId, sessionId: session.id }))) {
+  if (!(await canReadSession(getRequestPrincipal(c), user, session))) {
     return authzDenied(c);
   }
 
@@ -354,7 +380,7 @@ router.get("/:id/messages/:messageId", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session) return c.json({ message: "session not found" }, 404);
-  if (!(await hasPermission(user, "session.view", { spaceId: session.spaceId, sessionId: session.id }))) {
+  if (!(await canReadSession(getRequestPrincipal(c), user, session))) {
     return authzDenied(c);
   }
 
@@ -378,7 +404,7 @@ router.post("/:id/abort", async (c) => {
 
   const session = await getSpaceSessionById(sessionId);
   if (!session) return c.json({ message: "session not found" }, 404);
-  if (!(await hasPermission(user, "session.prompt.fullaccess", { spaceId: session.spaceId, sessionId: session.id }))) {
+  if (!(await canWriteSession(getRequestPrincipal(c), user, session, "session.prompt.fullaccess"))) {
     return authzDenied(c);
   }
 

--- a/apps/api/src/routes/skills.route.ts
+++ b/apps/api/src/routes/skills.route.ts
@@ -9,6 +9,7 @@ const router = new Hono();
 
 router.get("/", async (c) => {
   const actor = getOptionalAuth(c);
+  // Scoped principals may authorize Space access, never account-private paths.
   const accountUser = getOptionalAccountAuth(c);
   const spaceId = c.req.query("spaceId")?.trim() || null;
 

--- a/apps/api/src/routes/skills.route.ts
+++ b/apps/api/src/routes/skills.route.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { hasPermission } from "../permissions.js";
-import { getOptionalAuth, authzDenied } from "../lib/middleware.js";
+import { getOptionalAccountAuth, getOptionalAuth, authzDenied } from "../lib/middleware.js";
 import { listSkills } from "../skills.js";
 import { createLogger } from "@cohub/infra/logging";
 
@@ -8,21 +8,22 @@ const logger = createLogger({ serviceName: "cohub-api" });
 const router = new Hono();
 
 router.get("/", async (c) => {
-  const user = getOptionalAuth(c);
+  const actor = getOptionalAuth(c);
+  const accountUser = getOptionalAccountAuth(c);
   const spaceId = c.req.query("spaceId")?.trim() || null;
 
-  if (!user && !spaceId) {
+  if (!accountUser && !spaceId) {
     return c.json({ skills: [] });
   }
 
-  if (spaceId && !(await hasPermission(user, "space.view", { spaceId }))) {
+  if (spaceId && !(await hasPermission(actor, "space.view", { spaceId }))) {
     return authzDenied(c);
   }
 
   try {
     return c.json({
       skills: await listSkills({
-        userId: user?.uuid ?? null,
+        userId: accountUser?.uuid ?? null,
         spaceId,
       }),
     });

--- a/apps/api/src/routes/spaces/invitations.route.ts
+++ b/apps/api/src/routes/spaces/invitations.route.ts
@@ -10,6 +10,7 @@ import {
   withInvitationDatabaseLock,
   withInvitationLock,
 } from "../../invitation-lock.js";
+import { invitationLimitError } from "../../invitation-acceptance.js";
 import {
   canManageSpaceInvitations,
   canViewSpaceInvitations,
@@ -60,12 +61,9 @@ router.post("/", async (c) => {
   if (!VALID_ROLES.includes(role)) return c.json({ message: "invalid role" }, 400);
 
   const ttlSeconds = body?.ttlSeconds ?? DEFAULT_TTL_SECONDS;
-  if (ttlSeconds <= 0 || ttlSeconds > 30 * 24 * 60 * 60) {
-    return c.json({ message: "ttlSeconds must be between 1 and 30 days" }, 400);
-  }
-
   const maxUses = body?.maxUses ?? 0; // 0 = unlimited
-  if (maxUses < 0) return c.json({ message: "maxUses must be non-negative" }, 400);
+  const limitError = invitationLimitError(ttlSeconds, maxUses);
+  if (limitError) return c.json({ message: limitError }, 400);
 
   const token = generateToken();
   const key = inviteKey(token);

--- a/apps/api/src/routes/spaces/invitations.route.ts
+++ b/apps/api/src/routes/spaces/invitations.route.ts
@@ -1,10 +1,20 @@
 import { Hono } from "hono";
 import { redisCommandClient } from "../../redis.js";
-import { requireValidId, useAccountAuth, useAuth } from "../../lib/middleware.js";
+import { authzDenied, getRequestPrincipal, requireValidId } from "../../lib/middleware.js";
 import { getSpaceById } from "../../space-sessions.js";
-import { hasPermission, getRoleForSpaceUser } from "../../permissions.js";
+import { getRoleForSpaceUser, hasPermission } from "../../permissions.js";
 import type { SpaceRole } from "@cohub/db";
 import { projectSpaceInvitation } from "../../space-invitation-view.js";
+import {
+  InvitationLockTimeoutError,
+  withInvitationDatabaseLock,
+  withInvitationLock,
+} from "../../invitation-lock.js";
+import {
+  canManageSpaceInvitations,
+  canViewSpaceInvitations,
+  invitationAccountUser,
+} from "../../space-invitation-access.js";
 
 const VALID_ROLES: SpaceRole[] = ["host", "builder", "guest"];
 const DEFAULT_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
@@ -25,8 +35,9 @@ const router = new Hono();
 // Create a new invitation link
 
 router.post("/", async (c) => {
-  const user = useAccountAuth(c);
-  if (user instanceof Response) return user;
+  const principal = getRequestPrincipal(c);
+  const user = invitationAccountUser(principal);
+  if (!user) return authzDenied(c);
   const spaceId = c.req.param("id");
   if (!spaceId || !requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
 
@@ -35,7 +46,9 @@ router.post("/", async (c) => {
 
   // Only hosts can create invitations
   const actorRole = await getRoleForSpaceUser(spaceId, user.uuid);
-  if (actorRole !== "host") return c.json({ message: "forbidden" }, 403);
+  if (!canManageSpaceInvitations(principal, actorRole)) {
+    return c.json({ message: "forbidden" }, 403);
+  }
 
   const body = await c.req.json<{
     role?: SpaceRole;
@@ -86,15 +99,19 @@ router.post("/", async (c) => {
 // List active invitations for this space
 
 router.get("/", async (c) => {
-  const user = useAuth(c);
-  if (user instanceof Response) return user;
+  const principal = getRequestPrincipal(c);
+  const user = invitationAccountUser(principal);
+  if (!user) return authzDenied(c);
   const spaceId = c.req.param("id");
   if (!spaceId || !requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
 
-  if (!(await hasPermission(user, "member.view", { spaceId }))) {
+  const [hasMemberView, hasMemberManage] = await Promise.all([
+    hasPermission(user, "member.view", { spaceId }),
+    hasPermission(user, "member.manage", { spaceId }),
+  ]);
+  if (!canViewSpaceInvitations(principal, hasMemberView)) {
     return c.json({ message: "forbidden" }, 403);
   }
-  const canManage = await hasPermission(user, "member.manage", { spaceId });
 
   // Scan for invite keys belonging to this space
   const spaceInviteKey = `${INVITE_PREFIX}:space:${spaceId}`;
@@ -121,7 +138,7 @@ router.get("/", async (c) => {
       maxUses: Number.parseInt(data.max_uses ?? "0", 10) || null,
       createdAt: data.created_at ?? null,
       expiresInSeconds: ttl > 0 ? ttl : null,
-    }, canManage));
+    }, hasMemberManage));
   }
 
   return c.json({ items: invitations });
@@ -131,24 +148,37 @@ router.get("/", async (c) => {
 // Revoke an invitation
 
 router.delete("/:token", async (c) => {
-  const user = useAccountAuth(c);
-  if (user instanceof Response) return user;
+  const principal = getRequestPrincipal(c);
+  const user = invitationAccountUser(principal);
+  if (!user) return authzDenied(c);
   const spaceId = c.req.param("id");
   const token = c.req.param("token");
   if (!spaceId || !requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
 
   const actorRole = await getRoleForSpaceUser(spaceId, user.uuid);
-  if (actorRole !== "host") return c.json({ message: "forbidden" }, 403);
+  if (!canManageSpaceInvitations(principal, actorRole)) {
+    return c.json({ message: "forbidden" }, 403);
+  }
 
-  const key = inviteKey(token);
-  const exists = await redisCommandClient.exists(key);
-  if (!exists) return c.json({ message: "invitation not found" }, 404);
+  try {
+    const revoked = await withInvitationLock(token, () => withInvitationDatabaseLock(token, async () => {
+      const key = inviteKey(token);
+      const exists = await redisCommandClient.exists(key);
+      if (!exists) return c.json({ message: "invitation not found" }, 404);
 
-  const data = await redisCommandClient.hgetall(key);
-  if (data.space_id !== spaceId) return c.json({ message: "invitation not found" }, 404);
+      const data = await redisCommandClient.hgetall(key);
+      if (data.space_id !== spaceId) return c.json({ message: "invitation not found" }, 404);
 
-  await redisCommandClient.hset(key, "status", "revoked");
-  return c.json({ ok: true });
+      await redisCommandClient.hset(key, "status", "revoked");
+      return c.json({ ok: true });
+    }), redisCommandClient);
+    return revoked;
+  } catch (error) {
+    if (error instanceof InvitationLockTimeoutError) {
+      return c.json({ message: "invitation is busy, please try again" }, 503);
+    }
+    throw error;
+  }
 });
 
 export default router;

--- a/apps/api/src/routes/spaces/invitations.route.ts
+++ b/apps/api/src/routes/spaces/invitations.route.ts
@@ -4,6 +4,7 @@ import { requireValidId, useAccountAuth, useAuth } from "../../lib/middleware.js
 import { getSpaceById } from "../../space-sessions.js";
 import { hasPermission, getRoleForSpaceUser } from "../../permissions.js";
 import type { SpaceRole } from "@cohub/db";
+import { projectSpaceInvitation } from "../../space-invitation-view.js";
 
 const VALID_ROLES: SpaceRole[] = ["host", "builder", "guest"];
 const DEFAULT_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
@@ -93,6 +94,7 @@ router.get("/", async (c) => {
   if (!(await hasPermission(user, "member.view", { spaceId }))) {
     return c.json({ message: "forbidden" }, 403);
   }
+  const canManage = await hasPermission(user, "member.manage", { spaceId });
 
   // Scan for invite keys belonging to this space
   const spaceInviteKey = `${INVITE_PREFIX}:space:${spaceId}`;
@@ -111,15 +113,15 @@ router.get("/", async (c) => {
     const data = await redisCommandClient.hgetall(key);
     const ttl = await redisCommandClient.ttl(key);
 
-    invitations.push({
+    invitations.push(projectSpaceInvitation({
       token,
       role: data.role as SpaceRole,
-      status: data.status,
+      status: data.status ?? "unknown",
       useCount: Number.parseInt(data.use_count ?? "0", 10),
       maxUses: Number.parseInt(data.max_uses ?? "0", 10) || null,
       createdAt: data.created_at ?? null,
       expiresInSeconds: ttl > 0 ? ttl : null,
-    });
+    }, canManage));
   }
 
   return c.json({ items: invitations });

--- a/apps/api/src/routes/spaces/invitations.route.ts
+++ b/apps/api/src/routes/spaces/invitations.route.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { redisCommandClient } from "../../redis.js";
-import { requireValidId, useAuth } from "../../lib/middleware.js";
+import { requireValidId, useAccountAuth, useAuth } from "../../lib/middleware.js";
 import { getSpaceById } from "../../space-sessions.js";
 import { hasPermission, getRoleForSpaceUser } from "../../permissions.js";
 import type { SpaceRole } from "@cohub/db";
@@ -24,7 +24,7 @@ const router = new Hono();
 // Create a new invitation link
 
 router.post("/", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const spaceId = c.req.param("id");
   if (!spaceId || !requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
@@ -129,7 +129,7 @@ router.get("/", async (c) => {
 // Revoke an invitation
 
 router.delete("/:token", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const spaceId = c.req.param("id");
   const token = c.req.param("token");

--- a/apps/api/src/routes/spaces/spaces.route.ts
+++ b/apps/api/src/routes/spaces/spaces.route.ts
@@ -1167,7 +1167,6 @@ router.get("/by-slug/:username/:slug", async (c) => {
   return c.json({
     id: space.id,
     name: space.name,
-    slug: space.slug,
     accessLevel: "minimal" as const,
   });
 });

--- a/apps/api/src/routes/spaces/spaces.route.ts
+++ b/apps/api/src/routes/spaces/spaces.route.ts
@@ -22,7 +22,7 @@ import {
   sessionTurns,
 } from "@cohub/db";
 import { eq, and, inArray, desc, lt, or, sql } from "drizzle-orm";
-import { useAuth, getOptionalAuth, getWorkSessionPrincipal, getPreviewSessionPrincipal, getExecutionPrincipal, requireValidId, buildSpaceListItems, authzDenied, getSpacePublicProfile, normalizePublicAvatarUrl } from "../../lib/middleware.js";
+import { useAccountAuth, useAuth, getOptionalAuth, getRequestPrincipal, getWorkSessionPrincipal, getPreviewSessionPrincipal, getExecutionPrincipal, requireValidId, buildSpaceListItems, authzDenied, getSpacePublicProfile, normalizePublicAvatarUrl } from "../../lib/middleware.js";
 import { config } from "../../config.js";
 import { scheduleSandboxAutoDestroy } from "../../sandbox-idle-scheduler.js";
 import { attachSandboxPublicEndpoints } from "../../sandbox-public-network.js";
@@ -84,6 +84,7 @@ import { redisCommandClient } from "../../redis.js";
 import { featureGateResponse } from "../../lib/feature-gate.js";
 import { billingBlockedResponse } from "../../lib/billing-blocked.js";
 import { applyRequestSourceToMeta, getRequestSource, resolveSessionSourceFromRequest } from "../../lib/request-source.js";
+import { canWriteSessionResource } from "../../owner-resource-access.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -785,7 +786,7 @@ router.get("/default", async (c) => {
 // ── POST /api/spaces ─────────────────────────────────────────────────────────
 
 router.post("/", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
 
   const body = (await c.req
@@ -1682,7 +1683,7 @@ router.get("/:id/config", async (c) => {
   if (!space) return c.json({ message: "space not found" }, 404);
 
   const [allowedSpec, sandbox] = await Promise.all([
-    user?.uuid ? getAllowedSandboxSpecId(user.uuid) : Promise.resolve(DEFAULT_SANDBOX_SPEC_ID),
+    getAllowedSandboxSpecId(space.userUuid),
     getSpaceSandboxBySpaceId(spaceId),
   ]);
   return c.json({
@@ -1850,7 +1851,12 @@ router.post("/:id/prompt", async (c) => {
   if (sessionId) {
     const session = await getSpaceSessionById(sessionId);
     if (!session || session.spaceId !== spaceId) return c.json({ message: "session not found" }, 404);
-    if (!(await hasPermission(user, promptPermission, { spaceId, sessionId }))) {
+    if (!(await canWriteSessionResource(
+      getRequestPrincipal(c),
+      session,
+      promptPermission,
+      (permission, context) => hasPermission(user, permission, context),
+    ))) {
       return authzDenied(c);
     }
     promptSession = session;
@@ -2060,7 +2066,14 @@ router.post("/:id/sessions/:sessionId/turns/:turnId/steer", async (c) => {
   const sessionId = c.req.param("sessionId");
   const turnId = c.req.param("turnId");
   if (!requireValidId(spaceId) || !requireValidId(sessionId) || !requireValidId(turnId)) return c.json({ message: "not found" }, 404);
-  if (!(await hasPermission(user, "session.prompt.fullaccess", { spaceId, sessionId }))) return authzDenied(c);
+  const session = await getSpaceSessionById(sessionId);
+  if (!session || session.spaceId !== spaceId) return c.json({ message: "session not found" }, 404);
+  if (!(await canWriteSessionResource(
+    getRequestPrincipal(c),
+    session,
+    "session.prompt.fullaccess",
+    (permission, context) => hasPermission(user, permission, context),
+  ))) return authzDenied(c);
 
   try {
     const result = await promoteQueuedTurnToSteer({ spaceId, sessionId, turnId, actorUserId: user.uuid });
@@ -2082,7 +2095,14 @@ router.post("/:id/sessions/:sessionId/turns/:turnId/cancel", async (c) => {
   const sessionId = c.req.param("sessionId");
   const turnId = c.req.param("turnId");
   if (!requireValidId(spaceId) || !requireValidId(sessionId) || !requireValidId(turnId)) return c.json({ message: "not found" }, 404);
-  if (!(await hasPermission(user, "session.prompt.fullaccess", { spaceId, sessionId }))) return authzDenied(c);
+  const session = await getSpaceSessionById(sessionId);
+  if (!session || session.spaceId !== spaceId) return c.json({ message: "session not found" }, 404);
+  if (!(await canWriteSessionResource(
+    getRequestPrincipal(c),
+    session,
+    "session.prompt.fullaccess",
+    (permission, context) => hasPermission(user, permission, context),
+  ))) return authzDenied(c);
 
   try {
     const turn = await cancelQueuedTurn({ spaceId, sessionId, turnId, actorUserId: user.uuid });

--- a/apps/api/src/routes/spaces/spaces.route.ts
+++ b/apps/api/src/routes/spaces/spaces.route.ts
@@ -85,6 +85,8 @@ import { featureGateResponse } from "../../lib/feature-gate.js";
 import { billingBlockedResponse } from "../../lib/billing-blocked.js";
 import { applyRequestSourceToMeta, getRequestSource, resolveSessionSourceFromRequest } from "../../lib/request-source.js";
 import { canWriteSessionResource } from "../../owner-resource-access.js";
+import { sanitizeSpaceMeta, stripSensitiveSpaceFields } from "../../space-response-privacy.js";
+import { scheduledPromptAuthCoversExecution } from "../../scheduled-prompt-auth.js";
 
 
 const logger = createLogger({ serviceName: "cohub-api" });
@@ -1026,20 +1028,6 @@ router.post("/", async (c) => {
  * lists the viewer's spaces. All omitted fields are already optional in the
  * SDK type, so the response stays type-compatible.
  */
-function stripSensitiveSpaceFields(item: Record<string, unknown>): Record<string, unknown> {
-  const { storageRepoName, sandboxStatus, access, meta, ...rest } = item;
-  void storageRepoName;
-  void sandboxStatus;
-  void access;
-  if (meta && typeof meta === "object" && !Array.isArray(meta)) {
-    const { extraEnv, config, ...safeMeta } = meta as Record<string, unknown>;
-    void extraEnv;
-    void config;
-    return { ...rest, meta: safeMeta };
-  }
-  return rest;
-}
-
 async function buildDefaultSpaceResponse(c: Context, space: SpaceRow, user: AuthUser) {
   if (!getWorkSessionPrincipal(c)) return serializeSpaceForResponse(space, user);
   const [item] = await buildSpaceListItems([space]);
@@ -1065,55 +1053,6 @@ async function serializeSpaceForResponse(space: typeof spaces.$inferSelect, user
     access,
     ownerProfile,
   };
-}
-
-function sanitizeRepoUrl(url: string): string {
-  try {
-    const parsed = new URL(url);
-    parsed.username = "";
-    parsed.password = "";
-    return parsed.toString();
-  } catch {
-    return url;
-  }
-}
-
-function sanitizeSpaceMeta(meta: unknown): Record<string, unknown> | null {
-  if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
-    return meta as null;
-  }
-  const metaObj = meta as Record<string, unknown>;
-  const bootstrap = metaObj.bootstrap;
-  if (
-    !bootstrap ||
-    typeof bootstrap !== "object" ||
-    Array.isArray(bootstrap)
-  ) {
-    return metaObj;
-  }
-  const bootstrapObj = bootstrap as Record<string, unknown>;
-  const source = bootstrapObj.source;
-  if (
-    !source ||
-    typeof source !== "object" ||
-    Array.isArray(source)
-  ) {
-    return metaObj;
-  }
-  const sourceObj = source as Record<string, unknown>;
-  if (sourceObj.type === "git_repo" && typeof sourceObj.repoUrl === "string") {
-    return {
-      ...metaObj,
-      bootstrap: {
-        ...bootstrapObj,
-        source: {
-          ...sourceObj,
-          repoUrl: sanitizeRepoUrl(sourceObj.repoUrl as string),
-        },
-      },
-    };
-  }
-  return metaObj;
 }
 
 router.get("/:id", async (c) => {
@@ -1915,7 +1854,7 @@ router.post("/:id/prompt", async (c) => {
     ...(body.provider ? { provider: body.provider } : {}),
     ...(promptThinkingLevel ? { thinkingLevel: promptThinkingLevel } : {}),
     ...(promptLabelIds.length > 0 ? { labelIds: promptLabelIds } : {}),
-    ...(scheduledAuth ? { auth: scheduledAuth } : {}),
+    ...(scheduledAuth ? { auth: scheduledAuth, delegatedAuthRequired: true } : {}),
   };
 
   if (mode === "immediate") {
@@ -2000,6 +1939,9 @@ router.post("/:id/prompt", async (c) => {
       return c.json({ message: "delayMs must be a positive integer, e.g. 600000" }, 400);
     }
     const scheduledAt = new Date(Date.now() + delayMs);
+    if (!scheduledPromptAuthCoversExecution(scheduledAuth, scheduledAt)) {
+      return c.json({ message: "scheduled time exceeds the current Work authorization lifetime" }, 400);
+    }
     const { taskRunId } = await enqueueTask({
       type: "send_message",
       spaceId,
@@ -2019,6 +1961,9 @@ router.post("/:id/prompt", async (c) => {
     } catch (error) {
       return c.json({ message: error instanceof Error ? error.message.toLowerCase().replace(/\.$/, "") : "invalid sendAt" }, 400);
     }
+    if (!scheduledPromptAuthCoversExecution(scheduledAuth, scheduledAt)) {
+      return c.json({ message: "scheduled time exceeds the current Work authorization lifetime" }, 400);
+    }
     const { taskRunId } = await enqueueTask({
       type: "send_message",
       spaceId,
@@ -2030,6 +1975,7 @@ router.post("/:id/prompt", async (c) => {
   }
 
   const repeat = schedule as { cronExpression?: string; timezone?: string };
+  if (getRequestPrincipal(c)?.type !== "user") return authzDenied(c);
   if (!repeat.cronExpression?.trim()) return c.json({ message: "cronExpression is required, e.g. 0 9 * * *" }, 400);
   if (!repeat.timezone?.trim()) return c.json({ message: "timezone is required, e.g. Asia/Shanghai" }, 400);
   let parsedRepeat: { cronExpression: string; timezone: string; nextRun: Date };

--- a/apps/api/src/routes/tasks.route.ts
+++ b/apps/api/src/routes/tasks.route.ts
@@ -2,11 +2,12 @@ import { Hono } from "hono";
 import { db } from "../db/index.js";
 import { taskRuns } from "@cohub/db";
 import { eq, and, desc, inArray, lt, or } from "drizzle-orm";
-import { getOptionalAuth, useAuth, requireValidId, authzDenied } from "../lib/middleware.js";
+import { getOptionalAuth, getRequestPrincipal, useAuth, requireValidId, authzDenied } from "../lib/middleware.js";
 import { hasPermission } from "../permissions.js";
 import { taskQueue } from "../tasks.js";
 import { fallbackPublicUserProfile, getProfilesByUuids } from "../user-profiles.js";
 import { sanitizeTaskRunPricingForViewer } from "../task-run-privacy.js";
+import { canReadTaskResource, ownerTaskListScope, ownerTaskListTaskType } from "../owner-resource-access.js";
 
 const router = new Hono();
 
@@ -122,6 +123,7 @@ router.get("/", async (c) => {
   const cursor = c.req.query("cursor");
   const limitParam = Number(c.req.query("limit") ?? 50);
   const limit = Number.isFinite(limitParam) ? Math.min(Math.max(Math.floor(limitParam), 1), 100) : 50;
+  const principal = getRequestPrincipal(c);
   const user = spaceId ? getOptionalAuth(c) : useAuth(c);
   if (user instanceof Response) return user;
   const userId = user?.uuid;
@@ -154,8 +156,28 @@ router.get("/", async (c) => {
 
   if (!userId) return c.json({ message: "unauthorized" }, 401);
 
+  const ownerScope = ownerTaskListScope(principal);
+  if (!ownerScope || ownerScope.userUuid !== userId) return authzDenied(c);
+  if (
+    ownerScope.requiresGenerationGrant
+    && ownerScope.spaceId
+    && !(await hasPermission(user, "generation.create", { spaceId: ownerScope.spaceId }))
+  ) return authzDenied(c);
+
   const conditions = [eq(taskRuns.userUuid, userId)];
-  applyTaskFilters({ conditions, sessionId, cronJobId, taskType, status, cursor: cursorValue });
+  if (ownerScope.spaceId) conditions.push(eq(taskRuns.spaceId, ownerScope.spaceId));
+  const ownerTaskType = ownerTaskListTaskType(ownerScope, taskType);
+  if (ownerTaskType === null) {
+    return c.json({ runs: [], pageInfo: { hasMore: false, nextCursor: null } });
+  }
+  applyTaskFilters({
+    conditions,
+    sessionId,
+    cronJobId,
+    taskType: ownerTaskType,
+    status,
+    cursor: cursorValue,
+  });
   const rows = await db
     .select()
     .from(taskRuns)
@@ -172,6 +194,7 @@ router.get("/", async (c) => {
 
 router.get("/:taskId", async (c) => {
   const user = getOptionalAuth(c);
+  const principal = getRequestPrincipal(c);
 
   const taskId = c.req.param("taskId");
   if (!taskId?.trim()) return c.json({ message: "task run not found" }, 404);
@@ -179,11 +202,11 @@ router.get("/:taskId", async (c) => {
   const [run] = await db.select().from(taskRuns).where(eq(taskRuns.id, taskId)).limit(1);
   if (!run) return c.json({ message: "task run not found" }, 404);
 
-  if (run.spaceId) {
-    if (!(await hasPermission(user, "taskrun.view", { spaceId: run.spaceId, sessionId: run.sessionId ?? undefined }))) {
-      return authzDenied(c);
-    }
-  } else if (!user || run.userUuid !== user.uuid) {
+  if (!(await canReadTaskResource(
+    principal,
+    run,
+    (permission, context) => hasPermission(user, permission, context),
+  ))) {
     return authzDenied(c);
   }
 

--- a/apps/api/src/routes/tasks.route.ts
+++ b/apps/api/src/routes/tasks.route.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { db } from "../db/index.js";
 import { taskRuns } from "@cohub/db";
-import { eq, and, desc, inArray, lt, or } from "drizzle-orm";
+import { eq, and, desc, inArray, lt, or, sql, type SQL } from "drizzle-orm";
 import { getOptionalAuth, getRequestPrincipal, useAuth, requireValidId, authzDenied } from "../lib/middleware.js";
 import { hasPermission } from "../permissions.js";
 import { taskQueue } from "../tasks.js";
@@ -26,7 +26,7 @@ function buildTaskCursor(run: { createdAt: Date | string | null; id: string } | 
 }
 
 function applyTaskFilters(input: {
-  conditions: ReturnType<typeof eq>[];
+  conditions: SQL[];
   sessionId?: string;
   cronJobId?: string;
   taskType?: string;
@@ -137,9 +137,9 @@ router.get("/", async (c) => {
   const cursorValue = parseTaskCursor(cursor);
   if (cursorValue === "invalid") return c.json({ message: "invalid cursor" }, 400);
 
-  if (spaceId) {
+  if (spaceId && principal?.type !== "work_session") {
     if (!(await hasPermission(user, "taskrun.view", { spaceId, sessionId: sessionId ?? undefined }))) return authzDenied(c);
-    const conditions = [eq(taskRuns.spaceId, spaceId)];
+    const conditions: SQL[] = [eq(taskRuns.spaceId, spaceId)];
     applyTaskFilters({ conditions, sessionId, cronJobId, taskType, status, cursor: cursorValue });
     const rows = await db
       .select()
@@ -149,7 +149,7 @@ router.get("/", async (c) => {
       .limit(limit + 1);
     const runs = await hydrateTaskRunUserProfiles(rows.slice(0, limit), {
       sanitizeForList: true,
-      viewerUserId: userId,
+      viewerUserId: principal?.type === "user" ? userId : null,
     });
     return c.json({ runs, pageInfo: { hasMore: rows.length > limit, nextCursor: rows.length > limit ? buildTaskCursor(runs.at(-1)) : null } });
   }
@@ -158,14 +158,18 @@ router.get("/", async (c) => {
 
   const ownerScope = ownerTaskListScope(principal);
   if (!ownerScope || ownerScope.userUuid !== userId) return authzDenied(c);
+  if (spaceId && ownerScope.spaceId !== spaceId) return authzDenied(c);
   if (
     ownerScope.requiresGenerationGrant
     && ownerScope.spaceId
     && !(await hasPermission(user, "generation.create", { spaceId: ownerScope.spaceId }))
   ) return authzDenied(c);
 
-  const conditions = [eq(taskRuns.userUuid, userId)];
+  const conditions: SQL[] = [eq(taskRuns.userUuid, userId)];
   if (ownerScope.spaceId) conditions.push(eq(taskRuns.spaceId, ownerScope.spaceId));
+  if (ownerScope.workId) {
+    conditions.push(sql`${taskRuns.payload} -> 'data' ->> 'workId' = ${ownerScope.workId}`);
+  }
   const ownerTaskType = ownerTaskListTaskType(ownerScope, taskType);
   if (ownerTaskType === null) {
     return c.json({ runs: [], pageInfo: { hasMore: false, nextCursor: null } });
@@ -186,7 +190,7 @@ router.get("/", async (c) => {
     .limit(limit + 1);
   const runs = await hydrateTaskRunUserProfiles(rows.slice(0, limit), {
     sanitizeForList: true,
-    viewerUserId: userId,
+    viewerUserId: principal?.type === "user" ? userId : null,
   });
 
   return c.json({ runs, pageInfo: { hasMore: rows.length > limit, nextCursor: rows.length > limit ? buildTaskCursor(runs.at(-1)) : null } });
@@ -211,7 +215,9 @@ router.get("/:taskId", async (c) => {
   }
 
   const job = await taskQueue.getJob(run.jobId).catch(() => null);
-  const [hydratedRun] = await hydrateTaskRunUserProfiles([run], { viewerUserId: user?.uuid });
+  const [hydratedRun] = await hydrateTaskRunUserProfiles([run], {
+    viewerUserId: principal?.type === "user" ? user?.uuid : null,
+  });
   return c.json({ run: hydratedRun, progress: job?.progress ?? null });
 });
 

--- a/apps/api/src/routes/work-commerce.route.ts
+++ b/apps/api/src/routes/work-commerce.route.ts
@@ -1,6 +1,6 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { isBillingApiError } from "../lib/billing-api-error.js";
-import { authzDenied, getOptionalAuth, requireValidId, useAuth } from "../lib/middleware.js";
+import { authzDenied, getOptionalAuth, getRequestPrincipal, requireValidId, useAccountAuth } from "../lib/middleware.js";
 import { handleWorkCommerceRouteError } from "../lib/commerce-http.js";
 import { hasPermission } from "../permissions.js";
 import {
@@ -19,6 +19,20 @@ import { eq } from "drizzle-orm";
 import { config } from "../config.js";
 
 const router = new Hono();
+
+function useBoundWorkCommerceViewer(c: Context, workId: string) {
+  const principal = getRequestPrincipal(c);
+  const user = getOptionalAuth(c);
+  if (principal?.type === "user" && user) return { user, workSession: null };
+  if (
+    principal?.type === "work_session"
+    && principal.workSession.workId === workId
+    && user
+  ) {
+    return { user, workSession: principal.workSession };
+  }
+  return authzDenied(c);
+}
 
 async function getPublishedWorkOrDeny(workId: string, userUuid?: string | null) {
   const work = await getWorkCommerceContextById(workId);
@@ -92,12 +106,14 @@ router.post("/works/:id/commerce/products/resolve", async (c) => {
 });
 
 router.get("/works/:id/commerce/entitlements", async (c) => {
-  const user = useAuth(c);
-  if (user instanceof Response) return user;
   const workId = c.req.param("id");
   if (!requireValidId(workId)) return c.json({ message: "work not found" }, 404);
+  const viewer = useBoundWorkCommerceViewer(c, workId);
+  if (viewer instanceof Response) return viewer;
+  const { user } = viewer;
   const resolved = await getPublishedWorkOrDeny(workId, user.uuid);
   if ("error" in resolved) return c.json({ message: resolved.error }, 404);
+  if (viewer.workSession && viewer.workSession.spaceId !== resolved.work.spaceId) return authzDenied(c);
   if ((resolved.work.workVisibility ?? "public") === "space" && !(await hasPermission(user, "space.view", { spaceId: resolved.work.spaceId }))) return authzDenied(c);
   try {
     const businessKey = await requireSpaceCommerceBusinessKey(resolved.work.spaceId);
@@ -124,12 +140,14 @@ router.get("/works/:id/commerce/entitlements", async (c) => {
 });
 
 router.post("/works/:id/commerce/credits/consume", async (c) => {
-  const user = useAuth(c);
-  if (user instanceof Response) return user;
   const workId = c.req.param("id");
   if (!requireValidId(workId)) return c.json({ message: "work not found" }, 404);
+  const viewer = useBoundWorkCommerceViewer(c, workId);
+  if (viewer instanceof Response) return viewer;
+  const { user } = viewer;
   const resolved = await getPublishedWorkOrDeny(workId, user.uuid);
   if ("error" in resolved) return c.json({ message: resolved.error }, 404);
+  if (viewer.workSession && viewer.workSession.spaceId !== resolved.work.spaceId) return authzDenied(c);
   if ((resolved.work.workVisibility ?? "public") === "space" && !(await hasPermission(user, "space.view", { spaceId: resolved.work.spaceId }))) return authzDenied(c);
   const body = await c.req.json().catch(() => null) as {
     amount?: unknown;
@@ -177,7 +195,7 @@ router.post("/works/:id/commerce/credits/consume", async (c) => {
 });
 
 router.post("/works/:id/commerce/purchase", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const workId = c.req.param("id");
   if (!requireValidId(workId)) return c.json({ message: "work not found" }, 404);
@@ -232,14 +250,16 @@ router.post("/works/:id/commerce/purchase", async (c) => {
 });
 
 router.get("/works/:id/commerce/orders/:orderId", async (c) => {
-  const user = useAuth(c);
-  if (user instanceof Response) return user;
   const workId = c.req.param("id");
   const orderId = c.req.param("orderId");
   if (!requireValidId(workId)) return c.json({ message: "work not found" }, 404);
   if (!requireValidId(orderId)) return c.json({ message: "order not found" }, 404);
+  const viewer = useBoundWorkCommerceViewer(c, workId);
+  if (viewer instanceof Response) return viewer;
+  const { user } = viewer;
   const resolved = await getPublishedWorkOrDeny(workId, user.uuid);
   if ("error" in resolved) return c.json({ message: resolved.error }, 404);
+  if (viewer.workSession && viewer.workSession.spaceId !== resolved.work.spaceId) return authzDenied(c);
   if ((resolved.work.workVisibility ?? "public") === "space" && !(await hasPermission(user, "space.view", { spaceId: resolved.work.spaceId }))) return authzDenied(c);
   try {
     const businessKey = await requireSpaceCommerceBusinessKey(resolved.work.spaceId);

--- a/apps/api/src/routes/works.route.ts
+++ b/apps/api/src/routes/works.route.ts
@@ -11,6 +11,7 @@ import {
   getOptionalAuth,
   getSpacePublicProfile,
   requireValidId,
+  useAccountAuth,
   useAuth,
   type AuthUser,
 } from "../lib/middleware.js";
@@ -767,7 +768,7 @@ router.delete("/:id", async (c) => {
 });
 
 router.post("/:id/session", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const id = c.req.param("id");
   if (!requireValidId(id)) return c.json({ message: "work not found" }, 404);
@@ -784,7 +785,7 @@ router.post("/:id/session", async (c) => {
 });
 
 router.post("/:id/authorize", async (c) => {
-  const user = useAuth(c);
+  const user = useAccountAuth(c);
   if (user instanceof Response) return user;
   const id = c.req.param("id");
   if (!requireValidId(id)) return c.json({ message: "work not found" }, 404);

--- a/apps/api/src/scheduled-prompt-auth.test.ts
+++ b/apps/api/src/scheduled-prompt-auth.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { PromptAuthContext } from "@cohub/core/sessions";
+import {
+  SCHEDULED_PROMPT_AUTH_MARGIN_MS,
+  scheduledPromptAuthCoversExecution,
+} from "./scheduled-prompt-auth.js";
+
+const delegatedAuth = (expiresAtMs: number): PromptAuthContext => ({
+  type: "delegated_prompt",
+  source: "work_session",
+  actorUserId: "viewer",
+  workId: "work",
+  spaceId: "space",
+  scopes: ["session.prompt.create"],
+  workScopes: ["session.prompt.create"],
+  viewerScopes: [],
+  delegatedAt: new Date(0).toISOString(),
+  exp: expiresAtMs / 1000,
+  workViewerGrantId: "grant",
+});
+
+test("scheduled Work prompts must start before delegated authorization expires", () => {
+  const scheduledAt = new Date("2026-07-30T12:00:00.000Z");
+  assert.equal(scheduledPromptAuthCoversExecution(null, scheduledAt), true);
+  assert.equal(
+    scheduledPromptAuthCoversExecution(
+      delegatedAuth(scheduledAt.getTime() + SCHEDULED_PROMPT_AUTH_MARGIN_MS),
+      scheduledAt,
+    ),
+    false,
+  );
+  assert.equal(
+    scheduledPromptAuthCoversExecution(
+      delegatedAuth(scheduledAt.getTime() + SCHEDULED_PROMPT_AUTH_MARGIN_MS + 1),
+      scheduledAt,
+    ),
+    true,
+  );
+});

--- a/apps/api/src/scheduled-prompt-auth.ts
+++ b/apps/api/src/scheduled-prompt-auth.ts
@@ -1,0 +1,11 @@
+import type { PromptAuthContext } from "@cohub/core/sessions";
+
+export const SCHEDULED_PROMPT_AUTH_MARGIN_MS = 30_000;
+
+export function scheduledPromptAuthCoversExecution(
+  auth: PromptAuthContext | null,
+  scheduledAt: Date,
+): boolean {
+  if (!auth) return true;
+  return auth.exp * 1000 > scheduledAt.getTime() + SCHEDULED_PROMPT_AUTH_MARGIN_MS;
+}

--- a/apps/api/src/space-invitation-access.test.ts
+++ b/apps/api/src/space-invitation-access.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { AuthUser, RequestPrincipal } from "./lib/middleware.js";
+import {
+  canManageSpaceInvitations,
+  canViewSpaceInvitations,
+  invitationAccountUser,
+} from "./space-invitation-access.js";
+
+const account = { uuid: "viewer-1" } as AuthUser;
+const accountPrincipal: RequestPrincipal = { type: "user", user: account };
+const scopedPrincipals: RequestPrincipal[] = [
+  {
+    type: "work_session",
+    workSession: {
+      type: "work_session",
+      typ: "work_session",
+      userUuid: account.uuid,
+      workId: "work-1",
+      spaceId: "space-1",
+      workScopes: ["member.manage"],
+      viewerScopes: ["member.manage"],
+      scopes: ["member.manage"],
+      iat: 0,
+      exp: 1,
+    },
+  },
+  {
+    type: "preview_session",
+    previewSession: {
+      type: "preview_session",
+      typ: "preview_session",
+      userUuid: account.uuid,
+      spaceId: "space-1",
+      scopes: ["member.manage"],
+      iat: 0,
+      exp: 1,
+    },
+  },
+  {
+    type: "execution",
+    execution: {
+      type: "execution",
+      actorUserId: account.uuid,
+      spaceId: "space-1",
+      sessionId: null,
+      turnId: null,
+      source: "test",
+      scopes: ["member.manage"],
+      expiresAt: 1,
+    },
+  },
+];
+
+describe("space invitation principal isolation", () => {
+  it("rejects scoped-principal replay even when it carries the same user UUID", () => {
+    for (const principal of scopedPrincipals) {
+      assert.equal(invitationAccountUser(principal), null);
+    }
+    assert.equal(invitationAccountUser(null), null);
+    assert.equal(invitationAccountUser(accountPrincipal), account);
+  });
+
+  it("allows invitation management only to a real account host", () => {
+    assert.equal(canManageSpaceInvitations(accountPrincipal, "host"), true);
+    assert.equal(canManageSpaceInvitations(accountPrincipal, "builder"), false);
+    assert.equal(canManageSpaceInvitations(accountPrincipal, "guest"), false);
+    for (const principal of scopedPrincipals) {
+      assert.equal(canManageSpaceInvitations(principal, "host"), false);
+    }
+    assert.equal(canManageSpaceInvitations(null, "host"), false);
+  });
+
+  it("keeps account member.view separate from host-only management", () => {
+    assert.equal(canViewSpaceInvitations(accountPrincipal, true), true);
+    assert.equal(canViewSpaceInvitations(accountPrincipal, false), false);
+    for (const principal of scopedPrincipals) {
+      assert.equal(canViewSpaceInvitations(principal, true), false);
+    }
+  });
+});

--- a/apps/api/src/space-invitation-access.ts
+++ b/apps/api/src/space-invitation-access.ts
@@ -1,0 +1,20 @@
+import type { SpaceRole } from "@cohub/db";
+import type { AuthUser, RequestPrincipal } from "./lib/middleware.js";
+
+export function invitationAccountUser(principal: RequestPrincipal | null): AuthUser | null {
+  return principal?.type === "user" ? principal.user : null;
+}
+
+export function canManageSpaceInvitations(
+  principal: RequestPrincipal | null,
+  role: SpaceRole | null,
+): boolean {
+  return invitationAccountUser(principal) !== null && role === "host";
+}
+
+export function canViewSpaceInvitations(
+  principal: RequestPrincipal | null,
+  hasMemberView: boolean,
+): boolean {
+  return invitationAccountUser(principal) !== null && hasMemberView;
+}

--- a/apps/api/src/space-invitation-view.test.ts
+++ b/apps/api/src/space-invitation-view.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { projectSpaceInvitation } from "./space-invitation-view.js";
+
+const invitation = {
+  token: "inv_host_secret",
+  role: "host" as const,
+  status: "active",
+  useCount: 0,
+  maxUses: 1,
+  createdAt: "2026-07-31T00:00:00.000Z",
+  expiresInSeconds: 60,
+};
+
+test("member.view invitation summaries never expose bearer tokens", () => {
+  const summary = projectSpaceInvitation(invitation, false);
+  assert.equal("token" in summary, false);
+  assert.equal(summary.role, "host");
+  const managed = projectSpaceInvitation(invitation, true);
+  assert.equal("token" in managed ? managed.token : null, invitation.token);
+});

--- a/apps/api/src/space-invitation-view.test.ts
+++ b/apps/api/src/space-invitation-view.test.ts
@@ -15,7 +15,9 @@ const invitation = {
 test("member.view invitation summaries never expose bearer tokens", () => {
   const summary = projectSpaceInvitation(invitation, false);
   assert.equal("token" in summary, false);
+  assert.match(summary.id, /^invite_[A-Za-z0-9_-]{43}$/);
   assert.equal(summary.role, "host");
   const managed = projectSpaceInvitation(invitation, true);
+  assert.equal(managed.id, summary.id);
   assert.equal("token" in managed ? managed.token : null, invitation.token);
 });

--- a/apps/api/src/space-invitation-view.ts
+++ b/apps/api/src/space-invitation-view.ts
@@ -1,4 +1,8 @@
+import { createHash } from "node:crypto";
 import type { SpaceRole } from "@cohub/db";
+
+const invitationPublicId = (token: string) =>
+  `invite_${createHash("sha256").update(token).digest("base64url")}`;
 
 export function projectSpaceInvitation(
   input: {
@@ -13,5 +17,6 @@ export function projectSpaceInvitation(
   canManage: boolean,
 ) {
   const { token, ...summary } = input;
-  return canManage ? { token, ...summary } : summary;
+  const projected = { id: invitationPublicId(token), ...summary };
+  return canManage ? { token, ...projected } : projected;
 }

--- a/apps/api/src/space-invitation-view.ts
+++ b/apps/api/src/space-invitation-view.ts
@@ -1,0 +1,17 @@
+import type { SpaceRole } from "@cohub/db";
+
+export function projectSpaceInvitation(
+  input: {
+    token: string;
+    role: SpaceRole;
+    status: string;
+    useCount: number;
+    maxUses: number | null;
+    createdAt: string | null;
+    expiresInSeconds: number | null;
+  },
+  canManage: boolean,
+) {
+  const { token, ...summary } = input;
+  return canManage ? { token, ...summary } : summary;
+}

--- a/apps/api/src/space-response-privacy.test.ts
+++ b/apps/api/src/space-response-privacy.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  sanitizeRepoUrl,
+  sanitizeSpaceMeta,
+  stripSensitiveSpaceFields,
+} from "./space-response-privacy.js";
+
+test("space metadata strips repository credentials", () => {
+  assert.equal(
+    sanitizeRepoUrl("https://user:pass@example.com/repo.git"),
+    "https://example.com/repo.git",
+  );
+  const meta = sanitizeSpaceMeta({
+    bootstrap: {
+      source: { type: "git_repo", repoUrl: "https://user:pass@example.com/repo.git" },
+    },
+  });
+  assert.ok(meta);
+  assert.equal(
+    (meta.bootstrap as { source: { repoUrl: string } }).source.repoUrl,
+    "https://example.com/repo.git",
+  );
+});
+
+test("Work space responses keep meta but omit private fields", () => {
+  const response = stripSensitiveSpaceFields({
+    id: "space-1",
+    meta: {
+      publicProfile: { avatarUrl: "https://example.com/avatar.png" },
+      extraEnv: [{ key: "TOKEN", value: "secret" }],
+      config: { sandbox: { spec: "large" } },
+      privateNote: "owner-only",
+      bootstrap: {
+        status: "ready",
+        errorMessage: "private failure details",
+        source: { type: "git_repo", repoUrl: "https://user:pass@example.com/repo.git", ref: "main" },
+      },
+    },
+  });
+  assert.deepEqual(response.meta, {
+    publicProfile: { avatarUrl: "https://example.com/avatar.png" },
+    bootstrap: {
+      status: "ready",
+      source: { type: "git_repo", repoUrl: "https://example.com/repo.git", ref: "main" },
+    },
+  });
+  assert.equal("storageRepoName" in response, false);
+});

--- a/apps/api/src/space-response-privacy.ts
+++ b/apps/api/src/space-response-privacy.ts
@@ -1,0 +1,84 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sanitizePublicHttpUrl(value: unknown): string | null {
+  if (value === null) return null;
+  if (typeof value !== "string") return null;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" || parsed.protocol === "http:" ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+export function sanitizeRepoUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.username = "";
+    parsed.password = "";
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+/** Remove credentials from the bootstrap source while preserving public state. */
+export function sanitizeSpaceMeta(meta: unknown): Record<string, unknown> | null {
+  if (!isRecord(meta)) return null;
+
+  const bootstrap = isRecord(meta.bootstrap) ? meta.bootstrap : null;
+  const source = bootstrap && isRecord(bootstrap.source) ? bootstrap.source : null;
+  if (!source || typeof source.repoUrl !== "string") return { ...meta };
+
+  return {
+    ...meta,
+    bootstrap: {
+      ...bootstrap,
+      source: {
+        ...source,
+        repoUrl: sanitizeRepoUrl(source.repoUrl),
+      },
+    },
+  };
+}
+
+function sanitizeWorkMeta(meta: unknown): Record<string, unknown> | null {
+  const sanitized = sanitizeSpaceMeta(meta);
+  if (!sanitized) return null;
+
+  // Work account-list responses expose only state useful to a viewer. Keep
+  // the public profile and bootstrap progress, never arbitrary owner metadata.
+  const result: Record<string, unknown> = {};
+  if (isRecord(sanitized.publicProfile)) {
+    result.publicProfile = {
+      avatarUrl: sanitizePublicHttpUrl(sanitized.publicProfile.avatarUrl),
+    };
+  }
+  if (isRecord(sanitized.bootstrap)) {
+    const bootstrap = sanitized.bootstrap;
+    const safeBootstrap: Record<string, unknown> = {};
+    for (const key of ["status", "stage", "startedAt", "finishedAt"] as const) {
+      if (key in bootstrap) safeBootstrap[key] = bootstrap[key];
+    }
+    if (isRecord(bootstrap.source)) {
+      const source = bootstrap.source;
+      const safeSource: Record<string, unknown> = {};
+      for (const key of ["type", "ref", "checkpointId", "repoUrl"] as const) {
+        if (key in source) safeSource[key] = source[key];
+      }
+      if (Object.keys(safeSource).length > 0) safeBootstrap.source = safeSource;
+    }
+    if (Object.keys(safeBootstrap).length > 0) result.bootstrap = safeBootstrap;
+  }
+  return result;
+}
+
+export function stripSensitiveSpaceFields(item: Record<string, unknown>): Record<string, unknown> {
+  const { storageRepoName, sandboxStatus, access, meta, ...rest } = item;
+  void storageRepoName;
+  void sandboxStatus;
+  void access;
+  return { ...rest, meta: sanitizeWorkMeta(meta) };
+}

--- a/apps/api/src/space-sessions.ts
+++ b/apps/api/src/space-sessions.ts
@@ -410,7 +410,7 @@ export const attachSessionSpaceSummaries = async <T extends { spaceId: string }>
  */
 export const listUserSessions = async (
   userUuid: string,
-  options?: { limit?: number; cursor?: string | null },
+  options?: { limit?: number; cursor?: string | null; creatorOnly?: boolean },
 ) => {
   const limit = resolveSessionListLimit(options?.limit);
   const cursor = decodeSessionListCursor(options?.cursor);
@@ -420,6 +420,16 @@ export const listUserSessions = async (
   const creatorWhere = activityCursor
     ? and(eq(spaceSessions.userUuid, userUuid), activityCursor)
     : eq(spaceSessions.userUuid, userUuid);
+
+  if (options?.creatorOnly) {
+    const rows = await db
+      .select()
+      .from(spaceSessions)
+      .where(creatorWhere)
+      .orderBy(...sessionListOrderBy)
+      .limit(branchLimit);
+    return paginateSessionRows(rows, limit);
+  }
 
   const participantOnly = and(
     userSessionParticipantCondition(userUuid),

--- a/apps/api/src/task-run-privacy.test.ts
+++ b/apps/api/src/task-run-privacy.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { sanitizeTaskRunPricingForViewer } from "./task-run-privacy.js";
+
+const generationRun = {
+  taskType: "generation",
+  userUuid: "viewer-1",
+  payload: {
+    data: {
+      model: "image-model",
+      modelDiscount: { multiplier: 0.5 },
+    },
+  },
+  result: {
+    output: [],
+    billing: { amountUsd: 0.1 },
+  },
+};
+
+describe("task run pricing privacy", () => {
+  it("keeps pricing only for a real account owner", () => {
+    assert.equal(
+      sanitizeTaskRunPricingForViewer(generationRun, "viewer-1"),
+      generationRun,
+    );
+  });
+
+  it("strips pricing when a scoped principal represents the same UUID", () => {
+    const sanitized = sanitizeTaskRunPricingForViewer(generationRun, null);
+    assert.deepEqual(sanitized.payload, { data: { model: "image-model" } });
+    assert.deepEqual(sanitized.result, { output: [] });
+  });
+});

--- a/apps/api/src/user-profiles.public.test.ts
+++ b/apps/api/src/user-profiles.public.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { publicUserProfile, type UserProfile } from "./user-profiles.js";
+
+test("public user profiles omit internal identity and sync metadata", () => {
+  const internalProfile: UserProfile = {
+    userUuid: "viewer-1",
+    logtoUserId: "logto-internal-id",
+    username: "viewer",
+    displayName: "Viewer",
+    avatarUrl: "https://assets.example/avatar.webp",
+    syncedAt: "2026-07-30T00:00:00.000Z",
+  };
+  const profile = publicUserProfile(internalProfile);
+
+  assert.deepEqual(profile, {
+    userUuid: "viewer-1",
+    username: "viewer",
+    displayName: "Viewer",
+    avatarUrl: "https://assets.example/avatar.webp",
+  });
+  assert.equal("logtoUserId" in profile, false);
+  assert.equal("syncedAt" in profile, false);
+});

--- a/apps/api/src/user-profiles.ts
+++ b/apps/api/src/user-profiles.ts
@@ -24,6 +24,15 @@ export type UserProfile = PublicUserProfile & {
   syncedAt: string;
 };
 
+export const publicUserProfile = (
+  profile: Pick<UserProfile, "userUuid" | "username" | "displayName" | "avatarUrl">,
+): PublicUserProfile => ({
+  userUuid: profile.userUuid,
+  username: profile.username,
+  displayName: profile.displayName,
+  avatarUrl: profile.avatarUrl,
+});
+
 export class UsernameConflictError extends Error {
   override name = "UsernameConflictError";
 }

--- a/apps/api/src/work-session-policy.test.ts
+++ b/apps/api/src/work-session-policy.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resolveActiveWorkSessionPolicy } from "./work-session-policy.js";
+
+const token = {
+  spaceId: "space-1",
+  workScopes: ["space.view", "file.view"],
+  viewerScopes: ["generation.create", "user.session.list"],
+};
+
+describe("resolveActiveWorkSessionPolicy", () => {
+  it("intersects token scopes with the current published Work policy", () => {
+    assert.deepEqual(resolveActiveWorkSessionPolicy(token, {
+      status: "published",
+      spaceId: "space-1",
+      workScopes: ["space.view"],
+      allowedViewerScopes: ["generation.create"],
+    }), {
+      workScopes: ["space.view"],
+      allowedViewerScopes: ["generation.create"],
+    });
+  });
+
+  it("invalidates tokens for disabled, deleted, or differently bound Works", () => {
+    assert.equal(resolveActiveWorkSessionPolicy(token, null), null);
+    assert.equal(resolveActiveWorkSessionPolicy(token, {
+      status: "disabled",
+      spaceId: "space-1",
+      workScopes: ["space.view"],
+      allowedViewerScopes: ["generation.create"],
+    }), null);
+    assert.equal(resolveActiveWorkSessionPolicy(token, {
+      status: "published",
+      spaceId: "space-2",
+      workScopes: ["space.view"],
+      allowedViewerScopes: ["generation.create"],
+    }), null);
+  });
+});

--- a/apps/api/src/work-session-policy.ts
+++ b/apps/api/src/work-session-policy.ts
@@ -1,0 +1,4 @@
+export {
+  resolveActiveWorkSessionPolicy,
+  type ActiveWorkSessionPolicy,
+} from "@cohub/core/permissions";

--- a/apps/gateway/src/api-client.ts
+++ b/apps/gateway/src/api-client.ts
@@ -16,6 +16,7 @@ export type RealtimeAuthResult =
       ok: true;
       user: GatewayAuthUser & { uuid: string };
       principalType: "user" | "work_session";
+      tokenExpiresAt: number | null;
     }
   | {
       ok: false;
@@ -50,6 +51,7 @@ export const authenticateRealtimeToken = async (input: { token: string }): Promi
       ok: true,
       user,
       principalType: "user",
+      tokenExpiresAt: typeof user.tokenExpiresAt === "number" ? user.tokenExpiresAt : null,
     };
   } catch (error) {
     const status = error instanceof AuthorizationError ? error.status : 401;
@@ -84,6 +86,7 @@ export const authenticateRealtimeToken = async (input: { token: string }): Promi
   const data = await parseJson<{
     uuid?: string;
     principalType?: "user" | "work_session";
+    tokenExpiresAt?: number | null;
     profile?: { displayName?: string | null; avatarUrl?: string | null };
   }>(response);
   if (!data?.uuid || (data.principalType !== "user" && data.principalType !== "work_session")) {
@@ -104,6 +107,7 @@ export const authenticateRealtimeToken = async (input: { token: string }): Promi
       avatar_url: data.profile?.avatarUrl ?? undefined,
     },
     principalType: data.principalType,
+    tokenExpiresAt: typeof data.tokenExpiresAt === "number" ? data.tokenExpiresAt : null,
   };
 };
 
@@ -216,6 +220,7 @@ export const submitInternalSessionPrompt = async (input: {
   sessionId: string;
   userId: string;
   authToken?: string | null;
+  principalType: "user" | "work_session";
   clientMessageId: string;
   content: ContentBlock[];
   source: string;
@@ -236,6 +241,7 @@ export const submitInternalSessionPrompt = async (input: {
       content: input.content,
       userId: input.userId,
       authToken: input.authToken ?? null,
+      principalType: input.principalType,
       clientMessageId: input.clientMessageId,
       source: input.source,
       model: input.model ?? null,

--- a/apps/gateway/src/api-client.ts
+++ b/apps/gateway/src/api-client.ts
@@ -7,6 +7,13 @@ import type { BillingPayload } from "@cohub/protocol";
 import type { GatewayAuthUser } from "./config.js";
 import { gatewayConfig } from "./config.js";
 
+const GATEWAY_API_REQUEST_TIMEOUT_MS = 10_000;
+
+const fetchGatewayApi = (input: string | URL, init?: RequestInit) => fetch(input, {
+  ...init,
+  signal: init?.signal ?? AbortSignal.timeout(GATEWAY_API_REQUEST_TIMEOUT_MS),
+});
+
 const parseJson = async <T>(response: Response): Promise<T | null> => {
   return response.json().catch(() => null) as Promise<T | null>;
 };
@@ -67,7 +74,7 @@ export const authenticateRealtimeToken = async (input: { token: string }): Promi
     }
   }
 
-  const response = await fetch(`${gatewayConfig.apiBaseUrl}/api/me`, {
+  const response = await fetchGatewayApi(`${gatewayConfig.apiBaseUrl}/api/me`, {
     headers: {
       authorization: `Bearer ${input.token}`,
       ...buildTraceHeaders(),
@@ -112,7 +119,7 @@ export const authenticateRealtimeToken = async (input: { token: string }): Promi
 };
 
 export const requestGatewayChannelReconcile = async (): Promise<{ stats: unknown }> => {
-  const response = await fetch(`${gatewayConfig.apiBaseUrl}/internal/gateway/reconcile-channels`, {
+  const response = await fetchGatewayApi(`${gatewayConfig.apiBaseUrl}/internal/gateway/reconcile-channels`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -130,7 +137,7 @@ export const requestGatewayChannelReconcile = async (): Promise<{ stats: unknown
 };
 
 export const notifySpacePresenceUpdated = async (spaceId: string): Promise<void> => {
-  const response = await fetch(`${gatewayConfig.apiBaseUrl}/internal/gateway/space-presence-updated`, {
+  const response = await fetchGatewayApi(`${gatewayConfig.apiBaseUrl}/internal/gateway/space-presence-updated`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -151,7 +158,7 @@ export const authorizeBoardAwareness = async (input: {
   spaceId: string;
   permission: "view" | "edit";
 }): Promise<boolean> => {
-  const response = await fetch(`${gatewayConfig.apiBaseUrl}/internal/gateway/authorize-board-awareness`, {
+  const response = await fetchGatewayApi(`${gatewayConfig.apiBaseUrl}/internal/gateway/authorize-board-awareness`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -172,7 +179,7 @@ export const authorizeRealtimeRooms = async (input: {
   authToken: string;
   rooms: string[];
 }): Promise<{ rooms: RealtimeRoom[]; rejected: Array<{ room: string; code: "BAD_ROOM" | "FORBIDDEN"; message: string }> }> => {
-  const response = await fetch(`${gatewayConfig.apiBaseUrl}/internal/gateway/authorize-realtime-rooms`, {
+  const response = await fetchGatewayApi(`${gatewayConfig.apiBaseUrl}/internal/gateway/authorize-realtime-rooms`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -230,11 +237,12 @@ export const submitInternalSessionPrompt = async (input: {
   context?: Record<string, unknown> | null;
 }): Promise<{ ok: true; turnId: string; userMessageId: string; trace: TraceIdentifiers }> => {
   const requestId = typeof input.context?.requestId === "string" ? input.context.requestId : null;
-  const response = await fetch(`${gatewayConfig.apiBaseUrl}/internal/spaces/${input.spaceId}/sessions/${input.sessionId}/prompt`, {
+  const response = await fetchGatewayApi(`${gatewayConfig.apiBaseUrl}/internal/spaces/${input.spaceId}/sessions/${input.sessionId}/prompt`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "x-worker-secret": gatewayConfig.workerSecret,
+      ...(input.authToken ? { authorization: `Bearer ${input.authToken}` } : {}),
       ...buildTraceHeaders({ requestId }),
     },
     body: JSON.stringify({
@@ -271,7 +279,7 @@ export const authorizeSessionAccess = async (input: {
   spaceId: string;
   sessionId: string;
 }): Promise<SessionAuthorizationResult> => {
-  const sessionResponse = await fetch(`${gatewayConfig.apiBaseUrl}/api/sessions/${input.sessionId}`, {
+  const sessionResponse = await fetchGatewayApi(`${gatewayConfig.apiBaseUrl}/api/sessions/${input.sessionId}`, {
     headers: {
       authorization: `Bearer ${input.token}`,
       ...buildTraceHeaders(),
@@ -363,7 +371,7 @@ export const authorizeLocalSandbox = async (input: {
   authToken: string;
   spaceId: string;
 }): Promise<LocalSandboxAuthorizeResult> => {
-  const response = await fetch(`${gatewayConfig.apiBaseUrl}/internal/gateway/local-sandbox/authorize`, {
+  const response = await fetchGatewayApi(`${gatewayConfig.apiBaseUrl}/internal/gateway/local-sandbox/authorize`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -389,7 +397,7 @@ export const reportLocalSandboxStatus = async (input: {
   hostname?: string | null;
   gatewayNodeId?: string | null;
 }): Promise<void> => {
-  const response = await fetch(`${gatewayConfig.apiBaseUrl}/internal/gateway/local-sandbox/status`, {
+  const response = await fetchGatewayApi(`${gatewayConfig.apiBaseUrl}/internal/gateway/local-sandbox/status`, {
     method: "POST",
     headers: {
       "content-type": "application/json",

--- a/apps/gateway/src/api-client.ts
+++ b/apps/gateway/src/api-client.ts
@@ -15,6 +15,7 @@ export type RealtimeAuthResult =
   | {
       ok: true;
       user: GatewayAuthUser & { uuid: string };
+      principalType: "user" | "work_session";
     }
   | {
       ok: false;
@@ -48,6 +49,7 @@ export const authenticateRealtimeToken = async (input: { token: string }): Promi
     return {
       ok: true,
       user,
+      principalType: "user",
     };
   } catch (error) {
     const status = error instanceof AuthorizationError ? error.status : 401;
@@ -79,8 +81,12 @@ export const authenticateRealtimeToken = async (input: { token: string }): Promi
       },
     };
   }
-  const data = await parseJson<{ uuid?: string; profile?: { displayName?: string | null; avatarUrl?: string | null } }>(response);
-  if (!data?.uuid) {
+  const data = await parseJson<{
+    uuid?: string;
+    principalType?: "user" | "work_session";
+    profile?: { displayName?: string | null; avatarUrl?: string | null };
+  }>(response);
+  if (!data?.uuid || (data.principalType !== "user" && data.principalType !== "work_session")) {
     return {
       ok: false,
       status: 401,
@@ -97,6 +103,7 @@ export const authenticateRealtimeToken = async (input: { token: string }): Promi
       nick_name: data.profile?.displayName ?? undefined,
       avatar_url: data.profile?.avatarUrl ?? undefined,
     },
+    principalType: data.principalType,
   };
 };
 

--- a/apps/gateway/src/connection-state-queue.test.ts
+++ b/apps/gateway/src/connection-state-queue.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  ConnectionStateQueueOverflowError,
+  enqueueConnectionState,
+} from "./connection-state-queue.js";
+
+test("connection state operations run in arrival order", async () => {
+  const queue = { stateTail: Promise.resolve(), pendingStateOperations: 0 };
+  const events: string[] = [];
+  let releaseFirst: () => void = () => undefined;
+  const firstGate = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+
+  const first = enqueueConnectionState(queue, async () => {
+    events.push("first:start");
+    await firstGate;
+    events.push("first:end");
+  });
+  const second = enqueueConnectionState(queue, async () => {
+    events.push("second");
+  });
+
+  await Promise.resolve();
+  assert.deepEqual(events, ["first:start"]);
+  releaseFirst();
+  await Promise.all([first, second]);
+  assert.deepEqual(events, ["first:start", "first:end", "second"]);
+});
+
+test("a failed state operation does not poison the connection queue", async () => {
+  const queue = { stateTail: Promise.resolve(), pendingStateOperations: 0 };
+  const failed = enqueueConnectionState(queue, async () => {
+    throw new Error("authentication failed");
+  });
+  const recovered = enqueueConnectionState(queue, async () => "subscribed");
+
+  await assert.rejects(failed, /authentication failed/);
+  assert.equal(await recovered, "subscribed");
+});
+
+test("connection state queues reject excess work without retaining it", async () => {
+  const queue = { stateTail: Promise.resolve(), pendingStateOperations: 0 };
+  let release: () => void = () => undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  const first = enqueueConnectionState(queue, () => gate, { maxPending: 2 });
+  const second = enqueueConnectionState(queue, async () => undefined, { maxPending: 2 });
+  await assert.rejects(
+    enqueueConnectionState(queue, async () => undefined, { maxPending: 2 }),
+    ConnectionStateQueueOverflowError,
+  );
+  assert.equal(queue.pendingStateOperations, 2);
+
+  release();
+  await Promise.all([first, second]);
+  assert.equal(queue.pendingStateOperations, 0);
+});

--- a/apps/gateway/src/connection-state-queue.ts
+++ b/apps/gateway/src/connection-state-queue.ts
@@ -1,0 +1,28 @@
+export type ConnectionStateQueue = {
+  stateTail: Promise<void>;
+  pendingStateOperations: number;
+};
+
+export const MAX_PENDING_CONNECTION_STATE_OPERATIONS = 64;
+
+export class ConnectionStateQueueOverflowError extends Error {
+  override name = "ConnectionStateQueueOverflowError";
+}
+
+export function enqueueConnectionState<T>(
+  queue: ConnectionStateQueue,
+  operation: () => Promise<T>,
+  options: { allowWhenFull?: boolean; maxPending?: number } = {},
+): Promise<T> {
+  const maxPending = options.maxPending ?? MAX_PENDING_CONNECTION_STATE_OPERATIONS;
+  if (!options.allowWhenFull && queue.pendingStateOperations >= maxPending) {
+    return Promise.reject(new ConnectionStateQueueOverflowError("connection state queue is full"));
+  }
+  queue.pendingStateOperations += 1;
+  const run = queue.stateTail.then(operation);
+  const settled = run.finally(() => {
+    queue.pendingStateOperations -= 1;
+  });
+  queue.stateTail = settled.then(() => undefined, () => undefined);
+  return settled;
+}

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -572,11 +572,23 @@ const authorizeRoomsForConnection = async (
   return { rooms: accepted, rejected };
 };
 
+const WS_CONNECTION_SWEEP_CONCURRENCY = 16;
+
 const startWsConnectionSweeper = () => {
-  setInterval(async () => {
+  let sweepInFlight = false;
+  const sweep = async () => {
+    if (sweepInFlight) return;
+    sweepInFlight = true;
     const now = Date.now();
-    for (const [connectionId, ctx] of wsConnections.entries()) {
-      await enqueueConnectionState(ctx, async () => {
+    const connections = [...wsConnections.entries()];
+    let nextConnection = 0;
+    const sweepConnection = async () => {
+      while (nextConnection < connections.length) {
+        const connection = connections[nextConnection];
+        nextConnection += 1;
+        if (!connection) return;
+        const [connectionId, ctx] = connection;
+        await enqueueConnectionState(ctx, async () => {
         if (ctx.closing) return;
         if (isRealtimeAuthExpired(ctx.authExpiresAtMs, now)) {
           const socket = wsSockets.get(connectionId);
@@ -617,9 +629,22 @@ const startWsConnectionSweeper = () => {
           socket.close(4001, `expired:${now}`);
         }
         await cleanupWsConnection(ctx);
-      }, { allowWhenFull: true });
+        }).catch((error) => {
+          if (error instanceof ConnectionStateQueueOverflowError) return;
+          logger.warn("[Gateway] failed to sweep realtime connection", { connectionId, error });
+        });
+      }
     }
-  }, 30_000);
+    try {
+      await Promise.all(Array.from(
+        { length: Math.min(WS_CONNECTION_SWEEP_CONCURRENCY, connections.length) },
+        sweepConnection,
+      ));
+    } finally {
+      sweepInFlight = false;
+    }
+  };
+  setInterval(() => void sweep(), 30_000);
 };
 
 const resolveRealtimeRoomsForEnvelope = (payload: GatewayWsBroadcastPayload): RealtimeRoom[] => {

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -923,7 +923,9 @@ async function main() {
               ? message.payload.capabilities.filter((value) => typeof value === "string" && value.trim())
               : [],
           );
-          subscribeConnectionToRoom(ctx, getRealtimeUserRoom(result.user.uuid));
+          if (result.principalType === "user") {
+            subscribeConnectionToRoom(ctx, getRealtimeUserRoom(result.user.uuid));
+          }
           await persistWsConnection(ctx);
           sendWsEnvelope(socket, buildRealtimeEnvelope({
             domain: "system",

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -22,6 +22,7 @@ import type {
 import type { PlannedGatewayOutboundCommand } from "@cohub/protocol/gateway";
 import {
   getRealtimeBoardRoom,
+  getRealtimeSessionRoom,
   getRealtimeSpaceRoom,
   getRealtimeUserRoom,
   getSessionTurnPatchStreamKey,
@@ -47,6 +48,10 @@ import { markChannelDegraded, touchChannelOutbound } from "./channel-health.js";
 import { handleAsrWebSocketConnection } from "./asr/session.js";
 import { handleRelayControlConnection, handleRelayDataConnection, handleRelayPeerConnection } from "./relay/index.js";
 import {
+  isRealtimeAuthExpired,
+  realtimeConnectionTtlSeconds,
+} from "./realtime-auth-lifetime.js";
+import {
   createPubSubRedisClient,
   redisCommandClient,
   REALTIME_OUTBOUND_CHANNEL,
@@ -60,6 +65,9 @@ type WsConnectionContext = {
   userName?: string;
   userAvatarUrl?: string;
   token?: string;
+  principalType?: "user" | "work_session";
+  authExpiresAtMs?: number;
+  lastRoomAuthorizationAt: number;
   capabilities: Set<string>;
   rooms: Set<RealtimeRoom>;
   presenceMetaBySpace: Map<string, Record<string, unknown> | null>;
@@ -207,6 +215,11 @@ const unsubscribeConnectionFromAllRooms = (ctx: WsConnectionContext) => {
 };
 
 const persistWsConnection = async (ctx: WsConnectionContext) => {
+  const ttlSeconds = realtimeConnectionTtlSeconds(
+    ctx.authExpiresAtMs,
+    WS_CONNECTION_TTL_SECONDS,
+  );
+  if (ttlSeconds <= 0) return;
   await redisCommandClient.set(getWsConnectionKey(ctx.connectionId), JSON.stringify({
     connectionId: ctx.connectionId,
     userId: ctx.userId ?? null,
@@ -214,9 +227,10 @@ const persistWsConnection = async (ctx: WsConnectionContext) => {
     userAvatarUrl: ctx.userAvatarUrl ?? null,
     capabilities: [...ctx.capabilities],
     rooms: [...ctx.rooms],
+    authExpiresAtMs: ctx.authExpiresAtMs ?? null,
     connectedAt: Date.now(),
     nodeId: process.env.POD_NAME || process.env.HOSTNAME || "unknown",
-  }), "EX", WS_CONNECTION_TTL_SECONDS);
+  }), "EX", ttlSeconds);
 };
 
 const cleanupWsConnection = async (ctx: WsConnectionContext | undefined) => {
@@ -447,7 +461,12 @@ const parseWsJson = (value: string): WsClientEvent => {
 };
 
 const touchWsConnection = async (ctx: WsConnectionContext) => {
-  await redisCommandClient.expire(getWsConnectionKey(ctx.connectionId), WS_CONNECTION_TTL_SECONDS).catch(() => undefined);
+  const ttlSeconds = realtimeConnectionTtlSeconds(
+    ctx.authExpiresAtMs,
+    WS_CONNECTION_TTL_SECONDS,
+  );
+  if (ttlSeconds <= 0) return;
+  await redisCommandClient.expire(getWsConnectionKey(ctx.connectionId), ttlSeconds).catch(() => undefined);
   const spaceIds = [...ctx.rooms]
     .map(getSpaceIdFromRoom)
     .filter((spaceId): spaceId is string => Boolean(spaceId));
@@ -491,7 +510,11 @@ const setCachedRoomAuth = (authToken: string, room: RealtimeRoom, value: { accep
   });
 };
 
-const authorizeRoomsForConnection = async (ctx: WsConnectionContext, rooms: RealtimeRoom[]) => {
+const authorizeRoomsForConnection = async (
+  ctx: WsConnectionContext,
+  rooms: RealtimeRoom[],
+  bypassCache = false,
+) => {
   if (!ctx.token) throw new Error("authentication required");
 
   const accepted: RealtimeRoom[] = [];
@@ -499,7 +522,7 @@ const authorizeRoomsForConnection = async (ctx: WsConnectionContext, rooms: Real
   const misses: RealtimeRoom[] = [];
 
   for (const room of rooms) {
-    const cached = getCachedRoomAuth(ctx.token, room);
+    const cached = bypassCache ? null : getCachedRoomAuth(ctx.token, room);
     if (!cached) {
       misses.push(room);
       continue;
@@ -526,6 +549,36 @@ const startWsConnectionSweeper = () => {
   setInterval(async () => {
     const now = Date.now();
     for (const [connectionId, ctx] of wsConnections.entries()) {
+      if (isRealtimeAuthExpired(ctx.authExpiresAtMs, now)) {
+        const socket = wsSockets.get(connectionId);
+        if (socket && socket.readyState === socket.OPEN) {
+          socket.close(4003, "authentication expired");
+        }
+        await cleanupWsConnection(ctx);
+        continue;
+      }
+      if (
+        ctx.token
+        && ctx.rooms.size > 0
+        && now - ctx.lastRoomAuthorizationAt >= ROOM_AUTH_CACHE_TTL_MS
+      ) {
+        const currentRooms = [...ctx.rooms];
+        const roomAuth = await authorizeRoomsForConnection(ctx, currentRooms, true).catch((error) => {
+          logger.warn("[Gateway] failed to reauthorize realtime rooms", {
+            connectionId,
+            error,
+          });
+          return null;
+        });
+        if (roomAuth) {
+          const accepted = new Set(roomAuth.rooms);
+          for (const room of currentRooms) {
+            if (!accepted.has(room)) unsubscribeConnectionFromRoom(ctx, room);
+          }
+          ctx.lastRoomAuthorizationAt = now;
+          await persistWsConnection(ctx);
+        }
+      }
       const raw = await redisCommandClient.get(getWsConnectionKey(connectionId)).catch(() => null);
       if (raw) continue;
       const socket = wsSockets.get(connectionId);
@@ -542,9 +595,14 @@ const resolveRealtimeRoomsForEnvelope = (payload: GatewayWsBroadcastPayload): Re
   const explicitRooms = normalizeRealtimeRooms(Array.isArray(payload.rooms) ? payload.rooms : []);
   if (explicitRooms.length > 0) return explicitRooms;
 
+  const resourceRooms: RealtimeRoom[] = [];
   if (typeof payload.spaceId === "string" && payload.spaceId.trim()) {
-    return [getRealtimeSpaceRoom(payload.spaceId.trim())];
+    resourceRooms.push(getRealtimeSpaceRoom(payload.spaceId.trim()));
   }
+  if (typeof payload.sessionId === "string" && payload.sessionId.trim()) {
+    resourceRooms.push(getRealtimeSessionRoom(payload.sessionId.trim()));
+  }
+  if (resourceRooms.length > 0) return resourceRooms;
 
   const task = payloadRecord.task;
   if (task && typeof task === "object") {
@@ -567,10 +625,16 @@ async function fanOutBroadcastToLocalSockets(payload: GatewayWsBroadcastPayload)
 
   const deliverConnection = (connectionId: string) => {
     if (deliveredConnectionIds.has(connectionId)) return;
+    const ctx = wsConnections.get(connectionId);
     const socket = wsSockets.get(connectionId);
     if (!socket) return;
+    if (isRealtimeAuthExpired(ctx?.authExpiresAtMs)) {
+      if (socket.readyState === socket.OPEN) socket.close(4003, "authentication expired");
+      void cleanupWsConnection(ctx);
+      return;
+    }
     deliveredConnectionIds.add(connectionId);
-    sendWsRealtime(socket, wsConnections.get(connectionId), envelope);
+    sendWsRealtime(socket, ctx, envelope);
   };
 
   for (const room of resolveRealtimeRoomsForEnvelope(payload)) {
@@ -628,6 +692,7 @@ const submitWebsocketSessionMessage = async (ctx: WsConnectionContext, requestId
   }
 
   if (!ctx.userId) throw new WsClientInputError("authentication required");
+  if (!ctx.principalType) throw new WsClientInputError("authentication required");
   if (!spaceId || !sessionId) throw new WsClientInputError("spaceId and sessionId are required");
   if (content.length === 0) throw new WsClientInputError("content is required");
 
@@ -637,6 +702,7 @@ const submitWebsocketSessionMessage = async (ctx: WsConnectionContext, requestId
     sessionId,
     userId: ctx.userId,
     authToken: ctx.token,
+    principalType: ctx.principalType,
     clientMessageId,
     content,
     source: "websocket",
@@ -852,6 +918,8 @@ async function main() {
     const connectionId = randomUUID();
     const ctx: WsConnectionContext = {
       connectionId,
+      authExpiresAtMs: undefined,
+      lastRoomAuthorizationAt: 0,
       capabilities: new Set(),
       rooms: new Set(),
       presenceMetaBySpace: new Map(),
@@ -888,6 +956,12 @@ async function main() {
         const message = parseWsJson(raw);
         requestId = typeof message.requestId === "string" ? message.requestId : undefined;
 
+        if (ctx.token && isRealtimeAuthExpired(ctx.authExpiresAtMs)) {
+          socket.close(4003, "authentication expired");
+          await cleanupWsConnection(ctx);
+          return;
+        }
+
         if (message.type === "ping") {
           await touchWsConnection(ctx);
           sendWsEnvelope(socket, buildRealtimeEnvelope({
@@ -918,6 +992,11 @@ async function main() {
           ctx.userName = typeof result.user.nick_name === "string" ? result.user.nick_name : undefined;
           ctx.userAvatarUrl = typeof result.user.avatar_url === "string" ? result.user.avatar_url : undefined;
           ctx.token = token;
+          ctx.principalType = result.principalType;
+          ctx.authExpiresAtMs = result.tokenExpiresAt === null
+            ? undefined
+            : result.tokenExpiresAt * 1000;
+          ctx.lastRoomAuthorizationAt = Date.now();
           ctx.capabilities = new Set(
             Array.isArray(message.payload.capabilities)
               ? message.payload.capabilities.filter((value) => typeof value === "string" && value.trim())

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -51,6 +51,11 @@ import {
   isRealtimeAuthExpired,
   realtimeConnectionTtlSeconds,
 } from "./realtime-auth-lifetime.js";
+import { hasRealtimeRoomCapacity } from "./realtime-room-admission.js";
+import {
+  ConnectionStateQueueOverflowError,
+  enqueueConnectionState,
+} from "./connection-state-queue.js";
 import {
   createPubSubRedisClient,
   redisCommandClient,
@@ -77,6 +82,9 @@ type WsConnectionContext = {
   boardAwarenessRate: BoardAwarenessRate;
   boardAwarenessPending: number;
   boardAwarenessTail: Promise<void>;
+  stateTail: Promise<void>;
+  pendingStateOperations: number;
+  closing: boolean;
 };
 
 type GatewayWsBroadcastPayload = RealtimeServerEvent & {
@@ -235,10 +243,29 @@ const persistWsConnection = async (ctx: WsConnectionContext) => {
 
 const cleanupWsConnection = async (ctx: WsConnectionContext | undefined) => {
   if (!ctx) return;
+  ctx.closing = true;
   unsubscribeConnectionFromAllRooms(ctx);
   wsSockets.delete(ctx.connectionId);
-  wsConnections.delete(ctx.connectionId);
+  if (wsConnections.get(ctx.connectionId) === ctx) wsConnections.delete(ctx.connectionId);
   await redisCommandClient.del(getWsConnectionKey(ctx.connectionId)).catch(() => undefined);
+};
+
+const closeWsConnection = (
+  ctx: WsConnectionContext,
+  socket: WebSocket,
+  code: number,
+  reason: string,
+) => {
+  if (ctx.closing) return;
+  ctx.closing = true;
+  if (socket.readyState === socket.OPEN || socket.readyState === socket.CONNECTING) {
+    socket.close(code, reason);
+  }
+  void enqueueConnectionState(
+    ctx,
+    () => cleanupWsConnection(ctx),
+    { allowWhenFull: true },
+  ).catch((error) => logger.warn("[Gateway] failed to cleanup closed WebSocket", { connectionId: ctx.connectionId, error }));
 };
 
 const sendWsEnvelope = (socket: WebSocket, envelope: RealtimeEnvelope) => {
@@ -549,43 +576,48 @@ const startWsConnectionSweeper = () => {
   setInterval(async () => {
     const now = Date.now();
     for (const [connectionId, ctx] of wsConnections.entries()) {
-      if (isRealtimeAuthExpired(ctx.authExpiresAtMs, now)) {
+      await enqueueConnectionState(ctx, async () => {
+        if (ctx.closing) return;
+        if (isRealtimeAuthExpired(ctx.authExpiresAtMs, now)) {
+          const socket = wsSockets.get(connectionId);
+          if (socket && socket.readyState === socket.OPEN) {
+            socket.close(4003, "authentication expired");
+          }
+          ctx.closing = true;
+          await cleanupWsConnection(ctx);
+          return;
+        }
+        if (
+          ctx.token
+          && ctx.rooms.size > 0
+          && now - ctx.lastRoomAuthorizationAt >= ROOM_AUTH_CACHE_TTL_MS
+        ) {
+          const currentRooms = [...ctx.rooms];
+          const roomAuth = await authorizeRoomsForConnection(ctx, currentRooms, true).catch((error) => {
+            logger.warn("[Gateway] failed to reauthorize realtime rooms", {
+              connectionId,
+              error,
+            });
+            return null;
+          });
+          if (ctx.closing) return;
+          if (roomAuth) {
+            const accepted = new Set(roomAuth.rooms);
+            for (const room of currentRooms) {
+              if (!accepted.has(room)) unsubscribeConnectionFromRoom(ctx, room);
+            }
+            ctx.lastRoomAuthorizationAt = now;
+            await persistWsConnection(ctx);
+          }
+        }
+        const raw = await redisCommandClient.get(getWsConnectionKey(connectionId)).catch(() => null);
+        if (raw) return;
         const socket = wsSockets.get(connectionId);
         if (socket && socket.readyState === socket.OPEN) {
-          socket.close(4003, "authentication expired");
+          socket.close(4001, `expired:${now}`);
         }
         await cleanupWsConnection(ctx);
-        continue;
-      }
-      if (
-        ctx.token
-        && ctx.rooms.size > 0
-        && now - ctx.lastRoomAuthorizationAt >= ROOM_AUTH_CACHE_TTL_MS
-      ) {
-        const currentRooms = [...ctx.rooms];
-        const roomAuth = await authorizeRoomsForConnection(ctx, currentRooms, true).catch((error) => {
-          logger.warn("[Gateway] failed to reauthorize realtime rooms", {
-            connectionId,
-            error,
-          });
-          return null;
-        });
-        if (roomAuth) {
-          const accepted = new Set(roomAuth.rooms);
-          for (const room of currentRooms) {
-            if (!accepted.has(room)) unsubscribeConnectionFromRoom(ctx, room);
-          }
-          ctx.lastRoomAuthorizationAt = now;
-          await persistWsConnection(ctx);
-        }
-      }
-      const raw = await redisCommandClient.get(getWsConnectionKey(connectionId)).catch(() => null);
-      if (raw) continue;
-      const socket = wsSockets.get(connectionId);
-      if (socket && socket.readyState === socket.OPEN) {
-        socket.close(4001, `expired:${now}`);
-      }
-      await cleanupWsConnection(ctx);
+      }, { allowWhenFull: true });
     }
   }, 30_000);
 };
@@ -595,14 +627,12 @@ const resolveRealtimeRoomsForEnvelope = (payload: GatewayWsBroadcastPayload): Re
   const explicitRooms = normalizeRealtimeRooms(Array.isArray(payload.rooms) ? payload.rooms : []);
   if (explicitRooms.length > 0) return explicitRooms;
 
-  const resourceRooms: RealtimeRoom[] = [];
-  if (typeof payload.spaceId === "string" && payload.spaceId.trim()) {
-    resourceRooms.push(getRealtimeSpaceRoom(payload.spaceId.trim()));
-  }
   if (typeof payload.sessionId === "string" && payload.sessionId.trim()) {
-    resourceRooms.push(getRealtimeSessionRoom(payload.sessionId.trim()));
+    return [getRealtimeSessionRoom(payload.sessionId.trim())];
   }
-  if (resourceRooms.length > 0) return resourceRooms;
+  if (typeof payload.spaceId === "string" && payload.spaceId.trim()) {
+    return [getRealtimeSpaceRoom(payload.spaceId.trim())];
+  }
 
   const task = payloadRecord.task;
   if (task && typeof task === "object") {
@@ -627,10 +657,9 @@ async function fanOutBroadcastToLocalSockets(payload: GatewayWsBroadcastPayload)
     if (deliveredConnectionIds.has(connectionId)) return;
     const ctx = wsConnections.get(connectionId);
     const socket = wsSockets.get(connectionId);
-    if (!socket) return;
+    if (!ctx || !socket || ctx.closing) return;
     if (isRealtimeAuthExpired(ctx?.authExpiresAtMs)) {
-      if (socket.readyState === socket.OPEN) socket.close(4003, "authentication expired");
-      void cleanupWsConnection(ctx);
+      closeWsConnection(ctx, socket, 4003, "authentication expired");
       return;
     }
     deliveredConnectionIds.add(connectionId);
@@ -864,7 +893,7 @@ async function main() {
   });
 
   const server = serve({ fetch: app.fetch, port: gatewayConfig.port }) as unknown as import("node:http").Server;
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({ noServer: true, maxPayload: WS_MAX_MESSAGE_BYTES });
   const asrWss = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 });
   // Local sandbox relay: control (runner⇒gateway), data (runner dial-out), and
   // peer (agent/worker⇒gateway) channels. Large payloads flow on data channels.
@@ -929,6 +958,9 @@ async function main() {
       boardAwarenessRate: { startedAt: Date.now(), count: 0 },
       boardAwarenessPending: 0,
       boardAwarenessTail: Promise.resolve(),
+      stateTail: Promise.resolve(),
+      pendingStateOperations: 0,
+      closing: false,
     };
     wsConnections.set(connectionId, ctx);
     wsSockets.set(connectionId, socket);
@@ -938,7 +970,21 @@ async function main() {
       payload: { connectionId },
     }));
 
-    socket.on("message", async (data: RawData) => {
+    socket.on("message", (data: RawData) => {
+      const rawSize = typeof data === "string"
+        ? Buffer.byteLength(data, "utf-8")
+        : Buffer.isBuffer(data)
+          ? data.byteLength
+          : Array.isArray(data)
+            ? data.reduce((total, chunk) => total + (Buffer.isBuffer(chunk) ? chunk.byteLength : Buffer.byteLength(String(chunk))), 0)
+            : data.byteLength;
+      if (rawSize > WS_MAX_MESSAGE_BYTES) {
+        sendWsError(socket, "MESSAGE_TOO_LARGE", "message too large");
+        closeWsConnection(ctx, socket, 1009, "message too large");
+        return;
+      }
+      const queued = enqueueConnectionState(ctx, async () => {
+      if (ctx.closing) return;
       let requestId: string | undefined;
       try {
         const raw = typeof data === "string"
@@ -948,16 +994,11 @@ async function main() {
             : Array.isArray(data)
               ? Buffer.concat(data.map((chunk) => Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))).toString("utf-8")
               : Buffer.from(data).toString("utf-8");
-        if (Buffer.byteLength(raw, "utf-8") > WS_MAX_MESSAGE_BYTES) {
-          sendWsError(socket, "MESSAGE_TOO_LARGE", "message too large");
-          return;
-        }
-
         const message = parseWsJson(raw);
         requestId = typeof message.requestId === "string" ? message.requestId : undefined;
 
         if (ctx.token && isRealtimeAuthExpired(ctx.authExpiresAtMs)) {
-          socket.close(4003, "authentication expired");
+          closeWsConnection(ctx, socket, 4003, "authentication expired");
           await cleanupWsConnection(ctx);
           return;
         }
@@ -980,6 +1021,7 @@ async function main() {
             return;
           }
           const result: RealtimeAuthResult = await authenticateRealtimeToken({ token });
+          if (ctx.closing) return;
           if (!result.ok) {
             sendWsError(socket, "UNAUTHORIZED", result.error.message, requestId);
             return;
@@ -1028,8 +1070,26 @@ async function main() {
             sendWsError(socket, "BAD_REQUEST", "rooms are required", requestId);
             return;
           }
+          if (!hasRealtimeRoomCapacity(ctx.rooms, rooms)) {
+            sendWsEnvelope(socket, buildRealtimeEnvelope({
+              domain: "system",
+              type: "system.subscribe.error",
+              requestId: requestId ?? null,
+              payload: {
+                rejected: rooms
+                  .filter((room) => !ctx.rooms.has(room))
+                  .map((room) => ({
+                    room,
+                    code: "ROOM_LIMIT",
+                    message: "Realtime room limit exceeded",
+                  })),
+              },
+            }));
+            return;
+          }
           try {
             const result = await authorizeRoomsForConnection(ctx, rooms);
+            if (ctx.closing) return;
             for (const room of result.rooms) subscribeConnectionToRoom(ctx, room);
             await persistWsConnection(ctx);
             sendWsEnvelope(socket, buildRealtimeEnvelope({
@@ -1087,6 +1147,10 @@ async function main() {
           const spaceId = typeof message.payload.spaceId === "string" ? message.payload.spaceId : "";
           const room = getRealtimeSpaceRoom(spaceId);
           if (!ctx.rooms.has(room)) {
+            if (!hasRealtimeRoomCapacity(ctx.rooms, [room])) {
+              sendWsError(socket, "BAD_REQUEST", "realtime room limit exceeded", requestId);
+              return;
+            }
             const result = await authorizeRoomsForConnection(ctx, [room]);
             if (result.rooms.length === 0) {
               sendWsEnvelope(socket, buildRealtimeEnvelope({
@@ -1181,13 +1245,23 @@ async function main() {
         logger.error("[Gateway] WebSocket message handling failed:", error);
         sendWsError(socket, "INTERNAL_ERROR", "internal error", requestId);
       }
+      });
+      queued.catch((error) => {
+        if (error instanceof ConnectionStateQueueOverflowError) {
+          closeWsConnection(ctx, socket, 1013, "too many pending requests");
+          return;
+        }
+        logger.warn("[Gateway] WebSocket state operation failed", { connectionId, error });
+      });
     });
 
     socket.on("close", () => {
-      void cleanupWsConnection(wsConnections.get(connectionId));
+      const current = wsConnections.get(connectionId);
+      if (current) closeWsConnection(current, socket, 1000, "closed");
     });
     socket.on("error", () => {
-      void cleanupWsConnection(wsConnections.get(connectionId));
+      const current = wsConnections.get(connectionId);
+      if (current) closeWsConnection(current, socket, 1011, "socket error");
     });
   });
 

--- a/apps/gateway/src/realtime-auth-lifetime.test.ts
+++ b/apps/gateway/src/realtime-auth-lifetime.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  isRealtimeAuthExpired,
+  realtimeConnectionTtlSeconds,
+} from "./realtime-auth-lifetime.js";
+
+test("realtime auth lifetime never extends a token", () => {
+  assert.equal(isRealtimeAuthExpired(1_999, 2_000), true);
+  assert.equal(isRealtimeAuthExpired(2_001, 2_000), false);
+  assert.equal(realtimeConnectionTtlSeconds(undefined, 300, 2_000), 300);
+  assert.equal(realtimeConnectionTtlSeconds(12_000, 300, 2_000), 10);
+  assert.equal(realtimeConnectionTtlSeconds(1_999, 300, 2_000), 0);
+});

--- a/apps/gateway/src/realtime-auth-lifetime.ts
+++ b/apps/gateway/src/realtime-auth-lifetime.ts
@@ -1,0 +1,15 @@
+export function isRealtimeAuthExpired(
+  expiresAtMs: number | undefined,
+  now = Date.now(),
+): boolean {
+  return expiresAtMs !== undefined && expiresAtMs <= now;
+}
+
+export function realtimeConnectionTtlSeconds(
+  expiresAtMs: number | undefined,
+  maxTtlSeconds: number,
+  now = Date.now(),
+): number {
+  if (expiresAtMs === undefined) return maxTtlSeconds;
+  return Math.max(0, Math.min(maxTtlSeconds, Math.ceil((expiresAtMs - now) / 1000)));
+}

--- a/apps/gateway/src/realtime-room-admission.test.ts
+++ b/apps/gateway/src/realtime-room-admission.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  MAX_REALTIME_ROOMS_PER_CONNECTION,
+  type RealtimeRoom,
+} from "@cohub/protocol/realtime";
+import { hasRealtimeRoomCapacity } from "./realtime-room-admission.js";
+
+test("realtime room admission counts only new unique rooms", () => {
+  const current = new Set<RealtimeRoom>(["user:viewer"]);
+  assert.equal(hasRealtimeRoomCapacity(current, ["user:viewer", "space:one"]), true);
+
+  const full = new Set<RealtimeRoom>(
+    Array.from(
+      { length: MAX_REALTIME_ROOMS_PER_CONNECTION },
+      (_, index) => `session:${index}` as RealtimeRoom,
+    ),
+  );
+  assert.equal(hasRealtimeRoomCapacity(full, ["session:0"]), true);
+  assert.equal(hasRealtimeRoomCapacity(full, ["session:overflow"]), false);
+});

--- a/apps/gateway/src/realtime-room-admission.ts
+++ b/apps/gateway/src/realtime-room-admission.ts
@@ -1,0 +1,10 @@
+import { MAX_REALTIME_ROOMS_PER_CONNECTION, type RealtimeRoom } from "@cohub/protocol/realtime";
+
+export function hasRealtimeRoomCapacity(
+  currentRooms: ReadonlySet<RealtimeRoom>,
+  requestedRooms: readonly RealtimeRoom[],
+): boolean {
+  const combined = new Set(currentRooms);
+  for (const room of requestedRooms) combined.add(room);
+  return combined.size <= MAX_REALTIME_ROOMS_PER_CONNECTION;
+}

--- a/apps/web/src/lib/components/SessionSidebarRowContent.svelte
+++ b/apps/web/src/lib/components/SessionSidebarRowContent.svelte
@@ -2,6 +2,7 @@
 import type { UserSessionListItem } from "@neta-art/cohub";
 import UserAvatar from "$lib/components/UserAvatar.svelte";
 import type { ModelCatalogItem } from "$lib/model-catalog";
+import { getUserSessionLastMessageId } from "$lib/session-record-merge";
 import { getSessionSidebarActivity } from "$lib/session-sidebar-activity";
 import { getSessionActivityAt } from "$lib/session-sort";
 import { authStore } from "$lib/stores/auth.svelte";
@@ -43,7 +44,7 @@ const activityTime = $derived(
 	formatCompactAbsoluteTime(getSessionActivityAt(session)),
 );
 const isUnread = $derived(
-	unreadTracker.isUnread(session, session.lastMessageId),
+	unreadTracker.isUnread(session, getUserSessionLastMessageId(session)),
 );
 const shouldShowActivity = $derived(
 	activity.active ||

--- a/apps/web/src/lib/components/SessionSidebarRowContent.svelte
+++ b/apps/web/src/lib/components/SessionSidebarRowContent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { SessionRecord } from "@neta-art/cohub";
+import type { UserSessionListItem } from "@neta-art/cohub";
 import UserAvatar from "$lib/components/UserAvatar.svelte";
 import type { ModelCatalogItem } from "$lib/model-catalog";
 import { getSessionSidebarActivity } from "$lib/session-sidebar-activity";
@@ -16,7 +16,7 @@ const {
 	modelsCatalog,
 	showSourceBadge = false,
 }: {
-	session: SessionRecord;
+	session: UserSessionListItem;
 	title: string;
 	isMobile?: boolean;
 	modelsCatalog?: ModelCatalogItem[] | null;
@@ -85,7 +85,7 @@ function getInitials(name: string) {
 	);
 }
 
-function getSessionParticipants(session: SessionRecord): Participant[] {
+function getSessionParticipants(session: UserSessionListItem): Participant[] {
 	const participants: Participant[] = [];
 	const seen = new Set<string>();
 	const addProfile = (

--- a/apps/web/src/lib/features/session-chat/session-utils.ts
+++ b/apps/web/src/lib/features/session-chat/session-utils.ts
@@ -21,7 +21,9 @@ function tailText(value: unknown, limit = 420) {
 	return trimmed.length > limit ? `…${trimmed.slice(-limit)}` : trimmed;
 }
 
-export function getSessionTitle(session: SessionRecord): string {
+export function getSessionTitle(
+	session: Pick<SessionRecord, "title"> & { latestMessageText?: string | null },
+): string {
 	const candidates = [session.title, session.latestMessageText];
 	for (const candidate of candidates) {
 		const normalized = candidate

--- a/apps/web/src/lib/features/sessions/UserSessionsPage.svelte
+++ b/apps/web/src/lib/features/sessions/UserSessionsPage.svelte
@@ -175,14 +175,17 @@ function accessForSessions() {
 async function openChatSession(input: {
 	spaceId: string;
 	sessionId: string;
-	session?: SessionRecord | null;
+	session?: SessionRecord | UserSessionListItem | null;
 	turnSequence?: number | null;
 }) {
 	const { spaceId, sessionId, session, turnSequence = null } = input;
 	spaceBox.current = spaceId;
 	sessionChat.enterSpace(spaceId);
-	if (session) {
-		sessionChat.upsertSessionRecord(session);
+	if (
+		session &&
+		(!("accessLevel" in session) || session.accessLevel !== "summary")
+	) {
+		sessionChat.upsertSessionRecord(session as SessionRecord);
 	}
 	sessionChat.syncContext({
 		spaceId,

--- a/apps/web/src/lib/features/sessions/UserSessionsPage.svelte
+++ b/apps/web/src/lib/features/sessions/UserSessionsPage.svelte
@@ -21,6 +21,10 @@ import {
 import { DESKTOP_SHELL_MIN_WIDTH_PX } from "$lib/layout/breakpoints";
 import { sdk } from "$lib/sdk";
 import {
+	isFullUserSessionListItem,
+	isUserSessionSummary,
+} from "$lib/session-record-merge";
+import {
 	buildSessionsRoute,
 	buildSpaceSessionRoute,
 	buildUserSessionRoute,
@@ -181,11 +185,8 @@ async function openChatSession(input: {
 	const { spaceId, sessionId, session, turnSequence = null } = input;
 	spaceBox.current = spaceId;
 	sessionChat.enterSpace(spaceId);
-	if (
-		session &&
-		(!("accessLevel" in session) || session.accessLevel !== "summary")
-	) {
-		sessionChat.upsertSessionRecord(session as SessionRecord);
+	if (session && !isUserSessionSummary(session)) {
+		sessionChat.upsertSessionRecord(session);
 	}
 	sessionChat.syncContext({
 		spaceId,
@@ -416,6 +417,7 @@ $effect(() => {
 		// Skip no-op writes (same title/updatedAt) to avoid churn.
 		if (
 			existing &&
+			isFullUserSessionListItem(existing) &&
 			existing.title === session.title &&
 			existing.updatedAt === session.updatedAt &&
 			existing.lastMessageId === session.lastMessageId

--- a/apps/web/src/lib/features/sessions/user-session-list-controller.svelte.ts
+++ b/apps/web/src/lib/features/sessions/user-session-list-controller.svelte.ts
@@ -192,13 +192,22 @@ export function createUserSessionListController() {
 
 		const existing = findById(sessionId);
 		if (existing) {
-			upsertSession({
-				...existing,
-				spaceId: existing.spaceId || spaceId,
-				latestMessageText: preview ?? existing.latestMessageText,
-				lastMessageAt: completedAt,
-				updatedAt: completedAt,
-			});
+			upsertSession(
+				existing.accessLevel === "summary"
+					? {
+							...existing,
+							spaceId: existing.spaceId || spaceId,
+							lastMessageAt: completedAt,
+							updatedAt: completedAt,
+						}
+					: {
+							...existing,
+							spaceId: existing.spaceId || spaceId,
+							latestMessageText: preview ?? existing.latestMessageText,
+							lastMessageAt: completedAt,
+							updatedAt: completedAt,
+						},
+			);
 		}
 		// Always reconcile with server so unknown / participant sessions appear.
 		scheduleRealtimeRefresh();

--- a/apps/web/src/lib/features/space/modules/work-utils.ts
+++ b/apps/web/src/lib/features/space/modules/work-utils.ts
@@ -35,12 +35,14 @@ export const WORK_VIEWER_SCOPE_OPTIONS: {
 	{
 		scope: "session.prompt.readonly",
 		label: "Prompt read-only",
-		description: "Allow viewer-authorized read access to prompts.",
+		description:
+			"Allow read-only prompts and polling replies from viewer-owned sessions in this space.",
 	},
 	{
 		scope: "session.prompt.fullaccess",
 		label: "Prompt full access",
-		description: "Allow viewer-authorized prompt writes.",
+		description:
+			"Allow prompt writes and reading replies from viewer-owned sessions in this space.",
 	},
 	{
 		scope: "generation.create",

--- a/apps/web/src/lib/features/work/WorkAuthorizeDialog.svelte
+++ b/apps/web/src/lib/features/work/WorkAuthorizeDialog.svelte
@@ -40,15 +40,15 @@ const OPERATION_GROUPS: OperationGroup[] = [
 		scopes: ["generation.create"],
 	},
 	{
-		title: "Send instructions in sessions",
+		title: "Use your sessions",
 		description:
-			"Send prompts and run agent actions in the current space as you.",
+			"Send prompts and read replies from sessions you own in the current space.",
 		scopes: ["session.prompt.fullaccess"],
 	},
 	{
 		title: "Read data",
 		description:
-			"Read files in the current space and list your sessions there.",
+			"Run read-only prompts, list session summaries, or read other account data you approve.",
 		scopes: [
 			"session.prompt.readonly",
 			"user.session.list",

--- a/apps/web/src/lib/session-record-merge.ts
+++ b/apps/web/src/lib/session-record-merge.ts
@@ -1,4 +1,6 @@
-import type { SessionRecord } from "@neta-art/cohub";
+import type { SessionRecord, UserSessionListItem } from "@neta-art/cohub";
+
+type MergeableSession = SessionRecord | UserSessionListItem;
 
 function hasOwn<T extends object, K extends PropertyKey>(
 	value: T,
@@ -18,7 +20,15 @@ function hasOwn<T extends object, K extends PropertyKey>(
 export function mergeSessionRecord(
 	existing: SessionRecord | undefined | null,
 	incoming: SessionRecord,
-): SessionRecord {
+): SessionRecord;
+export function mergeSessionRecord(
+	existing: UserSessionListItem | undefined | null,
+	incoming: UserSessionListItem,
+): UserSessionListItem;
+export function mergeSessionRecord(
+	existing: MergeableSession | undefined | null,
+	incoming: MergeableSession,
+): MergeableSession {
 	if (!existing) return incoming;
 	return {
 		...existing,
@@ -33,15 +43,33 @@ export function mergeSessionRecord(
 		participantProfiles: hasOwn(incoming, "participantProfiles")
 			? incoming.participantProfiles
 			: existing.participantProfiles,
-	};
+	} as MergeableSession;
 }
 
+export function mergeSessionRecords(sessions: SessionRecord[]): SessionRecord[];
 export function mergeSessionRecords(
-	sessions: SessionRecord[],
-): SessionRecord[] {
-	const byId = new Map<string, SessionRecord>();
+	sessions: UserSessionListItem[],
+): UserSessionListItem[];
+export function mergeSessionRecords(
+	sessions: MergeableSession[],
+): MergeableSession[] {
+	const byId = new Map<string, MergeableSession>();
 	for (const session of sessions) {
-		byId.set(session.id, mergeSessionRecord(byId.get(session.id), session));
+		const existing = byId.get(session.id);
+		byId.set(session.id, {
+			...existing,
+			...session,
+			meta: hasOwn(session, "meta") ? session.meta : existing?.meta,
+			userProfile: hasOwn(session, "userProfile")
+				? session.userProfile
+				: existing?.userProfile,
+			participantUserUuids: hasOwn(session, "participantUserUuids")
+				? session.participantUserUuids
+				: existing?.participantUserUuids,
+			participantProfiles: hasOwn(session, "participantProfiles")
+				? session.participantProfiles
+				: existing?.participantProfiles,
+		} as MergeableSession);
 	}
 	return Array.from(byId.values());
 }

--- a/apps/web/src/lib/session-record-merge.ts
+++ b/apps/web/src/lib/session-record-merge.ts
@@ -1,12 +1,47 @@
-import type { SessionRecord, UserSessionListItem } from "@neta-art/cohub";
+import type {
+	SessionRecord,
+	UserSessionListItem,
+	UserSessionSummary,
+} from "@neta-art/cohub";
 
 type MergeableSession = SessionRecord | UserSessionListItem;
+export type FullUserSessionListItem = Exclude<
+	UserSessionListItem,
+	UserSessionSummary
+>;
 
-function hasOwn<T extends object, K extends PropertyKey>(
-	value: T,
-	key: K,
-): value is T & Record<K, unknown> {
-	return Object.hasOwn(value, key);
+export function isUserSessionSummary(
+	session: UserSessionListItem,
+): session is UserSessionSummary {
+	return "accessLevel" in session && session.accessLevel === "summary";
+}
+
+export function isFullUserSessionListItem(
+	session: UserSessionListItem,
+): session is FullUserSessionListItem {
+	return !isUserSessionSummary(session);
+}
+
+/** Summary rows cannot infer unread state without exposing message identity. */
+export function getUserSessionLastMessageId(
+	session: UserSessionListItem,
+): string | null {
+	return isFullUserSessionListItem(session)
+		? (session.lastMessageId ?? null)
+		: null;
+}
+
+function mergeSessionValue(
+	existing: MergeableSession | undefined | null,
+	incoming: MergeableSession,
+): MergeableSession {
+	if (!existing) return incoming;
+	if (isUserSessionSummary(incoming)) {
+		return incoming;
+	}
+	const merged: Record<string, unknown> = { ...existing, ...incoming };
+	delete merged.accessLevel;
+	return merged as MergeableSession;
 }
 
 /**
@@ -18,7 +53,7 @@ function hasOwn<T extends object, K extends PropertyKey>(
  * to replace stale data.
  */
 export function mergeSessionRecord(
-	existing: SessionRecord | undefined | null,
+	existing: MergeableSession | undefined | null,
 	incoming: SessionRecord,
 ): SessionRecord;
 export function mergeSessionRecord(
@@ -29,21 +64,7 @@ export function mergeSessionRecord(
 	existing: MergeableSession | undefined | null,
 	incoming: MergeableSession,
 ): MergeableSession {
-	if (!existing) return incoming;
-	return {
-		...existing,
-		...incoming,
-		meta: hasOwn(incoming, "meta") ? incoming.meta : existing.meta,
-		userProfile: hasOwn(incoming, "userProfile")
-			? incoming.userProfile
-			: existing.userProfile,
-		participantUserUuids: hasOwn(incoming, "participantUserUuids")
-			? incoming.participantUserUuids
-			: existing.participantUserUuids,
-		participantProfiles: hasOwn(incoming, "participantProfiles")
-			? incoming.participantProfiles
-			: existing.participantProfiles,
-	} as MergeableSession;
+	return mergeSessionValue(existing, incoming);
 }
 
 export function mergeSessionRecords(sessions: SessionRecord[]): SessionRecord[];
@@ -55,21 +76,7 @@ export function mergeSessionRecords(
 ): MergeableSession[] {
 	const byId = new Map<string, MergeableSession>();
 	for (const session of sessions) {
-		const existing = byId.get(session.id);
-		byId.set(session.id, {
-			...existing,
-			...session,
-			meta: hasOwn(session, "meta") ? session.meta : existing?.meta,
-			userProfile: hasOwn(session, "userProfile")
-				? session.userProfile
-				: existing?.userProfile,
-			participantUserUuids: hasOwn(session, "participantUserUuids")
-				? session.participantUserUuids
-				: existing?.participantUserUuids,
-			participantProfiles: hasOwn(session, "participantProfiles")
-				? session.participantProfiles
-				: existing?.participantProfiles,
-		} as MergeableSession);
+		byId.set(session.id, mergeSessionValue(byId.get(session.id), session));
 	}
 	return Array.from(byId.values());
 }

--- a/apps/web/src/lib/session-sort.ts
+++ b/apps/web/src/lib/session-sort.ts
@@ -1,24 +1,31 @@
-import type { SessionRecord } from "@neta-art/cohub";
+type SessionActivityRecord = {
+	id: string;
+	lastMessageAt: string | null;
+	updatedAt: string;
+	createdAt: string;
+};
 
-export function getSessionActivityAt(session: SessionRecord) {
+export function getSessionActivityAt(session: SessionActivityRecord) {
 	return (
 		session.lastMessageAt ?? session.updatedAt ?? session.createdAt ?? null
 	);
 }
 
-export function getSessionSortTime(session: SessionRecord) {
+export function getSessionSortTime(session: SessionActivityRecord) {
 	return Date.parse(getSessionActivityAt(session) ?? "") || 0;
 }
 
 export function compareSessionsByRecentActivity(
-	a: SessionRecord,
-	b: SessionRecord,
+	a: SessionActivityRecord,
+	b: SessionActivityRecord,
 ) {
 	const timeDelta = getSessionSortTime(b) - getSessionSortTime(a);
 	if (timeDelta !== 0) return timeDelta;
 	return b.id.localeCompare(a.id);
 }
 
-export function sortSessionsByRecentActivity(sessions: SessionRecord[]) {
+export function sortSessionsByRecentActivity<T extends SessionActivityRecord>(
+	sessions: T[],
+): T[] {
 	return [...sessions].sort(compareSessionsByRecentActivity);
 }

--- a/apps/web/src/lib/stores/session-state.svelte.ts
+++ b/apps/web/src/lib/stores/session-state.svelte.ts
@@ -39,7 +39,7 @@ class UnreadTracker {
 	}
 
 	isUnread(
-		session: SessionRecord,
+		session: Pick<SessionRecord, "id">,
 		latestItemId: string | null | undefined,
 	): boolean {
 		if (!latestItemId) return false;

--- a/apps/web/src/routes/(app)/spaces/[id]/settings/+page.svelte
+++ b/apps/web/src/routes/(app)/spaces/[id]/settings/+page.svelte
@@ -1079,7 +1079,8 @@ async function createInvite() {
 	}
 }
 
-async function copyInviteLink(token: string) {
+async function copyInviteLink(token: string | undefined) {
+	if (!token) return false;
 	const url = `${window.location.origin}/invite/${token}`;
 	try {
 		if (navigator.clipboard?.writeText) {
@@ -1107,7 +1108,8 @@ async function copyInviteLink(token: string) {
 	}
 }
 
-async function revokeInvite(token: string) {
+async function revokeInvite(token: string | undefined) {
+	if (!token) return;
 	if (!canManageSpaceMembers) return;
 	if (!window.confirm("Revoke this invitation link? It will no longer work."))
 		return;
@@ -1687,7 +1689,7 @@ $effect(() => {
 								<p class="mt-3 text-[12px] text-text-tertiary">No invite links.</p>
 							{:else if invitations.length > 0}
 								<div class="mt-3 divide-y divide-border-subtle rounded-md border border-border-subtle">
-									{#each invitations as invitation (invitation.token)}
+									{#each invitations as invitation (`${invitation.token ?? "summary"}:${invitation.role}:${invitation.createdAt ?? ""}`)}
 										<div class="flex items-center justify-between gap-3 px-3 py-2.5">
 											<div class="min-w-0 flex-1">
 												<div class="flex flex-wrap items-center gap-2">
@@ -1696,7 +1698,7 @@ $effect(() => {
 												</div>
 												<div class="mt-0.5 text-[10px] text-text-placeholder">{invitation.status === 'active' ? formatInviteExpiry(invitation.expiresInSeconds) : invitation.status === 'revoked' ? 'Revoked' : 'All uses exhausted'}</div>
 											</div>
-											{#if invitation.status === 'active'}
+										{#if invitation.status === 'active' && invitation.token && canManageSpaceMembers}
 												<div class="flex shrink-0 items-center gap-0.5">
 													<button type="button" title="Copy invite link" onclick={() => { void copyInviteLink(invitation.token); }} class="inline-flex h-8 w-8 items-center justify-center rounded-[5px] text-text-tertiary transition-colors hover:bg-bg-hover hover:text-text-primary">{#if copiedInviteToken === invitation.token}<Check class="h-3.5 w-3.5 text-status-running" />{:else}<Copy class="h-3.5 w-3.5" />{/if}</button>
 													<button type="button" title="Revoke invite" onclick={() => { void revokeInvite(invitation.token); }} class="inline-flex h-8 w-8 items-center justify-center rounded-[5px] text-text-tertiary transition-colors hover:bg-error-bg hover:text-error-soft"><Trash2 class="h-3.5 w-3.5" /></button>

--- a/apps/web/src/routes/(app)/spaces/[id]/settings/+page.svelte
+++ b/apps/web/src/routes/(app)/spaces/[id]/settings/+page.svelte
@@ -1689,7 +1689,7 @@ $effect(() => {
 								<p class="mt-3 text-[12px] text-text-tertiary">No invite links.</p>
 							{:else if invitations.length > 0}
 								<div class="mt-3 divide-y divide-border-subtle rounded-md border border-border-subtle">
-									{#each invitations as invitation (`${invitation.token ?? "summary"}:${invitation.role}:${invitation.createdAt ?? ""}`)}
+										{#each invitations as invitation (invitation.id)}
 										<div class="flex items-center justify-between gap-3 px-3 py-2.5">
 											<div class="min-w-0 flex-1">
 												<div class="flex flex-wrap items-center gap-2">

--- a/apps/web/src/tests/session-record-merge.test.ts
+++ b/apps/web/src/tests/session-record-merge.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { SessionRecord, UserSessionSummary } from "@neta-art/cohub";
+import {
+	getUserSessionLastMessageId,
+	isFullUserSessionListItem,
+	isUserSessionSummary,
+	mergeSessionRecord,
+} from "$lib/session-record-merge";
+
+const full: SessionRecord = {
+	id: "session-1",
+	spaceId: "space-1",
+	userUuid: "viewer-1",
+	title: "Session",
+	source: "web",
+	status: "active",
+	externalSessionId: "external-secret",
+	meta: { secret: true },
+	latestMessageText: "private prompt",
+	lastMessageAt: "2026-07-31T00:00:00.000Z",
+	lastMessageId: "message-1",
+	totalMessages: 3,
+	totalCost: "1.25",
+	bindings: [
+		{
+			id: "binding-1",
+			spaceId: "space-1",
+			spaceSessionId: "session-1",
+			spaceChannelId: "channel-1",
+			provider: "private-provider",
+			bindingKey: "private-binding",
+			externalChatId: "external-chat-1",
+			status: "active",
+			meta: null,
+			createdAt: "2026-07-31T00:00:00.000Z",
+			updatedAt: "2026-07-31T00:00:00.000Z",
+			lastMessageAt: null,
+		},
+	],
+	createdAt: "2026-07-31T00:00:00.000Z",
+	updatedAt: "2026-07-31T00:00:00.000Z",
+};
+
+const summary: UserSessionSummary = {
+	accessLevel: "summary",
+	id: full.id,
+	spaceId: full.spaceId,
+	userUuid: full.userUuid,
+	title: full.title,
+	source: full.source,
+	status: full.status,
+	lastMessageAt: full.lastMessageAt,
+	createdAt: full.createdAt,
+	updatedAt: full.updatedAt,
+};
+
+test("a summary response clears private fields cached from earlier full access", () => {
+	const merged = mergeSessionRecord(full, summary);
+	assert.equal(merged.accessLevel, "summary");
+	assert.equal("externalSessionId" in merged, false);
+	assert.equal("meta" in merged, false);
+	assert.equal("latestMessageText" in merged, false);
+	assert.equal("lastMessageId" in merged, false);
+	assert.equal("totalMessages" in merged, false);
+	assert.equal("totalCost" in merged, false);
+	assert.equal("bindings" in merged, false);
+});
+
+test("a full response upgrades a cached summary without retaining its discriminator", () => {
+	const merged = mergeSessionRecord(summary, full);
+	assert.equal("accessLevel" in merged, false);
+	assert.equal(merged.externalSessionId, full.externalSessionId);
+	assert.deepEqual(merged.meta, full.meta);
+});
+
+test("summary rows stay read-safe while full rows retain message identity", () => {
+	assert.equal(isUserSessionSummary(summary), true);
+	assert.equal(isFullUserSessionListItem(summary), false);
+	assert.equal(getUserSessionLastMessageId(summary), null);
+	assert.equal(isUserSessionSummary(full), false);
+	assert.equal(isFullUserSessionListItem(full), true);
+	assert.equal(getUserSessionLastMessageId(full), "message-1");
+});

--- a/apps/worker/src/tasks/generation-task.ts
+++ b/apps/worker/src/tasks/generation-task.ts
@@ -29,8 +29,13 @@ import {
   type GenerationUsageBilling,
 } from "@cohub/protocol/generation";
 import type { TaskPayload } from "@cohub/protocol/task";
+import type { PromptAuthContext } from "@cohub/core/sessions";
+import { requireDelegatedTaskAuth, resolveScheduledPromptAuth, type WorkViewerGrantSnapshot } from "../work-viewer-prompt-auth.js";
+import { works, workViewerGrants } from "@cohub/db";
+import { and, eq } from "drizzle-orm";
 import { defaultJobRetention } from "@cohub/infra/bullmq";
 import { config } from "../config.js";
+import { db } from "../db.js";
 import { recordGenerationUsageStatsHourly } from "../generation-usage-stats.js";
 import { redisCommandClient } from "../redis.js";
 import { enqueueTask } from "./enqueue.js";
@@ -49,6 +54,34 @@ const billingUsageGate = createBillingUsageGate({
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+async function loadGenerationWorkViewerGrant(input: {
+  grantId: string;
+  workId: string;
+  spaceId: string;
+  viewerUserUuid: string;
+}): Promise<WorkViewerGrantSnapshot | null> {
+  const [grant] = await db
+    .select({
+      scopes: workViewerGrants.scopes,
+      expiresAt: workViewerGrants.expiresAt,
+      revokedAt: workViewerGrants.revokedAt,
+      workStatus: works.status,
+      workSpaceId: works.spaceId,
+      workScopes: works.workScopes,
+      allowedViewerScopes: works.allowedViewerScopes,
+    })
+    .from(workViewerGrants)
+    .innerJoin(works, eq(works.id, workViewerGrants.workId))
+    .where(and(
+      eq(workViewerGrants.id, input.grantId),
+      eq(workViewerGrants.workId, input.workId),
+      eq(workViewerGrants.spaceId, input.spaceId),
+      eq(workViewerGrants.viewerUserUuid, input.viewerUserUuid),
+    ))
+    .limit(1);
+  return grant ?? null;
 }
 
 function parseModelDiscountSnapshot(value: unknown): GenerationModelDiscountSnapshot {
@@ -88,11 +121,25 @@ function parseGenerationTaskData(data: unknown): GenerationTaskData {
   if (data.meta !== undefined && !isRecord(data.meta)) {
     throw new Error("Invalid generation task payload: meta must be an object");
   }
+  if (data.workId !== undefined && (typeof data.workId !== "string" || !data.workId.trim())) {
+    throw new Error("Invalid generation task payload: workId must be a non-empty string");
+  }
+  if (data.declarationScope !== undefined && data.declarationScope !== "platform" && data.declarationScope !== "user") {
+    throw new Error("Invalid generation task payload: declarationScope must be platform or user");
+  }
+  const declarationScope = data.declarationScope ?? (data.workId ? "platform" : "user");
+  if (data.workId && declarationScope !== "platform") {
+    throw new Error("Invalid generation task payload: Work generation must use platform declarations");
+  }
   return {
     model: data.model,
     content: data.content as GenerationTaskData["content"],
     parameters: data.parameters,
     meta: data.meta,
+    declarationScope,
+    ...(data.workId === undefined ? {} : { workId: data.workId.trim() }),
+    ...(data.auth === undefined ? {} : { auth: isRecord(data.auth) ? data.auth : null }),
+    ...(data.delegatedAuthRequired === undefined ? {} : { delegatedAuthRequired: data.delegatedAuthRequired === true }),
     ...(data.modelDiscount === undefined
       ? {}
       : { modelDiscount: parseModelDiscountSnapshot(data.modelDiscount) }),
@@ -359,8 +406,23 @@ registerTask(GENERATION_TASK_TYPE, async (job: Job, context) => {
     turnId: turnId ?? null,
   });
 
+  const delegatedAuthRequired = data.delegatedAuthRequired === true;
+  const taskAuth = requireDelegatedTaskAuth(
+    delegatedAuthRequired,
+    data.auth as PromptAuthContext | null | undefined,
+  );
+  if (taskAuth) {
+    await resolveScheduledPromptAuth(
+        taskAuth,
+        { spaceId, userId, requiredPermission: "generation.create" },
+        loadGenerationWorkViewerGrant,
+      );
+  }
+
   try {
-    const declaration = await loader.loadGenerationDeclaration(userId, data.model);
+    const declaration = data.declarationScope === "platform"
+      ? await loader.loadPlatformGenerationDeclaration(data.model)
+      : await loader.loadGenerationDeclaration(userId, data.model);
     if (!declaration) throw new Error(`Generation model is unavailable: ${data.model}`);
 
     // Re-read authoritative entitlements before trusting a queued snapshot. This

--- a/apps/worker/src/tasks/send-message-task.ts
+++ b/apps/worker/src/tasks/send-message-task.ts
@@ -12,9 +12,9 @@ import { getSessionDomainServices } from "../session-services.js";
 import { createLogger } from "@cohub/infra/logging";
 import { db } from "../db.js";
 import { dispatchLabelAssignmentsUpdated } from "../label-events.js";
-import { workViewerGrants } from "@cohub/db";
+import { works, workViewerGrants } from "@cohub/db";
 import { and, eq } from "drizzle-orm";
-import { resolveScheduledPromptAuth } from "../work-viewer-prompt-auth.js";
+import { requireDelegatedTaskAuth, resolveScheduledPromptAuth } from "../work-viewer-prompt-auth.js";
 
 const MAX_TASK_SOURCE_LENGTH = 255;
 
@@ -43,8 +43,13 @@ async function loadWorkViewerGrant(input: {
       scopes: workViewerGrants.scopes,
       expiresAt: workViewerGrants.expiresAt,
       revokedAt: workViewerGrants.revokedAt,
+      workStatus: works.status,
+      workSpaceId: works.spaceId,
+      workScopes: works.workScopes,
+      allowedViewerScopes: works.allowedViewerScopes,
     })
     .from(workViewerGrants)
+    .innerJoin(works, eq(works.id, workViewerGrants.workId))
     .where(and(
       eq(workViewerGrants.id, input.grantId),
       eq(workViewerGrants.workId, input.workId),
@@ -58,7 +63,7 @@ async function loadWorkViewerGrant(input: {
 const sendMessageHandler = async (job: import("bullmq").Job, context?: { taskRunId: string }) => {
   const payload = job.data as TaskPayload;
   const spaceId = payload.spaceId;
-  const { content, sessionId, title, source: payloadSource, model, provider, thinkingLevel, clientMessageId, generationPolicy, accessMode, intent, labelIds, auth, env } = (payload.data ?? {}) as {
+  const { content, sessionId, title, source: payloadSource, model, provider, thinkingLevel, clientMessageId, generationPolicy, accessMode, intent, labelIds, auth, delegatedAuthRequired, env } = (payload.data ?? {}) as {
     content?: ContentBlock[];
     sessionId?: string;
     title?: string;
@@ -72,6 +77,7 @@ const sendMessageHandler = async (job: import("bullmq").Job, context?: { taskRun
     intent?: SessionTurnIntent | null;
     labelIds?: string[];
     auth?: PromptAuthContext | null;
+    delegatedAuthRequired?: boolean;
     env?: PromptEnv | null;
   };
 
@@ -88,8 +94,9 @@ const sendMessageHandler = async (job: import("bullmq").Job, context?: { taskRun
   const promptPermission = promptAccessMode === "read_only"
     ? "session.prompt.readonly"
     : "session.prompt.fullaccess";
+  const taskAuth = requireDelegatedTaskAuth(delegatedAuthRequired === true, auth);
   const promptAuth = await resolveScheduledPromptAuth(
-    auth ?? null,
+    taskAuth,
     { spaceId, userId, requiredPermission: promptPermission },
     loadWorkViewerGrant,
   );

--- a/apps/worker/src/tasks/send-message-task.ts
+++ b/apps/worker/src/tasks/send-message-task.ts
@@ -4,7 +4,7 @@ import type { TaskPayload } from "@cohub/protocol/task";
 import { registerTask } from "./registry.js";
 import { assignLabelsToSession } from "@cohub/core/labels";
 import { assignSessionSourceSystemLabel } from "@cohub/core/labels/session-source";
-import { getPromptAuthScopes, parsePromptEnv, type PromptAccessMode, type PromptAuthContext, type PromptEnv, type SubmitSessionPromptContext } from "@cohub/core/sessions";
+import { parsePromptEnv, type PromptAccessMode, type PromptAuthContext, type PromptEnv, type SubmitSessionPromptContext } from "@cohub/core/sessions";
 import type { SessionTurnIntent } from "@cohub/protocol/model";
 import { getPromptTemplateService } from "../prompt-templates.js";
 import { getSkillService } from "../skills.js";
@@ -12,6 +12,9 @@ import { getSessionDomainServices } from "../session-services.js";
 import { createLogger } from "@cohub/infra/logging";
 import { db } from "../db.js";
 import { dispatchLabelAssignmentsUpdated } from "../label-events.js";
+import { workViewerGrants } from "@cohub/db";
+import { and, eq } from "drizzle-orm";
+import { resolveScheduledPromptAuth } from "../work-viewer-prompt-auth.js";
 
 const MAX_TASK_SOURCE_LENGTH = 255;
 
@@ -29,11 +32,27 @@ const sessionPromptService = getSessionDomainServices({
   skillService: getSkillService(),
 });
 
-function sanitizeTaskPromptAuth(auth: PromptAuthContext | null | undefined, input: { spaceId: string; userId: string }) {
-  if (auth?.type !== "delegated_prompt" || auth.spaceId !== input.spaceId) return null;
-  if (auth.actorUserId !== input.userId) return null;
-  if (getPromptAuthScopes(auth, input.spaceId).length === 0) return null;
-  return auth;
+async function loadWorkViewerGrant(input: {
+  grantId: string;
+  workId: string;
+  spaceId: string;
+  viewerUserUuid: string;
+}) {
+  const [grant] = await db
+    .select({
+      scopes: workViewerGrants.scopes,
+      expiresAt: workViewerGrants.expiresAt,
+      revokedAt: workViewerGrants.revokedAt,
+    })
+    .from(workViewerGrants)
+    .where(and(
+      eq(workViewerGrants.id, input.grantId),
+      eq(workViewerGrants.workId, input.workId),
+      eq(workViewerGrants.spaceId, input.spaceId),
+      eq(workViewerGrants.viewerUserUuid, input.viewerUserUuid),
+    ))
+    .limit(1);
+  return grant ?? null;
 }
 
 const sendMessageHandler = async (job: import("bullmq").Job, context?: { taskRunId: string }) => {
@@ -64,6 +83,16 @@ const sendMessageHandler = async (job: import("bullmq").Job, context?: { taskRun
 
   const taskRunId = (context?.taskRunId ?? String(job.id ?? "")).trim();
   if (!taskRunId) throw new Error("taskRunId is required for send_message task");
+
+  const promptAccessMode = accessMode ?? "full_access";
+  const promptPermission = promptAccessMode === "read_only"
+    ? "session.prompt.readonly"
+    : "session.prompt.fullaccess";
+  const promptAuth = await resolveScheduledPromptAuth(
+    auth ?? null,
+    { spaceId, userId, requiredPermission: promptPermission },
+    loadWorkViewerGrant,
+  );
 
   const promptEnv = parsePromptEnv(env);
   const source = normalizeTaskSource(payloadSource);
@@ -97,14 +126,14 @@ const sendMessageHandler = async (job: import("bullmq").Job, context?: { taskRun
     provider: provider ?? null,
     thinkingLevel: thinkingLevel ?? null,
     generationPolicy: generationPolicy ?? null,
-    accessMode: accessMode ?? "full_access",
+    accessMode: promptAccessMode,
     env: promptEnv,
     intent: intent ?? null,
     context: {
       kind: "scheduled_task",
       taskRunId,
       cronJobId: payload.cronJobId ?? null,
-      auth: sanitizeTaskPromptAuth(auth ?? null, { spaceId, userId }),
+      auth: promptAuth,
     } satisfies SubmitSessionPromptContext,
   });
 

--- a/apps/worker/src/work-viewer-prompt-auth.ts
+++ b/apps/worker/src/work-viewer-prompt-auth.ts
@@ -1,5 +1,6 @@
 import {
   normalizePermissionScopes,
+  resolveActiveWorkSessionPolicy,
   scopeListHasPermission,
   type Permission,
 } from "@cohub/core/permissions";
@@ -12,7 +13,19 @@ export type WorkViewerGrantSnapshot = {
   scopes: string[];
   expiresAt: Date | null;
   revokedAt: Date | null;
+  workStatus: string;
+  workSpaceId: string;
+  workScopes: string[];
+  allowedViewerScopes: string[];
 };
+
+export function requireDelegatedTaskAuth(
+  required: boolean,
+  auth: PromptAuthContext | null | undefined,
+): PromptAuthContext | null {
+  if (required && !auth) throw new Error("delegated Work authorization is missing from task");
+  return auth ?? null;
+}
 
 export async function resolveScheduledPromptAuth(
   auth: PromptAuthContext | null | undefined,
@@ -55,7 +68,15 @@ export async function resolveScheduledPromptAuth(
     throw new Error("delegated Work grant is no longer active");
   }
 
-  const tokenViewerScopes = normalizePermissionScopes(auth.viewerScopes);
+  const activePolicy = resolveActiveWorkSessionPolicy(auth, {
+    status: grant.workStatus,
+    spaceId: grant.workSpaceId,
+    workScopes: grant.workScopes,
+    allowedViewerScopes: grant.allowedViewerScopes,
+  });
+  if (!activePolicy) throw new Error("delegated Work is no longer active");
+
+  const tokenViewerScopes = activePolicy.allowedViewerScopes;
   const grantScopes = normalizePermissionScopes(grant.scopes);
   if (
     !scopeListHasPermission(tokenViewerScopes, input.requiredPermission)
@@ -67,7 +88,7 @@ export async function resolveScheduledPromptAuth(
   const tokenViewerScopeSet = new Set(tokenViewerScopes);
   const viewerScopes = grantScopes.filter((scope) => tokenViewerScopeSet.has(scope));
   const tokenScopeSet = new Set(normalizePermissionScopes(auth.scopes));
-  const scopes = normalizePermissionScopes([...auth.workScopes, ...viewerScopes])
+  const scopes = normalizePermissionScopes([...activePolicy.workScopes, ...viewerScopes])
     .filter((scope) => tokenScopeSet.has(scope));
   if (!scopeListHasPermission(scopes, input.requiredPermission)) {
     throw new Error("delegated Work grant no longer allows this prompt");

--- a/apps/worker/src/work-viewer-prompt-auth.ts
+++ b/apps/worker/src/work-viewer-prompt-auth.ts
@@ -1,0 +1,76 @@
+import {
+  normalizePermissionScopes,
+  scopeListHasPermission,
+  type Permission,
+} from "@cohub/core/permissions";
+import {
+  getPromptAuthScopes,
+  type PromptAuthContext,
+} from "@cohub/core/sessions";
+
+export type WorkViewerGrantSnapshot = {
+  scopes: string[];
+  expiresAt: Date | null;
+  revokedAt: Date | null;
+};
+
+export async function resolveScheduledPromptAuth(
+  auth: PromptAuthContext | null | undefined,
+  input: {
+    spaceId: string;
+    userId: string;
+    requiredPermission: Permission;
+  },
+  loadGrant: (input: {
+    grantId: string;
+    workId: string;
+    spaceId: string;
+    viewerUserUuid: string;
+  }) => Promise<WorkViewerGrantSnapshot | null>,
+  now = Date.now(),
+): Promise<PromptAuthContext | null> {
+  if (!auth) return null;
+  if (auth.type !== "delegated_prompt" || auth.spaceId !== input.spaceId) {
+    throw new Error("delegated prompt authorization is invalid");
+  }
+  if (auth.actorUserId !== input.userId) {
+    throw new Error("delegated prompt actor does not match task owner");
+  }
+  const tokenScopes = getPromptAuthScopes(auth, input.spaceId, () => now);
+  if (!scopeListHasPermission(tokenScopes, input.requiredPermission)) {
+    throw new Error("delegated prompt authorization expired or lacks permission");
+  }
+  if (auth.source !== "work_session") return auth;
+
+  const workId = auth.workId?.trim();
+  const grantId = auth.workViewerGrantId?.trim();
+  if (!workId || !grantId) throw new Error("delegated Work grant is missing");
+  const grant = await loadGrant({
+    grantId,
+    workId,
+    spaceId: input.spaceId,
+    viewerUserUuid: input.userId,
+  });
+  if (!grant || grant.revokedAt || (grant.expiresAt && grant.expiresAt.getTime() <= now)) {
+    throw new Error("delegated Work grant is no longer active");
+  }
+
+  const tokenViewerScopes = normalizePermissionScopes(auth.viewerScopes);
+  const grantScopes = normalizePermissionScopes(grant.scopes);
+  if (
+    !scopeListHasPermission(tokenViewerScopes, input.requiredPermission)
+    || !scopeListHasPermission(grantScopes, input.requiredPermission)
+  ) {
+    throw new Error("delegated Work grant no longer allows this prompt");
+  }
+
+  const tokenViewerScopeSet = new Set(tokenViewerScopes);
+  const viewerScopes = grantScopes.filter((scope) => tokenViewerScopeSet.has(scope));
+  const tokenScopeSet = new Set(normalizePermissionScopes(auth.scopes));
+  const scopes = normalizePermissionScopes([...auth.workScopes, ...viewerScopes])
+    .filter((scope) => tokenScopeSet.has(scope));
+  if (!scopeListHasPermission(scopes, input.requiredPermission)) {
+    throw new Error("delegated Work grant no longer allows this prompt");
+  }
+  return { ...auth, scopes, viewerScopes };
+}

--- a/apps/worker/tests/work-viewer-prompt-auth.test.ts
+++ b/apps/worker/tests/work-viewer-prompt-auth.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { PromptAuthContext } from "@cohub/core/sessions";
-import { resolveScheduledPromptAuth } from "../src/work-viewer-prompt-auth.js";
+import { requireDelegatedTaskAuth, resolveScheduledPromptAuth } from "../src/work-viewer-prompt-auth.js";
 
 const now = Date.UTC(2026, 6, 31);
 const auth: PromptAuthContext = {
@@ -18,6 +18,59 @@ const auth: PromptAuthContext = {
   workViewerGrantId: "grant-1",
 };
 
+const activeGrant = {
+  scopes: ["session.prompt.fullaccess", "user.session.list"],
+  expiresAt: new Date(now + 30_000),
+  revokedAt: null,
+  workStatus: "published",
+  workSpaceId: "space-1",
+  workScopes: ["space.view"],
+  allowedViewerScopes: ["session.prompt.fullaccess", "user.session.list"],
+};
+
+test("delegated worker tasks fail closed when their authorization is missing", () => {
+  assert.equal(requireDelegatedTaskAuth(false, null), null);
+  assert.throws(
+    () => requireDelegatedTaskAuth(true, null),
+    /authorization is missing/,
+  );
+  assert.equal(requireDelegatedTaskAuth(true, auth), auth);
+});
+
+test("Work generation tasks revalidate generation.create against the active grant", async () => {
+  const generationAuth: PromptAuthContext = {
+    ...auth,
+    scopes: ["space.view", "generation.create"],
+    viewerScopes: ["generation.create"],
+  };
+  const resolved = await resolveScheduledPromptAuth(
+    generationAuth,
+    { spaceId: "space-1", userId: "viewer-1", requiredPermission: "generation.create" },
+    async () => ({
+      ...activeGrant,
+      scopes: ["generation.create"],
+      allowedViewerScopes: ["generation.create"],
+    }),
+    now,
+  );
+  assert.deepEqual(resolved?.viewerScopes, ["generation.create"]);
+
+  await assert.rejects(
+    resolveScheduledPromptAuth(
+      generationAuth,
+      { spaceId: "space-1", userId: "viewer-1", requiredPermission: "generation.create" },
+      async () => ({
+        ...activeGrant,
+        expiresAt: new Date(now - 1),
+        scopes: ["generation.create"],
+        allowedViewerScopes: ["generation.create"],
+      }),
+      now,
+    ),
+    /no longer active/,
+  );
+});
+
 test("scheduled Work prompts revalidate the exact active grant", async () => {
   const calls: unknown[] = [];
   const resolved = await resolveScheduledPromptAuth(
@@ -29,11 +82,7 @@ test("scheduled Work prompts revalidate the exact active grant", async () => {
     },
     async (input) => {
       calls.push(input);
-      return {
-        scopes: ["session.prompt.fullaccess", "user.session.list"],
-        expiresAt: new Date(now + 30_000),
-        revokedAt: null,
-      };
+      return activeGrant;
     },
     now,
   );
@@ -55,7 +104,7 @@ test("scheduled Work prompts stop after revoke, expiry, or scope removal", async
   };
   await assert.rejects(
     resolveScheduledPromptAuth(auth, input, async () => ({
-      scopes: ["session.prompt.fullaccess"],
+      ...activeGrant,
       expiresAt: new Date(now + 1_000),
       revokedAt: new Date(now - 1),
     }), now),
@@ -63,17 +112,37 @@ test("scheduled Work prompts stop after revoke, expiry, or scope removal", async
   );
   await assert.rejects(
     resolveScheduledPromptAuth(auth, input, async () => ({
-      scopes: ["session.prompt.fullaccess"],
+      ...activeGrant,
       expiresAt: new Date(now - 1),
-      revokedAt: null,
     }), now),
     /no longer active/,
   );
   await assert.rejects(
     resolveScheduledPromptAuth(auth, input, async () => ({
+      ...activeGrant,
       scopes: ["generation.create"],
-      expiresAt: new Date(now + 1_000),
-      revokedAt: null,
+    }), now),
+    /no longer allows/,
+  );
+});
+
+test("scheduled Work prompts stop after the Work is disabled or its policy shrinks", async () => {
+  const input = {
+    spaceId: "space-1",
+    userId: "viewer-1",
+    requiredPermission: "session.prompt.fullaccess" as const,
+  };
+  await assert.rejects(
+    resolveScheduledPromptAuth(auth, input, async () => ({
+      ...activeGrant,
+      workStatus: "disabled",
+    }), now),
+    /Work is no longer active/,
+  );
+  await assert.rejects(
+    resolveScheduledPromptAuth(auth, input, async () => ({
+      ...activeGrant,
+      allowedViewerScopes: ["user.session.list"],
     }), now),
     /no longer allows/,
   );

--- a/apps/worker/tests/work-viewer-prompt-auth.test.ts
+++ b/apps/worker/tests/work-viewer-prompt-auth.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { PromptAuthContext } from "@cohub/core/sessions";
+import { resolveScheduledPromptAuth } from "../src/work-viewer-prompt-auth.js";
+
+const now = Date.UTC(2026, 6, 31);
+const auth: PromptAuthContext = {
+  type: "delegated_prompt",
+  source: "work_session",
+  actorUserId: "viewer-1",
+  workId: "work-1",
+  spaceId: "space-1",
+  scopes: ["space.view", "session.prompt.fullaccess"],
+  workScopes: ["space.view"],
+  viewerScopes: ["session.prompt.fullaccess"],
+  delegatedAt: new Date(now - 1_000).toISOString(),
+  exp: Math.floor((now + 60_000) / 1000),
+  workViewerGrantId: "grant-1",
+};
+
+test("scheduled Work prompts revalidate the exact active grant", async () => {
+  const calls: unknown[] = [];
+  const resolved = await resolveScheduledPromptAuth(
+    auth,
+    {
+      spaceId: "space-1",
+      userId: "viewer-1",
+      requiredPermission: "session.prompt.fullaccess",
+    },
+    async (input) => {
+      calls.push(input);
+      return {
+        scopes: ["session.prompt.fullaccess", "user.session.list"],
+        expiresAt: new Date(now + 30_000),
+        revokedAt: null,
+      };
+    },
+    now,
+  );
+  assert.deepEqual(calls, [{
+    grantId: "grant-1",
+    workId: "work-1",
+    spaceId: "space-1",
+    viewerUserUuid: "viewer-1",
+  }]);
+  assert.deepEqual(resolved?.viewerScopes, ["session.prompt.fullaccess"]);
+  assert.equal(resolved?.scopes.includes("user.session.list"), false);
+});
+
+test("scheduled Work prompts stop after revoke, expiry, or scope removal", async () => {
+  const input = {
+    spaceId: "space-1",
+    userId: "viewer-1",
+    requiredPermission: "session.prompt.fullaccess" as const,
+  };
+  await assert.rejects(
+    resolveScheduledPromptAuth(auth, input, async () => ({
+      scopes: ["session.prompt.fullaccess"],
+      expiresAt: new Date(now + 1_000),
+      revokedAt: new Date(now - 1),
+    }), now),
+    /no longer active/,
+  );
+  await assert.rejects(
+    resolveScheduledPromptAuth(auth, input, async () => ({
+      scopes: ["session.prompt.fullaccess"],
+      expiresAt: new Date(now - 1),
+      revokedAt: null,
+    }), now),
+    /no longer active/,
+  );
+  await assert.rejects(
+    resolveScheduledPromptAuth(auth, input, async () => ({
+      scopes: ["generation.create"],
+      expiresAt: new Date(now + 1_000),
+      revokedAt: null,
+    }), now),
+    /no longer allows/,
+  );
+});

--- a/packages/core/src/permissions/index.ts
+++ b/packages/core/src/permissions/index.ts
@@ -163,6 +163,36 @@ export const normalizePermissionScopes = (scopes: readonly string[]): Permission
   return Array.from(new Set(scopes.filter((scope): scope is Permission => typeof scope === "string" && ALL_PERMISSION_SET.has(scope as Permission))));
 };
 
+export type ActiveWorkSessionPolicy = {
+  workScopes: Permission[];
+  allowedViewerScopes: Permission[];
+};
+
+export function resolveActiveWorkSessionPolicy(
+  token: {
+    spaceId: string;
+    workScopes?: readonly string[];
+    viewerScopes?: readonly string[];
+  },
+  current: {
+    status: string;
+    spaceId: string;
+    workScopes: readonly string[];
+    allowedViewerScopes: readonly string[];
+  } | null,
+): ActiveWorkSessionPolicy | null {
+  if (current?.status !== "published" || current.spaceId !== token.spaceId) return null;
+
+  const tokenWorkScopes = new Set(normalizePermissionScopes(token.workScopes ?? []));
+  const tokenViewerScopes = new Set(normalizePermissionScopes(token.viewerScopes ?? []));
+  return {
+    workScopes: normalizePermissionScopes(current.workScopes)
+      .filter((scope) => tokenWorkScopes.has(scope)),
+    allowedViewerScopes: normalizePermissionScopes(current.allowedViewerScopes)
+      .filter((scope) => tokenViewerScopes.has(scope)),
+  };
+}
+
 export const scopeListHasPermission = (scopes: readonly Permission[], permission: Permission) => {
   if (scopes.includes(permission)) return true;
   if (permission === "session.prompt.readonly" && scopes.includes("session.prompt.fullaccess")) return true;

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -24,6 +24,8 @@ export type AuthUserProfile = {
   organizationId?: string;
   scopes?: string[];
   audience?: string[];
+  /** Verified JWT `exp` claim, in epoch seconds. */
+  tokenExpiresAt?: number;
   [key: string]: unknown;
 };
 
@@ -136,5 +138,6 @@ export async function verifyUserAccessToken(input: {
     scopes: scopeClaims(payload),
     audience: audienceClaims(payload.aud),
     email: stringClaim(payload, "email"),
+    tokenExpiresAt: payload.exp,
   };
 }

--- a/packages/infra/src/config-runtime/generation-declarations.ts
+++ b/packages/infra/src/config-runtime/generation-declarations.ts
@@ -111,12 +111,7 @@ export function createGenerationDeclarationLoader(input: {
   }
 
   async function loadGenerationDeclarations(userId: string): Promise<GenerationModelDeclaration[]> {
-    const platformGenerations = await loadCachedGenerations({
-      redisKey: PLATFORM_GENERATIONS_REDIS_KEY,
-      dir: platformGenerationsDir(),
-      allowMissing: false,
-    });
-    if (!platformGenerations) throw new Error("Generation declarations directory not found");
+    const platformGenerations = await loadPlatformGenerationDeclarations();
 
     const userGenerations = await loadCachedGenerations({
       redisKey: getUserGenerationsRedisKey(userId),
@@ -127,15 +122,35 @@ export function createGenerationDeclarationLoader(input: {
     return mergeGenerationsConfigs(platformGenerations, userGenerations).declarations;
   }
 
+  async function loadPlatformGenerationDeclarations(): Promise<GenerationsConfig> {
+    const platformGenerations = await loadCachedGenerations({
+      redisKey: PLATFORM_GENERATIONS_REDIS_KEY,
+      dir: platformGenerationsDir(),
+      allowMissing: false,
+    });
+    if (!platformGenerations) throw new Error("Generation declarations directory not found");
+    return platformGenerations;
+  }
+
   return {
     loadGenerationDeclarations,
     async loadGenerationDeclaration(userId: string, model: string): Promise<GenerationModelDeclaration | null> {
       const declarations = await loadGenerationDeclarations(userId);
       return declarations.find((declaration) => declaration.model === model) ?? null;
     },
+    async loadPlatformGenerationDeclaration(model: string): Promise<GenerationModelDeclaration | null> {
+      const declarations = (await loadPlatformGenerationDeclarations()).declarations;
+      return declarations.find((declaration) => declaration.model === model) ?? null;
+    },
     async loadPublicGenerationModels(userId: string): Promise<ListGenerationModelsResponse> {
       return {
         models: (await loadGenerationDeclarations(userId)).map(toPublicGenerationDeclaration),
+      };
+    },
+    async loadPlatformPublicGenerationModels(): Promise<ListGenerationModelsResponse> {
+      return {
+        models: (await loadPlatformGenerationDeclarations()).declarations
+          .map(toPublicGenerationDeclaration),
       };
     },
   };

--- a/packages/protocol/board-awareness.test.ts
+++ b/packages/protocol/board-awareness.test.ts
@@ -4,6 +4,7 @@ import { BoardAwarenessClientPayloadSchema } from "./src/realtime/board-awarenes
 import { wsClientEventSchema } from "./src/realtime/schema.js";
 import {
 	getRealtimeBoardRoom,
+	getRealtimeBoardSpaceRoom,
 	getRealtimeSessionRoom,
 	normalizeRealtimeRooms,
 	parseRealtimeRoom,
@@ -26,6 +27,14 @@ test("Board rooms normalize alongside Space and user rooms", () => {
 		]),
 		[`board:${boardId}`, `space:${spaceId}`],
 	);
+});
+
+test("Board aggregate rooms use a separate permission domain", () => {
+	assert.equal(getRealtimeBoardSpaceRoom(spaceId), `boardspace:${spaceId}`);
+	assert.deepEqual(parseRealtimeRoom(`boardspace:${spaceId}`), {
+		kind: "boardspace",
+		id: spaceId,
+	});
 });
 
 test("Session rooms are explicit resource rooms", () => {

--- a/packages/protocol/board-awareness.test.ts
+++ b/packages/protocol/board-awareness.test.ts
@@ -4,6 +4,7 @@ import { BoardAwarenessClientPayloadSchema } from "./src/realtime/board-awarenes
 import { wsClientEventSchema } from "./src/realtime/schema.js";
 import {
 	getRealtimeBoardRoom,
+	getRealtimeSessionRoom,
 	normalizeRealtimeRooms,
 	parseRealtimeRoom,
 } from "./src/realtime/types.js";
@@ -25,6 +26,15 @@ test("Board rooms normalize alongside Space and user rooms", () => {
 		]),
 		[`board:${boardId}`, `space:${spaceId}`],
 	);
+});
+
+test("Session rooms are explicit resource rooms", () => {
+	const sessionId = "33333333-3333-4333-8333-333333333333";
+	assert.equal(getRealtimeSessionRoom(sessionId), `session:${sessionId}`);
+	assert.deepEqual(parseRealtimeRoom(`session:${sessionId}`), {
+		kind: "session",
+		id: sessionId,
+	});
 });
 
 test("Board awareness validates bounded state and gesture updates", () => {

--- a/packages/protocol/realtime-schema.test.ts
+++ b/packages/protocol/realtime-schema.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+	realtimeEnvelopeSchema,
+	wsClientEventSchema,
+} from "./src/realtime/schema.js";
+import { MAX_REALTIME_ROOMS_PER_REQUEST } from "./src/realtime/types.js";
+
+const sessionRoom = "session:33333333-3333-4333-8333-333333333333";
+
+test("Session rooms are valid subscription targets", () => {
+	for (const type of ["subscribe", "unsubscribe"] as const) {
+		assert.equal(
+			wsClientEventSchema.safeParse({
+				type,
+				payload: { rooms: [sessionRoom] },
+			}).success,
+			true,
+		);
+	}
+});
+
+test("subscription messages reject unbounded room lists", () => {
+	assert.equal(
+		wsClientEventSchema.safeParse({
+			type: "subscribe",
+			payload: {
+				rooms: Array.from(
+					{ length: MAX_REALTIME_ROOMS_PER_REQUEST + 1 },
+					(_, index) => `session:${index}`,
+				),
+			},
+		}).success,
+		false,
+	);
+});
+
+test("Session rooms are valid realtime envelope targets", () => {
+	assert.equal(
+		realtimeEnvelopeSchema.safeParse({
+			id: "event-1",
+			timestamp: Date.now(),
+			domain: "session",
+			type: "session.updated",
+			spaceId: "11111111-1111-4111-8111-111111111111",
+			sessionId: "33333333-3333-4333-8333-333333333333",
+			rooms: [sessionRoom],
+			payload: {},
+		}).success,
+		true,
+	);
+});

--- a/packages/protocol/src/generation/index.ts
+++ b/packages/protocol/src/generation/index.ts
@@ -38,6 +38,11 @@ export type GenerationTaskData = {
   content: GenerationContentBlock[];
   parameters?: Record<string, unknown>;
   meta?: Record<string, unknown>;
+  workId?: string;
+  /** Delegated Work authorization revalidated by the worker before billing. */
+  auth?: Record<string, unknown> | null;
+  delegatedAuthRequired?: boolean;
+  declarationScope?: "platform" | "user";
   /** Server-resolved pricing snapshot. This field is never accepted from the public request. */
   modelDiscount?: GenerationModelDiscountSnapshot;
 };

--- a/packages/protocol/src/realtime/index.ts
+++ b/packages/protocol/src/realtime/index.ts
@@ -13,11 +13,14 @@ export {
 } from "./board-awareness.js";
 export {
   AGENT_REALTIME_PATCH_CHANNEL,
+  MAX_REALTIME_ROOMS_PER_CONNECTION,
+  MAX_REALTIME_ROOMS_PER_REQUEST,
   REALTIME_OUTBOUND_CHANNEL,
   WS_BOARD_AWARENESS_CAPABILITY,
   WS_COMPACT_STREAM_CAPABILITY,
   WS_ROOM_SUBSCRIPTION_CAPABILITY,
   getRealtimeBoardRoom,
+  getRealtimeBoardSpaceRoom,
   getRealtimeSessionRoom,
   getRealtimeSpaceRoom,
   getRealtimeUserRoom,

--- a/packages/protocol/src/realtime/index.ts
+++ b/packages/protocol/src/realtime/index.ts
@@ -18,6 +18,7 @@ export {
   WS_COMPACT_STREAM_CAPABILITY,
   WS_ROOM_SUBSCRIPTION_CAPABILITY,
   getRealtimeBoardRoom,
+  getRealtimeSessionRoom,
   getRealtimeSpaceRoom,
   getRealtimeUserRoom,
   getSessionTurnPatchStreamKey,

--- a/packages/protocol/src/realtime/schema.ts
+++ b/packages/protocol/src/realtime/schema.ts
@@ -1,11 +1,16 @@
 import { z } from "zod";
 import type { ContentBlock } from "../core/content.js";
-import type { RealtimeCompactFrame, RealtimeEnvelope, RealtimeRoom } from "./types.js";
+import {
+  MAX_REALTIME_ROOMS_PER_REQUEST,
+  type RealtimeCompactFrame,
+  type RealtimeEnvelope,
+  type RealtimeRoom,
+} from "./types.js";
 import { BoardAwarenessClientPayloadSchema } from "./board-awareness.js";
 export type * from "./types.js";
 
 const contentBlockMetaSchema = z.record(z.string(), z.unknown());
-const realtimeRoomSchema = z.string().regex(/^(space|user|board):[^:]+$/);
+const realtimeRoomSchema = z.string().regex(/^(space|user|board|boardspace|session):[^:]+$/);
 
 export const contentBlockSchema = z.discriminatedUnion("type", [
   z.object({
@@ -68,14 +73,14 @@ export const wsClientEventSchema = z.discriminatedUnion("type", [
     type: z.literal("subscribe"),
     requestId: z.string().optional(),
     payload: z.object({
-      rooms: z.array(realtimeRoomSchema).min(1),
+      rooms: z.array(realtimeRoomSchema).min(1).max(MAX_REALTIME_ROOMS_PER_REQUEST),
     }),
   }),
   z.object({
     type: z.literal("unsubscribe"),
     requestId: z.string().optional(),
     payload: z.object({
-      rooms: z.array(realtimeRoomSchema).min(1),
+      rooms: z.array(realtimeRoomSchema).min(1).max(MAX_REALTIME_ROOMS_PER_REQUEST),
     }),
   }),
   z.object({

--- a/packages/protocol/src/realtime/types.ts
+++ b/packages/protocol/src/realtime/types.ts
@@ -22,21 +22,23 @@ export const AGENT_REALTIME_PATCH_CHANNEL = "pubsub:realtime:agent_patches";
 
 export type RealtimeRoom =
   | `space:${string}`
+  | `session:${string}`
   | `user:${string}`
   | `board:${string}`;
 
 export const getRealtimeSpaceRoom = (spaceId: string): RealtimeRoom => `space:${spaceId}`;
+export const getRealtimeSessionRoom = (sessionId: string): RealtimeRoom => `session:${sessionId}`;
 export const getRealtimeUserRoom = (userId: string): RealtimeRoom => `user:${userId}`;
 export const getRealtimeBoardRoom = (boardId: string): RealtimeRoom => `board:${boardId}`;
 
-export const parseRealtimeRoom = (room: string): { kind: "space" | "user" | "board"; id: string } | null => {
+export const parseRealtimeRoom = (room: string): { kind: "space" | "session" | "user" | "board"; id: string } | null => {
   const trimmed = room.trim();
   const separatorIndex = trimmed.indexOf(":");
   if (separatorIndex <= 0) return null;
   const kind = trimmed.slice(0, separatorIndex);
   const id = trimmed.slice(separatorIndex + 1).trim();
   if (!id) return null;
-  if (kind !== "space" && kind !== "user" && kind !== "board") return null;
+  if (kind !== "space" && kind !== "session" && kind !== "user" && kind !== "board") return null;
   return { kind, id };
 };
 

--- a/packages/protocol/src/realtime/types.ts
+++ b/packages/protocol/src/realtime/types.ts
@@ -19,26 +19,31 @@ export const WS_ROOM_SUBSCRIPTION_CAPABILITY = "realtime.rooms.v1";
 export const WS_BOARD_AWARENESS_CAPABILITY = "board.awareness.v1";
 export const REALTIME_OUTBOUND_CHANNEL = "pubsub:realtime:outbound";
 export const AGENT_REALTIME_PATCH_CHANNEL = "pubsub:realtime:agent_patches";
+export const MAX_REALTIME_ROOMS_PER_REQUEST = 128;
+// Account connections also retain one server-managed user room.
+export const MAX_REALTIME_ROOMS_PER_CONNECTION = MAX_REALTIME_ROOMS_PER_REQUEST + 1;
 
 export type RealtimeRoom =
   | `space:${string}`
   | `session:${string}`
   | `user:${string}`
-  | `board:${string}`;
+  | `board:${string}`
+  | `boardspace:${string}`;
 
 export const getRealtimeSpaceRoom = (spaceId: string): RealtimeRoom => `space:${spaceId}`;
 export const getRealtimeSessionRoom = (sessionId: string): RealtimeRoom => `session:${sessionId}`;
 export const getRealtimeUserRoom = (userId: string): RealtimeRoom => `user:${userId}`;
 export const getRealtimeBoardRoom = (boardId: string): RealtimeRoom => `board:${boardId}`;
+export const getRealtimeBoardSpaceRoom = (spaceId: string): RealtimeRoom => `boardspace:${spaceId}`;
 
-export const parseRealtimeRoom = (room: string): { kind: "space" | "session" | "user" | "board"; id: string } | null => {
+export const parseRealtimeRoom = (room: string): { kind: "space" | "session" | "user" | "board" | "boardspace"; id: string } | null => {
   const trimmed = room.trim();
   const separatorIndex = trimmed.indexOf(":");
   if (separatorIndex <= 0) return null;
   const kind = trimmed.slice(0, separatorIndex);
   const id = trimmed.slice(separatorIndex + 1).trim();
   if (!id) return null;
-  if (kind !== "space" && kind !== "session" && kind !== "user" && kind !== "board") return null;
+  if (kind !== "space" && kind !== "session" && kind !== "user" && kind !== "board" && kind !== "boardspace") return null;
   return { kind, id };
 };
 
@@ -156,7 +161,7 @@ export type SystemSubscribeErrorEvent = {
   requestId?: string | null;
   spaceId?: string | null;
   sessionId?: string | null;
-  payload: { rejected: Array<{ room: string; code: "BAD_ROOM" | "FORBIDDEN"; message: string }> };
+  payload: { rejected: Array<{ room: string; code: "BAD_ROOM" | "FORBIDDEN" | "ROOM_LIMIT"; message: string }> };
 };
 
 export type RealtimeSessionRecord = Pick<

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -258,8 +258,10 @@ results need viewer scopes.** A matching `session.prompt.*` grant can poll the
 viewer's own session in the current Work Space, while `session.view` is still
 required for another user's session. Likewise, `generation.create` can list and
 poll only the viewer's own generation tasks; it never exposes other task types.
-`taskrun.view` remains required for broader task access. `user.session.list`
-lists summaries only and does not grant turn content.
+`taskrun.view` remains a separate broad read permission, but it never widens a
+Work's generation-task recovery beyond tasks created by that same Work.
+`user.session.list` returns redacted summaries unless the token also has
+`session.view` in that Session's exact Space; it never grants turn content.
 
 For the complete API-to-scope mapping, initialization recipe, capability
 recipes, a full working example, and a pitfalls checklist, see the

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -253,11 +253,13 @@ Work permissions come in **two disjoint sets**:
   `generation.create`, `user.space.list`, `user.session.list`,
   `user.usage.read` — approved per-viewer via `auth.request()`.
 
-> **Read operations need work scopes. Action operations need viewer scopes.
-They never substitute for each other.** For example, `session.prompt.fullaccess`
-lets you send a prompt but does NOT let you read the reply — that needs
-`session.view` (a work scope). Similarly, `generation.create` lets you create
-a generation task, but polling its result needs `taskrun.view` (a work scope).
+> **Space-wide reads need work scopes. Viewer actions and their owner-bound
+results need viewer scopes.** A matching `session.prompt.*` grant can poll the
+viewer's own session in the current Work Space, while `session.view` is still
+required for another user's session. Likewise, `generation.create` can list and
+poll only the viewer's own generation tasks; it never exposes other task types.
+`taskrun.view` remains required for broader task access. `user.session.list`
+lists summaries only and does not grant turn content.
 
 For the complete API-to-scope mapping, initialization recipe, capability
 recipes, a full working example, and a pitfalls checklist, see the

--- a/packages/sdk/docs/work-runtime-guide.md
+++ b/packages/sdk/docs/work-runtime-guide.md
@@ -167,9 +167,9 @@ viewer action needed. These are **read** permissions.
 
 ```
 space.view       — read space config, list models
-session.view     — read sessions, turns, stream generation updates
+session.view     — read every visible session and turn in the Work's Space
 file.view        — read files / file tree
-taskrun.view     — read task run details (used by generation polling!)
+taskrun.view     — read every visible task run in the Work's Space
 ```
 
 Set via `workScopes` when creating/updating a Work.
@@ -185,19 +185,21 @@ session.prompt.readonly   — send read-only prompts (no side effects)
 session.prompt.fullaccess — send prompts with full access (write, create sessions)
 generation.create         — create generation tasks (image/video/audio)
 user.space.list           — list the viewer's spaces (account-level)
-user.session.list         — list recent sessions the viewer can view as themselves (across spaces)
+user.session.list         — list the viewer's session summaries across spaces
 user.usage.read           — read the viewer's aggregated usage
 ```
 
 ### The golden rule
 
-> **Read operations need work scopes. Action operations need viewer scopes.
-> They never substitute for each other.**
+> **Space-wide reads need work scopes. Owner-bound reads require the matching
+> viewer action grant and never apply to preview or execution principals.**
 
-`session.prompt.fullaccess` lets you **send** a prompt, but does **not** let
-you **read** the result — that needs `session.view` (a work scope).
-`generation.create` lets you **create** a generation task, but reading its
-result needs `taskrun.view` (a work scope).
+`session.prompt.fullaccess` or `session.prompt.readonly` lets the viewer send a
+prompt and poll the resulting session they own in the current Work Space.
+`user.session.list` only lists summaries; it does not grant message or turn
+content. Reading another user's session still needs `session.view`. A viewer
+can read a generation task they own while the `generation.create` grant remains
+active; `taskrun.view` is required for another user's task.
 
 ### Complete API → scope mapping
 
@@ -207,13 +209,13 @@ result needs `taskrun.view` (a work scope).
 | List models | `client.models.list()` / `listMultimodal()` | *(none — just authenticated)* | — |
 | Send a prompt (full) | `space.prompt({ accessMode: "full_access", content, ... })` | `session.prompt.fullaccess` | viewer |
 | Send a prompt (read-only) | `space.prompt({ accessMode: "read_only", content, ... })` | `session.prompt.readonly` | viewer |
-| Read turn result | `session.turns.get(turnId)` | `session.view` | work |
+| Read turn result | `session.turns.get(turnId)` | matching `session.prompt.*` grant for the viewer's own session in this Work Space; otherwise `session.view` | viewer / work |
 | Stream generation | `session.subscribeGeneration({ state, finalized })` | `session.view` | work |
 | Read file tree | `space.files.tree()` | `file.view` | work |
 | Read file content | `space.files.read(path)` | `file.view` | work |
 | Create generation task | `client.generations.create(request)` | `generation.create` | viewer |
-| **Poll generation result** | `client.generations.wait(taskRunId)` / `createAndWait()` | **`taskrun.view`** | **work** |
-| Read task run detail | `client.tasks.get(taskRunId)` | `taskrun.view` | work |
+| **Poll generation result** | `client.generations.wait(taskRunId)` / `createAndWait()` | Task owner: authenticated identity; otherwise `taskrun.view` | owner / work |
+| Read task run detail | `client.tasks.get(taskRunId)` | Task owner: authenticated identity; otherwise `taskrun.view` | owner / work |
 | List viewer's spaces | `client.spaces.list()` | `user.space.list` | viewer |
 | List viewer's sessions | `client.user.listSessions()` | `user.session.list` | viewer |
 | Read viewer's usage | `client.user.getUsage()` | `user.usage.read` | viewer |
@@ -223,16 +225,16 @@ result needs `taskrun.view` (a work scope).
 
 ### Minimal scope sets for common Work types
 
-**LLM chat Work** (send prompt + read reply):
-- workScopes: `["space.view", "session.view"]`
-- allowedViewerScopes: `["session.prompt.fullaccess"]`
+**Privacy-scoped LLM chat Work** (send prompt + poll the viewer's own reply):
+- workScopes: `["space.view"]`
+- allowedViewerScopes: `["session.prompt.fullaccess"]` (add `user.session.list` only for a history picker)
 
-**Image generation Work** (create + poll):
-- workScopes: `["space.view", "taskrun.view"]`
+**Image generation Work** (create + poll the viewer's own task):
+- workScopes: `["space.view"]`
 - allowedViewerScopes: `["generation.create"]`
 
 **LLM + image generation Work** (the demo):
-- workScopes: `["space.view", "session.view", "taskrun.view"]`
+- workScopes: `["space.view"]`
 - allowedViewerScopes: `["session.prompt.fullaccess", "generation.create"]`
 
 **File-reader Work** (static, no viewer action):
@@ -383,9 +385,11 @@ page load.
 Each recipe below shows the exact code pattern and scope requirements.
 Assume `client` and `space` are already initialized per [§4](#4-initialization-recipe).
 
-### LLM chat (`space.prompt` + `subscribeGeneration`)
+### LLM chat (`space.prompt` + owner polling or streaming)
 
-**Scopes:** viewer `session.prompt.fullaccess` (to send) + work `session.view` (to read/stream).
+**Scopes:** viewer `session.prompt.fullaccess` sends the prompt and polls the
+viewer-owned reply in the current Work Space. Add work `session.view` only to
+stream or read sessions beyond that owner boundary.
 For a read-only prompt (no side effects), use viewer `session.prompt.readonly`
 instead — but you **must** pass `accessMode: "read_only"` in the call (see the
 read-only recipe below).
@@ -411,7 +415,7 @@ const result = await space.prompt({
 const sessionId = result.session.id;
 const turnId = result.turn.id;
 
-// --- Option A: stream the reply (preferred) ---
+// --- Option A: stream the reply (requires broad Space read access) ---
 // Requires work scope: session.view
 const stop = space.session(sessionId).subscribeGeneration({
   state(event) {
@@ -434,8 +438,8 @@ const stop = space.session(sessionId).subscribeGeneration({
 });
 // Call stop() to unsubscribe when done.
 
-// --- Option B: poll for the reply (fallback) ---
-// Also requires work scope: session.view
+// --- Option B: poll the viewer-owned reply (privacy-scoped default) ---
+// Uses the active session.prompt.fullaccess viewer grant.
 async function waitForTurn(sessionId, turnId) {
   while (true) {
     const { turn } = await space.session(sessionId).turns.get(turnId);
@@ -456,15 +460,16 @@ const reply = turn.assistantText;
 
 > **Do not silently swallow `subscribeGeneration` errors.** If the work scope
 `session.view` is missing, the WebSocket subscription fails. If you catch and
-ignore it, your code silently degrades to polling — which will also 403.
-Surface the error so you can diagnose the missing scope.
+ignore it, explicitly fall back to polling the viewer-owned session with the
+matching `session.prompt.*` grant. Surface errors from both paths.
 
 #### Read-only prompt (`accessMode: "read_only"`)
 
-Use this when your Work only needs to **generate** a reply without persisting
-any side effects (no new session is written, no turn stored on the space's
-history). It requires the lighter viewer scope `session.prompt.readonly`
-instead of `session.prompt.fullaccess`.
+Use this when your Work only needs to **generate** a reply without execution
+side effects. Cohub still persists the viewer-owned session and turn so the
+reply can be polled and recovered; `read_only` limits the agent's execution
+capabilities, not conversation history. It requires the lighter viewer scope
+`session.prompt.readonly` instead of `session.prompt.fullaccess`.
 
 The critical detail: you **must** pass `accessMode: "read_only"` explicitly
 in the `space.prompt()` call. The scope you request via `auth.request` and
@@ -472,7 +477,7 @@ the `accessMode` you send must match — the backend picks the permission check
 based on `accessMode`, defaulting to `full_access` when omitted.
 
 ```js
-// 1. Request ONLY the read-only scope from a user gesture
+// 1. Request the read-only prompt scope from a user gesture
 await client.auth.request({
   scopes: ["session.prompt.readonly"],
   reason: "Generate a one-off character reply (read-only).",
@@ -481,28 +486,24 @@ await client.auth.request({
 // 2. Send the prompt with accessMode matching the granted scope
 const result = await space.prompt({
   accessMode: "read_only",   // ← required; omitting it → full_access → 403
-  sessionId: null,           // read-only prompts use a throwaway session
+  sessionId: null,           // Cohub creates a persisted viewer-owned session
   content: [{ type: "text", text: prompt }],
 });
 const sessionId = result.session.id;
 const turnId = result.turn.id;
 
-// 3. Read the reply — still needs the work scope: session.view
-const stop = space.session(sessionId).subscribeGeneration({
-  finalized: (event) => {
-    const reply = event.turn.assistantText
-      ?? (event.turn.assistantContent ?? [])
-          .filter(b => b.type === "text").map(b => b.text).join("");
-    console.log("reply:", reply);
-    stop();
-  },
-  error: (event) => console.error("stream error:", event),
-});
+// 3. Poll the viewer-owned session without a Space-wide session.view grant.
+const turn = await waitForTurn(sessionId, turnId);
+console.log("reply:", turn.assistantText);
 ```
 
 Publish the Work with:
-- workScopes: `["space.view", "session.view"]` (still needed to read the reply)
+- workScopes: `["space.view"]`
 - allowedViewerScopes: `["session.prompt.readonly"]`
+
+This privacy-scoped form can poll a session owned by the viewer. Add the broad
+`session.view` work scope only when the Work must stream or inspect sessions
+owned by other Space users.
 
 > **Scope/accessMode mismatch → 403.** Requesting `session.prompt.readonly`
 but calling `space.prompt({ content })` (no `accessMode`) fails because the
@@ -513,12 +514,13 @@ additionally granted — otherwise 403. Always keep them in sync.
 
 ### Image / media generation (`generations.createAndWait`)
 
-**Scopes:** viewer `generation.create` (to create) + work `taskrun.view` (to poll).
+**Scopes:** viewer `generation.create`. The created generation task belongs to
+the viewer, so the same authenticated identity can list and poll its full
+result. This grant never exposes non-generation task types.
 
 `createAndWait` is a convenience that calls `create` then `wait` (polls
-`GET /api/tasks/{id}`). **Both scopes are required** — `generation.create`
-for the create step, `taskrun.view` for the poll step. Missing `taskrun.view`
-is the #1 cause of "generation creates but never returns" bugs.
+`GET /api/tasks/{id}`). `taskrun.view` is needed only when reading a task owned
+by another Space user.
 
 ```js
 const result = await client.generations.createAndWait(
@@ -608,7 +610,7 @@ await client.auth.request({
 });
 const spaces = await client.spaces.list();
 
-// List sessions across all the viewer's spaces — needs user.session.list
+// List safe session summaries across all the viewer's spaces — needs user.session.list
 await client.auth.request({
   scopes: ["user.session.list"],
   reason: "List your recent sessions.",
@@ -664,7 +666,7 @@ A no-build HTML Work that tests LLM chat and image generation. This is the
 exact pattern that was verified end-to-end. Adapt it to your needs.
 
 > **Publish this Work with:**
-> - workScopes: `["space.view", "session.view", "taskrun.view"]`
+> - workScopes: `["space.view"]`
 > - allowedViewerScopes: `["session.prompt.fullaccess", "generation.create"]`
 >
 > See [§8](#8-publishing-a-work-apisdk) for the publish API call.
@@ -789,52 +791,18 @@ function extractText(blocks) {
     .join("");
 }
 
-function waitForTurn(sid, turnId, onStream) {
-  return new Promise((resolve, reject) => {
-    let done = false;
-    let stop = null;
-
-    const finish = (fn) => {
-      if (done) return;
-      done = true;
-      if (stop) try { stop(); } catch {}
-      fn();
-    };
-
-    // Primary path: stream via WebSocket (needs work scope: session.view)
-    try {
-      stop = space.session(sid).subscribeGeneration({
-        state: (event) => {
-          const text = extractText(event.state?.contentBlocks);
-          if (text) onStream?.(text);
-        },
-        finalized: (event) => finish(() => resolve(event.turn)),
-        error: (event) => finish(() =>
-          reject(new Error(event?.rawEvent?.payload?.message || "stream error"))),
-      });
-    } catch (err) {
-      console.warn("subscribeGeneration failed:", err);
+async function waitForTurn(sid, turnId, onStream) {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const { turn } = await space.session(sid).turns.get(turnId);
+    const text = turn.assistantText || extractText(turn.assistantContent);
+    if (text) onStream?.(text);
+    if (turn.status === "completed") return turn;
+    if (turn.status === "failed" || turn.status === "cancelled") {
+      throw new Error(turn.errorMessage || "failed");
     }
-
-    // Fallback: poll (also needs session.view — if missing, both paths 403)
-    const poll = async () => {
-      try {
-        const { turn } = await space.session(sid).turns.get(turnId);
-        if (turn.assistantText) onStream?.(turn.assistantText);
-        if (turn.status === "completed") finish(() => resolve(turn));
-        if (turn.status === "failed" || turn.status === "cancelled") {
-          finish(() => reject(new Error(turn.errorMessage || "failed")));
-        }
-      } catch (err) {
-        // Don't silently swallow — surface 403 (missing session.view)
-        console.error("poll error:", err);
-      }
-    };
-    const interval = setInterval(poll, 2000);
-    poll();
-    setTimeout(() => finish(() => reject(new Error("timeout"))), 120000);
-    // Note: in production, clear the interval in finish()
-  });
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+  throw new Error("timeout");
 }
 
 async function chat(text, outEl) {
@@ -917,7 +885,7 @@ $("btn-img").addEventListener("click", async () => {
     await ensureRuntime(out);
     const ok = await ensureViewerScopes(
       ["generation.create"],
-      "Image generation needs generation.create. taskrun.view comes from workScopes.",
+      "Image generation and owner-bound polling need generation.create.",
       out,
     );
     if (!ok) return;
@@ -952,25 +920,27 @@ Before publishing your Work, verify each item:
 
 - [ ] **Environment**: passed `env: "dev"` (or `"prod"`) explicitly — the SDK
   defaults to prod and browsers don't inject `ENV`.
-- [ ] **Work scopes include all read operations**: `space.view`, `session.view`
-  (for LLM reply reads), `taskrun.view` (for generation polling), `file.view`
-  (for file reads). Missing any of these → 403 on reads.
+- [ ] **Work scopes include only required Space-wide reads**: typically
+  `space.view` and, when needed, `file.view`. Add `session.view` or
+  `taskrun.view` only when the Work intentionally reads other users' data.
 - [ ] **Viewer scopes include all action operations**: `session.prompt.fullaccess`
   (or `.readonly`) for prompts, `generation.create` for generation.
 - [ ] **`session.prompt.*` scope matches `space.prompt({ accessMode })`.**
   Omitting `accessMode` defaults to `full_access`, so requesting only
   `session.prompt.readonly` and then calling `space.prompt({ content })` → 403.
   Set `accessMode: "read_only"` explicitly when using the readonly scope.
-- [ ] **`session.prompt.fullaccess` does NOT include `session.view`** — they
-  are separate. Sending a prompt succeeds but reading the reply 403s without
-  `session.view`.
-- [ ] **`generation.create` does NOT include `taskrun.view`** — creating a
-  generation task succeeds but polling the result 403s without `taskrun.view`.
+- [ ] **Owner session reads use the matching `session.prompt.*` grant** and are
+  limited to the viewer's own session in the current Work Space.
+- [ ] **`user.session.list` only lists session summaries.** It does not grant
+  message, turn, snapshot, or signed-media access.
+- [ ] **Owner generation polling checks the authenticated user**. Do not add
+  `taskrun.view` merely to poll a generation task just created by that viewer;
+  `generation.create` does not expose other task types.
 - [ ] **`auth.request()` is called from a user gesture** (button click), not
   on page load.
 - [ ] **`subscribeGeneration` errors are not silently swallowed** — if the
-  stream fails, surface it; a silent fallback to polling will also 403 if
-  `session.view` is missing.
+  stream fails without `session.view`, fall back to owner-bound polling only
+  while the matching `session.prompt.*` viewer grant remains active.
 - [ ] **Broker mode**: if the Work may be accessed standalone, pass
   `work: { brokerOrigin, workId }` and call `auth.request()` before any other
   API call (to avoid user-activation exhaustion).
@@ -995,7 +965,7 @@ await client.works.create({
   status: "published",
   targetType: "file",
   targetRef: "demo/index.html",
-  workScopes: ["space.view", "session.view", "taskrun.view"],
+  workScopes: ["space.view"],
   allowedViewerScopes: ["session.prompt.fullaccess", "generation.create"],
 });
 
@@ -1006,7 +976,7 @@ await client.works.create({
   status: "published",
   targetType: "directory",
   targetRef: "site",
-  workScopes: ["space.view", "session.view", "taskrun.view", "file.view"],
+  workScopes: ["space.view", "file.view"],
   allowedViewerScopes: ["session.prompt.fullaccess", "generation.create"],
 });
 

--- a/packages/sdk/docs/work-runtime-guide.md
+++ b/packages/sdk/docs/work-runtime-guide.md
@@ -185,7 +185,7 @@ session.prompt.readonly   — send read-only prompts (no side effects)
 session.prompt.fullaccess — send prompts with full access (write, create sessions)
 generation.create         — create generation tasks (image/video/audio)
 user.space.list           — list the viewer's spaces (account-level)
-user.session.list         — list the viewer's session summaries across spaces
+user.session.list         — list the viewer's sessions across spaces (redacted by default)
 user.usage.read           — read the viewer's aggregated usage
 ```
 
@@ -196,10 +196,12 @@ user.usage.read           — read the viewer's aggregated usage
 
 `session.prompt.fullaccess` or `session.prompt.readonly` lets the viewer send a
 prompt and poll the resulting session they own in the current Work Space.
-`user.session.list` only lists summaries; it does not grant message or turn
-content. Reading another user's session still needs `session.view`. A viewer
-can read a generation task they own while the `generation.create` grant remains
-active; `taskrun.view` is required for another user's task.
+`user.session.list` returns redacted summaries by default. A matching
+`session.view` Work scope upgrades only records in that Work's exact Space; it
+does not unlock records in any other Space or grant turn content by itself.
+Reading another user's session still needs `session.view`. A Work can read only
+generation tasks created by that same Work while its `generation.create` grant
+remains active; `taskrun.view` never widens that Work recovery boundary.
 
 ### Complete API → scope mapping
 
@@ -210,12 +212,12 @@ active; `taskrun.view` is required for another user's task.
 | Send a prompt (full) | `space.prompt({ accessMode: "full_access", content, ... })` | `session.prompt.fullaccess` | viewer |
 | Send a prompt (read-only) | `space.prompt({ accessMode: "read_only", content, ... })` | `session.prompt.readonly` | viewer |
 | Read turn result | `session.turns.get(turnId)` | matching `session.prompt.*` grant for the viewer's own session in this Work Space; otherwise `session.view` | viewer / work |
-| Stream generation | `session.subscribeGeneration({ state, finalized })` | `session.view` | work |
+| Stream generation | `session.subscribeGeneration({ state, finalized })` | matching `session.prompt.*` for a viewer-owned session; otherwise `session.view` | viewer / work |
 | Read file tree | `space.files.tree()` | `file.view` | work |
 | Read file content | `space.files.read(path)` | `file.view` | work |
 | Create generation task | `client.generations.create(request)` | `generation.create` | viewer |
-| **Poll generation result** | `client.generations.wait(taskRunId)` / `createAndWait()` | Task owner: authenticated identity; otherwise `taskrun.view` | owner / work |
-| Read task run detail | `client.tasks.get(taskRunId)` | Task owner: authenticated identity; otherwise `taskrun.view` | owner / work |
+| **Poll generation result** | `client.generations.wait(taskRunId)` / `createAndWait()` | matching `generation.create` grant and task created by this Work | viewer / work |
+| Read task run detail | `client.tasks.get(taskRunId)` | same-Work generation task + `generation.create`; non-Work Space readers use `taskrun.view` | viewer / work |
 | List viewer's spaces | `client.spaces.list()` | `user.space.list` | viewer |
 | List viewer's sessions | `client.user.listSessions()` | `user.session.list` | viewer |
 | Read viewer's usage | `client.user.getUsage()` | `user.usage.read` | viewer |
@@ -387,9 +389,9 @@ Assume `client` and `space` are already initialized per [§4](#4-initialization-
 
 ### LLM chat (`space.prompt` + owner polling or streaming)
 
-**Scopes:** viewer `session.prompt.fullaccess` sends the prompt and polls the
-viewer-owned reply in the current Work Space. Add work `session.view` only to
-stream or read sessions beyond that owner boundary.
+**Scopes:** viewer `session.prompt.fullaccess` sends the prompt and reads or
+streams the viewer-owned reply in the current Work Space. Add work
+`session.view` only to read sessions beyond that owner boundary.
 For a read-only prompt (no side effects), use viewer `session.prompt.readonly`
 instead — but you **must** pass `accessMode: "read_only"` in the call (see the
 read-only recipe below).
@@ -415,8 +417,8 @@ const result = await space.prompt({
 const sessionId = result.session.id;
 const turnId = result.turn.id;
 
-// --- Option A: stream the reply (requires broad Space read access) ---
-// Requires work scope: session.view
+// --- Option A: stream the viewer-owned reply ---
+// The matching session.prompt.fullaccess grant authorizes this Session room.
 const stop = space.session(sessionId).subscribeGeneration({
   state(event) {
     // Partial text as it streams in
@@ -458,10 +460,10 @@ const reply = turn.assistantText;
 `turn.assistantContent` (ContentBlock[] | null). Always check both —
 `assistantText` is a convenience; `assistantContent` is the source of truth.
 
-> **Do not silently swallow `subscribeGeneration` errors.** If the work scope
-`session.view` is missing, the WebSocket subscription fails. If you catch and
-ignore it, explicitly fall back to polling the viewer-owned session with the
-matching `session.prompt.*` grant. Surface errors from both paths.
+> **Do not silently swallow `subscribeGeneration` errors.** The matching
+> `session.prompt.*` grant must still be active for the viewer-owned Session
+> room. If streaming fails, explicitly fall back to owner-bound polling and
+> surface errors from both paths.
 
 #### Read-only prompt (`accessMode: "read_only"`)
 
@@ -501,26 +503,26 @@ Publish the Work with:
 - workScopes: `["space.view"]`
 - allowedViewerScopes: `["session.prompt.readonly"]`
 
-This privacy-scoped form can poll a session owned by the viewer. Add the broad
-`session.view` work scope only when the Work must stream or inspect sessions
+This privacy-scoped form can poll or stream a session owned by the viewer. Add
+the broad `session.view` work scope only when the Work must inspect sessions
 owned by other Space users.
 
 > **Scope/accessMode mismatch → 403.** Requesting `session.prompt.readonly`
 but calling `space.prompt({ content })` (no `accessMode`) fails because the
 backend defaults to `full_access` and checks `session.prompt.fullaccess`.
-Symmetrically, requesting `session.prompt.fullaccess` while passing
-`accessMode: "read_only"` also works only if `session.prompt.readonly` is
-additionally granted — otherwise 403. Always keep them in sync.
+`session.prompt.fullaccess` also satisfies a read-only prompt. Keep the requested
+scope as narrow as the behavior actually needs.
 
 ### Image / media generation (`generations.createAndWait`)
 
-**Scopes:** viewer `generation.create`. The created generation task belongs to
-the viewer, so the same authenticated identity can list and poll its full
-result. This grant never exposes non-generation task types.
+**Scopes:** viewer `generation.create`. The created generation task is tagged
+to both the viewer and the current Work, so that Work can list and poll its full
+result. This grant never exposes non-generation tasks or generation tasks from
+another Work, even for the same viewer and Space.
 
 `createAndWait` is a convenience that calls `create` then `wait` (polls
-`GET /api/tasks/{id}`). `taskrun.view` is needed only when reading a task owned
-by another Space user.
+`GET /api/tasks/{id}`). A Work cannot use `taskrun.view` to widen this recovery
+boundary; non-Work Space clients use that permission for broad task reads.
 
 ```js
 const result = await client.generations.createAndWait(
@@ -610,7 +612,8 @@ await client.auth.request({
 });
 const spaces = await client.spaces.list();
 
-// List safe session summaries across all the viewer's spaces — needs user.session.list
+// List sessions across the viewer's spaces — redacted unless this Work also
+// has session.view in the matching Space.
 await client.auth.request({
   scopes: ["user.session.list"],
   reason: "List your recent sessions.",
@@ -931,15 +934,16 @@ Before publishing your Work, verify each item:
   Set `accessMode: "read_only"` explicitly when using the readonly scope.
 - [ ] **Owner session reads use the matching `session.prompt.*` grant** and are
   limited to the viewer's own session in the current Work Space.
-- [ ] **`user.session.list` only lists session summaries.** It does not grant
-  message, turn, snapshot, or signed-media access.
+- [ ] **`user.session.list` is redacted per Session Space.** Full list records
+  require `session.view` in that exact Space; one Space scope never unlocks
+  another. The list permission does not grant turn or signed-media access.
 - [ ] **Owner generation polling checks the authenticated user**. Do not add
   `taskrun.view` merely to poll a generation task just created by that viewer;
   `generation.create` does not expose other task types.
 - [ ] **`auth.request()` is called from a user gesture** (button click), not
   on page load.
 - [ ] **`subscribeGeneration` errors are not silently swallowed** — if the
-  stream fails without `session.view`, fall back to owner-bound polling only
+  viewer-owned Session stream fails, fall back to owner-bound polling only
   while the matching `session.prompt.*` viewer grant remains active.
 - [ ] **Broker mode**: if the Work may be accessed standalone, pass
   `work: { brokerOrigin, workId }` and call `auth.request()` before any other

--- a/packages/sdk/src/apis/public-assets.ts
+++ b/packages/sdk/src/apis/public-assets.ts
@@ -49,9 +49,9 @@ export type UploadPublicAssetInput = {
 };
 
 export type UploadChatAttachmentInput = {
-  /** Optional association only; upload is user-scoped. */
+  /** Optional account association; Work uploads are always bound to the Work Space. */
   spaceId?: string;
-  /** Optional association only; upload is user-scoped. */
+  /** Optional association for an authorized prompt session. */
   sessionId?: string;
   file: Blob;
   mimeType: string;
@@ -128,7 +128,7 @@ export class PublicAssetsApi {
     return plan.asset;
   }
 
-  /** Durable public upload for any chat attachment (image or file). No space required. */
+  /** Durable viewer-scoped upload. Work sessions infer and enforce their bound Space. */
   uploadChatAttachment(input: UploadChatAttachmentInput) {
     return this.upload({
       purpose: "chat_attachment",

--- a/packages/sdk/src/apis/spaces.ts
+++ b/packages/sdk/src/apis/spaces.ts
@@ -1,6 +1,7 @@
 import type { SpacePublicEndpoints } from "@cohub/protocol/ports";
 import {
   getRealtimeBoardRoom,
+  getRealtimeBoardSpaceRoom,
   getRealtimeSessionRoom,
   getRealtimeSpaceRoom,
   type BoardAwarenessUpdatedEvent as ProtocolBoardAwarenessUpdatedEvent,
@@ -889,7 +890,10 @@ export class SpaceEventsApi {
       throw new Error("realtime transport is not configured for this client");
     }
     ensureRealtimeConnected(this.websocketClient);
-    const releaseRoom = this.websocketClient.retainRooms([getRealtimeSpaceRoom(this.spaceId)]);
+    const releaseRoom = this.websocketClient.retainRooms([
+      getRealtimeSpaceRoom(this.spaceId),
+      getRealtimeBoardSpaceRoom(this.spaceId),
+    ]);
     const offEvent = this.websocketClient.on("event", (event) => {
       if (event.spaceId !== this.spaceId) return;
       handler(event);
@@ -1479,7 +1483,6 @@ class BoardRealtimeClient {
     }
     ensureRealtimeConnected(this.websocketClient);
     const releaseRoom = this.websocketClient.retainRooms([
-      getRealtimeSpaceRoom(this.spaceId),
       getRealtimeBoardRoom(this.boardId),
     ]);
     const unsubscribe = this.websocketClient.on("event", (event) => {

--- a/packages/sdk/src/apis/spaces.ts
+++ b/packages/sdk/src/apis/spaces.ts
@@ -36,6 +36,7 @@ import type {
   SessionTurnsPaginatedResponse,
   SessionTurnSignedUrlsResponse,
   SessionRecord,
+  SessionSpaceRecord,
   SpaceAccessPolicy,
   SpaceCheckpointDetailResponse,
   SpaceCreateResponse,
@@ -702,7 +703,7 @@ export class SessionClient {
   }
 
   get(customFetch?: Fetch) {
-    return this.transport.request<{ space: SpaceRecord; session: SessionRecord }>(
+    return this.transport.request<{ space: SessionSpaceRecord; session: SessionRecord }>(
       `/api/sessions/${this.id}`,
       {
         fetch: customFetch,

--- a/packages/sdk/src/apis/spaces.ts
+++ b/packages/sdk/src/apis/spaces.ts
@@ -1,6 +1,7 @@
 import type { SpacePublicEndpoints } from "@cohub/protocol/ports";
 import {
   getRealtimeBoardRoom,
+  getRealtimeSessionRoom,
   getRealtimeSpaceRoom,
   type BoardAwarenessUpdatedEvent as ProtocolBoardAwarenessUpdatedEvent,
   type BoardPlaybackChangedEvent as ProtocolBoardPlaybackChangedEvent,
@@ -600,7 +601,7 @@ class SessionRealtimeClient {
       throw new Error("realtime transport is not configured for this client");
     }
     ensureRealtimeConnected(this.websocketClient);
-    const releaseRoom = this.websocketClient.retainRooms([getRealtimeSpaceRoom(this.spaceId)]);
+    const releaseRoom = this.websocketClient.retainRooms([getRealtimeSessionRoom(this.sessionId)]);
     const unsubscribe = this.websocketClient.on("event", (event) => {
       if (event.spaceId !== this.spaceId || event.sessionId !== this.sessionId) return;
       handlers.event?.(event);

--- a/packages/sdk/src/apis/user.ts
+++ b/packages/sdk/src/apis/user.ts
@@ -1,5 +1,5 @@
 import { HttpError, type HttpTransport, type Fetch } from "../transport.js";
-import type { LabelAssignmentRecord, LabelResourceType, MeResponse, SessionRecord, SpaceRecord, UserProfile, UserRulesResponse, UserSessionsResponse, SpaceUsageResponse } from "../types.js";
+import type { LabelAssignmentRecord, LabelResourceType, MeResponse, SessionRecord, SessionSpaceRecord, UserProfile, UserRulesResponse, UserSessionsResponse, SpaceUsageResponse } from "../types.js";
 
 export class UserApi {
   readonly labels: UserLabelsApi;
@@ -50,7 +50,7 @@ export class UserApi {
   }
 
   getSession(sessionId: string, customFetch?: Fetch) {
-    return this.transport.request<{ space: SpaceRecord; session: SessionRecord }>(
+    return this.transport.request<{ space: SessionSpaceRecord; session: SessionRecord }>(
       `/api/sessions/${sessionId}`,
       { fetch: customFetch },
     );

--- a/packages/sdk/src/session-generation-stream.ts
+++ b/packages/sdk/src/session-generation-stream.ts
@@ -1,5 +1,5 @@
 import type { ContentBlock, Usage } from "@cohub/protocol/core";
-import { getRealtimeSpaceRoom } from "@cohub/protocol/realtime/types";
+import { getRealtimeSessionRoom } from "@cohub/protocol/realtime/types";
 import type {
   MessageRecord,
   SessionTurnRecord,
@@ -447,7 +447,7 @@ export class SessionGenerationStreamClient {
     let recoveryAborted = false;
     let bufferedEvents: WebsocketEventPayload[] = [];
     let bufferedEventsReplayed = false;
-    const releaseRoom = this.websocketClient.retainRooms([getRealtimeSpaceRoom(this.spaceId)]);
+    const releaseRoom = this.websocketClient.retainRooms([getRealtimeSessionRoom(this.sessionId)]);
     const unsubscribe = this.websocketClient.on("event", (event) => {
       if (event.spaceId !== this.spaceId || event.sessionId !== this.sessionId) {
         return;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -146,14 +146,28 @@ export type SpacePresenceSnapshot = {
   updatedAt: string;
 };
 
-export type MeResponse = {
+export type AccountMeResponse = {
   uuid: string;
   profile: UserProfile;
   email: string | null;
-  principalType?: "user" | "work_session";
-  /** Space bound into a Work token; null for a normal account token. */
-  spaceId?: string | null;
+  principalType?: "user";
+  spaceId?: null;
+  /** Verified token expiry in epoch seconds. */
+  tokenExpiresAt?: number | null;
 };
+
+export type WorkViewerMeResponse = {
+  uuid: string;
+  profile: PublicUserProfile;
+  principalType: "work_session";
+  /** Space bound into the verified Work token. */
+  spaceId: string;
+  /** Verified Work token expiry in epoch seconds. */
+  tokenExpiresAt: number;
+  email?: never;
+};
+
+export type MeResponse = AccountMeResponse | WorkViewerMeResponse;
 
 export type BillingPluginStatus = {
   provider: "disabled" | "talesofai";
@@ -1034,25 +1048,28 @@ export type SpaceSessionsResponse = {
 
 export type UserSessionSpaceSummary = {
   id: string;
-  name: string;
+  name: string | null;
   slug: string | null;
   publicProfile?: SpacePublicProfile | null;
 };
 
-export type UserSessionSummary = SessionRecord & {
+export type UserSessionSummary = Omit<
+  SessionRecord,
+  "externalSessionId" | "meta" | "latestMessageText" | "lastMessageId"
+> & {
   accessLevel: "summary";
-  externalSessionId: null;
-  meta: null;
-  latestMessageText: null;
-  lastMessageId: null;
+  externalSessionId?: never;
+  meta?: never;
+  latestMessageText?: never;
+  lastMessageId?: never;
   space?: UserSessionSpaceSummary | null;
 };
 
 /** Cross-space session list item returned by `GET /api/me/sessions`. */
-export type UserSessionListItem = SessionRecord & {
-  accessLevel?: "summary";
+export type UserSessionListItem = (SessionRecord & {
+  accessLevel?: never;
   space?: UserSessionSpaceSummary | null;
-};
+}) | UserSessionSummary;
 
 export type UserSessionsResponse = {
   sessions: UserSessionListItem[];
@@ -1590,7 +1607,8 @@ export type ReferralDashboard = {
 // ─── Invitation types ───
 
 export type SpaceInvitation = {
-  token: string;
+  /** Bearer credential, present only for viewers with member.manage. */
+  token?: string;
   role: SpaceRole;
   status: "active" | "revoked" | "exhausted";
   useCount: number;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1053,15 +1053,22 @@ export type UserSessionSpaceSummary = {
   publicProfile?: SpacePublicProfile | null;
 };
 
-export type UserSessionSummary = Omit<
+export type UserSessionSummary = Pick<
   SessionRecord,
-  "externalSessionId" | "meta" | "latestMessageText" | "lastMessageId"
+  | "id"
+  | "spaceId"
+  | "userUuid"
+  | "userProfile"
+  | "participantUserUuids"
+  | "participantProfiles"
+  | "title"
+  | "source"
+  | "status"
+  | "lastMessageAt"
+  | "createdAt"
+  | "updatedAt"
 > & {
   accessLevel: "summary";
-  externalSessionId?: never;
-  meta?: never;
-  latestMessageText?: never;
-  lastMessageId?: never;
   space?: UserSessionSpaceSummary | null;
 };
 
@@ -1607,6 +1614,8 @@ export type ReferralDashboard = {
 // ─── Invitation types ───
 
 export type SpaceInvitation = {
+  /** Stable non-secret identifier suitable for rendering and reconciliation. */
+  id: string;
   /** Bearer credential, present only for viewers with member.manage. */
   token?: string;
   role: SpaceRole;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -150,6 +150,9 @@ export type MeResponse = {
   uuid: string;
   profile: UserProfile;
   email: string | null;
+  principalType?: "user" | "work_session";
+  /** Space bound into a Work token; null for a normal account token. */
+  spaceId?: string | null;
 };
 
 export type BillingPluginStatus = {
@@ -749,6 +752,17 @@ export type SpaceRecord = {
   isPinned?: boolean;
 };
 
+export type MinimalSpaceRecord = {
+  id: string;
+  name: string | null;
+  accessLevel: "minimal";
+  title?: never;
+  slug?: never;
+  publicProfile?: never;
+};
+
+export type SessionSpaceRecord = SpaceRecord | MinimalSpaceRecord;
+
 export type SpaceBootstrapSource =
   | { type: "blank" }
   | { type: "git_repo"; repoUrl?: string; ref?: string | null }
@@ -1025,8 +1039,18 @@ export type UserSessionSpaceSummary = {
   publicProfile?: SpacePublicProfile | null;
 };
 
+export type UserSessionSummary = SessionRecord & {
+  accessLevel: "summary";
+  externalSessionId: null;
+  meta: null;
+  latestMessageText: null;
+  lastMessageId: null;
+  space?: UserSessionSpaceSummary | null;
+};
+
 /** Cross-space session list item returned by `GET /api/me/sessions`. */
 export type UserSessionListItem = SessionRecord & {
+  accessLevel?: "summary";
   space?: UserSessionSpaceSummary | null;
 };
 

--- a/packages/sdk/src/websocket.ts
+++ b/packages/sdk/src/websocket.ts
@@ -1,6 +1,7 @@
 import {
   getRealtimeSpaceRoom,
   getSessionTurnPatchStreamKey,
+  MAX_REALTIME_ROOMS_PER_REQUEST,
   WS_BOARD_AWARENESS_CAPABILITY,
   WS_COMPACT_STREAM_CAPABILITY,
   WS_ROOM_SUBSCRIPTION_CAPABILITY,
@@ -239,6 +240,8 @@ export class WebsocketClient {
   private readonly compactStreamContexts = new Map<string, CompactStreamContext>();
   private readonly patchStreamBuffers = new Map<string, PatchStreamBuffer>();
   private readonly roomSubscriptions = new Map<RealtimeRoom, RoomSubscriptionState>();
+  private readonly pendingRoomRequests = new Map<string, RealtimeRoom[]>();
+  private roomRequestSequence = 0;
 
   public state: WebsocketClientState = "idle";
   public connectionId: string | null = null;
@@ -358,6 +361,7 @@ export class WebsocketClient {
         this.ws = null;
         this.compactStreamContexts.clear();
         this.patchStreamBuffers.clear();
+        this.resetPendingRoomSubscriptions();
         const closeError = new Error(formatCloseMessage(event.code, event.reason));
         this.rejectAuthWaiter(closeError);
         const retryAuthClose = event.code === AUTH_CLOSE_CODE && this.retryAuthClose;
@@ -397,6 +401,7 @@ export class WebsocketClient {
     this.retryAuthClose = false;
     this.compactStreamContexts.clear();
     this.patchStreamBuffers.clear();
+    this.pendingRoomRequests.clear();
     for (const state of this.roomSubscriptions.values()) {
       state.subscribed = false;
       state.pending = false;
@@ -499,6 +504,7 @@ export class WebsocketClient {
       if (roomsToRelease.length === 0) return;
       if (this.ws?.readyState === WebSocket.OPEN) {
         this.send({ type: "unsubscribe", payload: { rooms: roomsToRelease } });
+        this.flushRoomSubscriptions();
       }
     };
   }
@@ -560,11 +566,16 @@ export class WebsocketClient {
 
   private flushRoomSubscriptions() {
     if (this.ws?.readyState !== WebSocket.OPEN) return;
+    if (this.pendingRoomRequests.size > 0) return;
     const rooms = [...this.roomSubscriptions.entries()]
       .filter(([, state]) => state.refCount > 0 && !state.subscribed && !state.pending)
-      .map(([room]) => room);
+      .map(([room]) => room)
+      .slice(0, MAX_REALTIME_ROOMS_PER_REQUEST);
     if (rooms.length === 0) return;
-    this.send({ type: "subscribe", payload: { rooms } });
+    this.roomRequestSequence += 1;
+    const requestId = `rooms-${this.roomRequestSequence}`;
+    this.send({ type: "subscribe", requestId, payload: { rooms } });
+    this.pendingRoomRequests.set(requestId, rooms);
     for (const room of rooms) {
       const state = this.roomSubscriptions.get(room);
       if (state) state.pending = true;
@@ -572,10 +583,20 @@ export class WebsocketClient {
   }
 
   private async restoreRoomSubscriptions() {
+    this.pendingRoomRequests.clear();
     for (const state of this.roomSubscriptions.values()) {
       state.subscribed = false;
+      state.pending = false;
     }
     this.flushRoomSubscriptions();
+  }
+
+  private resetPendingRoomSubscriptions() {
+    this.pendingRoomRequests.clear();
+    for (const state of this.roomSubscriptions.values()) {
+      state.subscribed = false;
+      state.pending = false;
+    }
   }
 
   private createAuthWaiter() {
@@ -662,6 +683,15 @@ export class WebsocketClient {
           ? envelope.payload.code
           : undefined;
         const error = new WebsocketAuthError(message);
+        const requestId = envelope.requestId ?? null;
+        const pendingRooms = requestId ? this.pendingRoomRequests.get(requestId) : undefined;
+        if (requestId && pendingRooms) {
+          this.pendingRoomRequests.delete(requestId);
+          for (const room of pendingRooms) {
+            const state = this.roomSubscriptions.get(room);
+            if (state) state.pending = false;
+          }
+        }
         this.rejectAuthWaiter(error);
         this.emit("serverError", {
           code,
@@ -716,6 +746,7 @@ export class WebsocketClient {
       case "system.subscribe.ok": {
         const payload = envelope.payload as Record<string, unknown>;
         const rooms = normalizeRealtimeRooms(Array.isArray(payload.rooms) ? payload.rooms.filter((room): room is string => typeof room === "string") : []);
+        if (envelope.requestId) this.pendingRoomRequests.delete(envelope.requestId);
         for (const room of rooms) {
           const state = this.roomSubscriptions.get(room);
           if (state) {
@@ -725,6 +756,7 @@ export class WebsocketClient {
         }
         this.emit("subscribed", { rooms, requestId: envelope.requestId ?? null });
         this.emit("event", envelope);
+        this.flushRoomSubscriptions();
         return;
       }
       case "system.subscribe.error": {
@@ -739,13 +771,22 @@ export class WebsocketClient {
               }))
               .filter((entry) => entry.room)
           : [];
+        if (envelope.requestId) this.pendingRoomRequests.delete(envelope.requestId);
+        let reachedRoomLimit = false;
         for (const item of rejected) {
           const room = normalizeRealtimeRooms([item.room])[0];
           if (!room) continue;
-          this.roomSubscriptions.delete(room);
+          const state = this.roomSubscriptions.get(room);
+          if (item.code === "ROOM_LIMIT") {
+            reachedRoomLimit = true;
+            if (state) state.pending = false;
+          } else {
+            this.roomSubscriptions.delete(room);
+          }
         }
         this.emit("subscribeError", { rejected, requestId: envelope.requestId ?? null });
         this.emit("event", envelope);
+        if (!reachedRoomLimit) this.flushRoomSubscriptions();
         return;
       }
       case "system.ack.ok": {

--- a/packages/sdk/tests/board-client.test.ts
+++ b/packages/sdk/tests/board-client.test.ts
@@ -86,7 +86,7 @@ test("Board realtime subscriptions isolate events by space and Board", () => {
 		state: "open",
 		connectionId: "connection-self",
 		retainRooms(rooms: string[]) {
-			assert.deepEqual(rooms, ["space:space-1", "board:board-1"]);
+			assert.deepEqual(rooms, ["board:board-1"]);
 			return () => {
 				released += 1;
 			};

--- a/packages/sdk/tests/space-events.test.ts
+++ b/packages/sdk/tests/space-events.test.ts
@@ -7,13 +7,13 @@ import type {
 	WebsocketEventPayload,
 } from "../src/websocket.js";
 
-test("SpaceEventsApi routes published Work versions for the selected Space", () => {
+test("SpaceEventsApi retains aggregate rooms and routes Space events", () => {
 	let emit: ((event: WebsocketEventPayload) => void) | null = null;
 	let released = 0;
 	const websocket = {
 		state: "open",
 		retainRooms(rooms: string[]) {
-			assert.deepEqual(rooms, ["space:space-1"]);
+			assert.deepEqual(rooms, ["space:space-1", "boardspace:space-1"]);
 			return () => {
 				released += 1;
 			};
@@ -43,6 +43,12 @@ test("SpaceEventsApi routes published Work versions for the selected Space", () 
 	publish({
 		spaceId: "space-1",
 		type: "work.version.published",
+		payload: {},
+	} as WebsocketEventPayload);
+	publish({
+		spaceId: "space-1",
+		sessionId: "session-1",
+		type: "session.turn.patch",
 		payload: {},
 	} as WebsocketEventPayload);
 

--- a/packages/sdk/tests/space-events.test.ts
+++ b/packages/sdk/tests/space-events.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { SpaceEventsApi } from "../src/apis/spaces.js";
+import { SessionClient, SpaceEventsApi } from "../src/apis/spaces.js";
+import { HttpTransport } from "../src/transport.js";
 import type {
 	WebsocketClient,
 	WebsocketEventPayload,
@@ -46,6 +47,31 @@ test("SpaceEventsApi routes published Work versions for the selected Space", () 
 	} as WebsocketEventPayload);
 
 	assert.deepEqual(received, ["work.version.published"]);
+	stop();
+	assert.equal(released, 1);
+});
+
+test("Session realtime uses an owner-authorized Session room", () => {
+	let released = 0;
+	const websocket = {
+		state: "open",
+		retainRooms(rooms: string[]) {
+			assert.deepEqual(rooms, ["session:session-1"]);
+			return () => {
+				released += 1;
+			};
+		},
+		on() {
+			return () => undefined;
+		},
+	} as unknown as WebsocketClient;
+	const session = new SessionClient(
+		"space-1",
+		"session-1",
+		new HttpTransport(),
+		websocket,
+	);
+	const stop = session.realtime.subscribe({});
 	stop();
 	assert.equal(released, 1);
 });

--- a/packages/sdk/tests/websocket-reconnect.test.ts
+++ b/packages/sdk/tests/websocket-reconnect.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { setTimeout as delay } from "node:timers/promises";
 import { test } from "node:test";
+import { MAX_REALTIME_ROOMS_PER_REQUEST } from "@cohub/protocol/realtime";
 import { WebsocketClient, type WebSocketLike } from "../src/websocket.js";
 
 type CloseSnapshot = { code: number; reason: string; willReconnect: boolean };
@@ -151,5 +152,64 @@ test("stops after a forced authentication retry is rejected", async () => {
   assert.equal(client.state, "closed");
 
   release();
+  await client.disconnect();
+});
+
+test("batches room subscriptions and clears pending rooms after a request error", async () => {
+  FakeWebSocket.instances = [];
+  const client = new WebsocketClient({
+    url: "ws://localhost",
+    autoReconnect: false,
+    getAccessToken: () => "token",
+    WebSocketImpl: FakeWebSocket,
+  });
+  const rooms = Array.from(
+    { length: MAX_REALTIME_ROOMS_PER_REQUEST + 2 },
+    (_, index) => `session:session-${index}`,
+  );
+  const releaseRooms = client.subscribeRooms(rooms);
+  assert.equal((client as unknown as { roomSubscriptions: Map<string, unknown> }).roomSubscriptions.size, rooms.length);
+  const socket = FakeWebSocket.instances[0];
+  assert.ok(socket);
+  socket.open();
+  await waitFor(() => sentTypes(socket).includes("auth"), "expected auth request");
+  socket.receive(authOk("connection-batches"));
+
+  const subscriptions = () => socket.sent
+    .map((raw) => JSON.parse(raw) as { type: string; requestId?: string; payload?: { rooms?: string[] } })
+    .filter((event) => event.type === "subscribe");
+  await waitFor(() => subscriptions().length === 1, "expected first subscription batch");
+  const first = subscriptions()[0];
+  assert.equal(first?.payload?.rooms?.length, MAX_REALTIME_ROOMS_PER_REQUEST);
+  socket.receive({
+    id: "subscribe-ok",
+    timestamp: Date.now(),
+    domain: "system",
+    type: "system.subscribe.ok",
+    requestId: first?.requestId,
+    payload: { rooms: first?.payload?.rooms ?? [] },
+  });
+
+  await waitFor(() => subscriptions().length === 2, "expected second subscription batch");
+  const second = subscriptions()[1];
+  assert.equal(second?.payload?.rooms?.length, 2);
+  socket.receive({
+    id: "subscribe-error",
+    timestamp: Date.now(),
+    domain: "system",
+    type: "system.request.error",
+    requestId: second?.requestId,
+    payload: { code: "BAD_REQUEST", message: "room limit" },
+  });
+
+  const releaseExtra = client.subscribeSpace("after-limit");
+  await waitFor(() => subscriptions().length === 3, "expected failed rooms to become retryable");
+  assert.deepEqual(subscriptions()[2]?.payload?.rooms, [
+    ...rooms.slice(MAX_REALTIME_ROOMS_PER_REQUEST),
+    "space:after-limit",
+  ]);
+
+  releaseExtra();
+  releaseRooms();
   await client.disconnect();
 });


### PR DESCRIPTION
## Summary\n- bind Work recovery, realtime rooms, and viewer identity to the authorized user and Space\n- harden invitation concurrency, scheduled auth, WebSocket limits, and cross-store recovery\n- preserve policy-based realtime access while preventing scoped-principal escalation\n\n## Verification\n- pnpm lint\n- PUBLIC_COHUB_ENV=dev PUBLIC_API_ORIGIN=http://localhost:8787 PUBLIC_GATEWAY_ORIGIN=http://localhost:8788 pnpm typecheck\n- API 143 tests; Agent 18 tests; Gateway 12 tests; SDK 140 tests; Protocol 20 tests\n- full workspace test is blocked only by the unavailable private @talesofai-billing/sdk