### PR TITLE
[codex] add MiniMax H3 generation declaration

### DIFF
--- a/.changeset/bright-h3-audio.md
+++ b/.changeset/bright-h3-audio.md
@@ -1,0 +1,5 @@
+---
+"@neta-art/cohub-cli": patch
+---
+
+Support the `reference_audio` role used by MiniMax H3 generation requests.

--- a/docs/examples/generations/minimax-h3.yaml
+++ b/docs/examples/generations/minimax-h3.yaml
@@ -1,0 +1,115 @@
+schema: neta.generation.model.v1
+model: MiniMax-H3
+title: MiniMax H3
+description: MiniMax H3 video generation with text, frame, and multimodal reference inputs.
+adapter:
+  type: minimax.h3VideoGenerations
+content:
+  input:
+    - type: text
+      required: true
+      min: 1
+      max: 16
+      merge: newline
+      description: Video prompt.
+    - type: image
+      required: false
+      max: 9
+      sources:
+        - url
+      roles:
+        - first_frame
+        - last_frame
+        - reference_image
+      roleRequired: true
+      description: Public URL image input. Use frame roles for transitions or reference_image for subject/style references.
+    - type: video
+      required: false
+      max: 3
+      sources:
+        - url
+      roles:
+        - reference_video
+      roleRequired: true
+      description: Public URL reference video.
+    - type: audio
+      required: false
+      max: 3
+      sources:
+        - url
+      roles:
+        - reference_audio
+      roleRequired: true
+      description: Public URL reference audio. Requires at least one reference image or video.
+parameters:
+  duration:
+    type: integer
+    optional: true
+    default: 5
+    min: 4
+    max: 15
+    description: Video duration in seconds.
+  resolution:
+    type: string
+    optional: true
+    default: 768P
+    enum: [768P, 2K]
+    description: Output resolution.
+  ratio:
+    type: string
+    optional: true
+    default: "16:9"
+    enum: [adaptive, "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"]
+    description: Output aspect ratio. Frame and reference modes use adaptive automatically.
+  aigc_watermark:
+    type: boolean
+    optional: true
+    default: false
+    description: Add an AIGC watermark to the output.
+  poll_interval:
+    type: integer
+    optional: true
+    default: 2
+    min: 1
+    max: 30
+    description: Seconds between task status checks.
+  max_wait:
+    type: integer
+    optional: true
+    default: 600
+    min: 30
+    max: 1800
+    description: Maximum seconds to wait for task completion.
+examples:
+  - title: Text to video
+    request:
+      model: MiniMax-H3
+      content:
+        - type: text
+          text: a cinematic tracking shot through a rain-soaked neon market
+      parameters:
+        duration: 5
+        resolution: 768P
+        ratio: "16:9"
+  - title: First and last frame transition
+    request:
+      model: MiniMax-H3
+      content:
+        - type: text
+          text: create a smooth transition from the opening frame to the closing frame
+        - type: image
+          source:
+            type: url
+            url: https://example.com/start.png
+          meta:
+            role: first_frame
+        - type: image
+          source:
+            type: url
+            url: https://example.com/end.png
+          meta:
+            role: last_frame
+      parameters:
+        duration: 8
+        resolution: 2K
+        ratio: adaptive

--- a/docs/generations.md
+++ b/docs/generations.md
@@ -164,6 +164,7 @@ See the full examples:
 - [`docs/examples/generations/gemini-3.1-flash-image-preview.yaml`](./examples/generations/gemini-3.1-flash-image-preview.yaml)
 - [`docs/examples/generations/seedance-2-0-fast.yaml`](./examples/generations/seedance-2-0-fast.yaml)
 - [`docs/examples/generations/seedance-2-0.yaml`](./examples/generations/seedance-2-0.yaml)
+- [`docs/examples/generations/minimax-h3.yaml`](./examples/generations/minimax-h3.yaml)
 - [`docs/examples/generations/suno_music.yaml`](./examples/generations/suno_music.yaml)
 
 ## CLI
@@ -198,6 +199,8 @@ cohub generate "smoothly transition from the first frame to the last frame" \
   --image last_frame=https://example.com/last.png \
   --param duration=5
 
+cohub generate "create a smooth transition from the opening frame to the closing frame" --model MiniMax-H3 --image first_frame=https://example.com/start.png --image last_frame=https://example.com/end.png --param duration=8 --param resolution=2K
+
 cohub generate "keep the character identity from all reference images" \
   --model seedance-2-0-fast \
   --image reference_image=https://example.com/reference-1.png \
@@ -214,4 +217,4 @@ cohub generate "write a hopeful chorus about sunrise after a storm" \
   --param operation=lyrics
 ```
 
-Role-qualified media values add `meta.role` to that content block. Repeat `--image reference_image=...` for multiple reference images. Seedance role-qualified media should use public URL inputs. Do not mix first/last frame roles with reference roles in one request.
+Role-qualified media values add `meta.role` to that content block. Repeat `--image reference_image=...` for multiple reference images, or use `--audio reference_audio=...` for MiniMax H3 reference audio. Seedance and MiniMax H3 role-qualified media should use public URL inputs. Do not mix first/last frame roles with reference roles in one request.

--- a/packages/cli/src/commands/generations.ts
+++ b/packages/cli/src/commands/generations.ts
@@ -18,12 +18,12 @@ type GenerationSource =
 type MediaInputType = "image" | "video" | "audio";
 
 const frameMediaRoles = new Set(["first_frame", "last_frame"]);
-const referenceMediaRoles = new Set(["reference_image", "reference_video"]);
+const referenceMediaRoles = new Set(["reference_image", "reference_video", "reference_audio"]);
 
 const rolesByMediaType: Record<MediaInputType, ReadonlySet<string>> = {
   image: new Set([...frameMediaRoles, "reference_image"]),
   video: new Set(["reference_video"]),
-  audio: new Set(),
+  audio: new Set(["reference_audio"]),
 };
 
 const mediaRoles = new Set([...frameMediaRoles, ...referenceMediaRoles]);
@@ -109,7 +109,7 @@ function validateMediaRoleModes(content: GenerationContentBlock[]): void {
   if (hasFrameRole && hasReferenceRole) {
     error(
       "Invalid media role mix",
-      "Use first_frame/last_frame or reference_image/reference_video, not both.",
+      "Use first_frame/last_frame or reference_image/reference_video/reference_audio, not both.",
     );
   }
 }
@@ -268,7 +268,12 @@ export function registerGenerations(program: Command): void {
       collect,
       [],
     )
-    .option("--audio <path-or-url>", "Audio input file path or URL; repeatable", collect, [])
+    .option(
+      "--audio <path-or-url>",
+      "Audio input file path or URL; prefix with reference_audio= when needed; repeatable",
+      collect,
+      [],
+    )
     .option("--param <key=value>", "Generation parameter; repeatable, values may be JSON/number/boolean", collect, [])
     .option("--parameters <json>", "Generation parameters as a JSON object")
     .option("--meta <json>", "Meta as a JSON object")

--- a/skills/cohub-generate/SKILL.md
+++ b/skills/cohub-generate/SKILL.md
@@ -70,7 +70,7 @@ cohub generate "keep these characters consistent" \
   --image reference_image=https://example.com/b.png
 ```
 
-Roles include `first_frame`, `last_frame`, `reference_image`, and `reference_video`. Check `models show` for what a model accepts.
+Roles include `first_frame`, `last_frame`, `reference_image`, `reference_video`, and `reference_audio`. Check `models show` for what a model accepts.
 
 Pass generation parameters with `--param key=value` (repeatable; JSON, number, or boolean values) or `--parameters '<json>'`:
 
@@ -128,4 +128,3 @@ cohub generate "<edit instruction>" \
 ```
 
 For less common options, use `cohub generate -h`.
-


### PR DESCRIPTION
## Summary

- add the Cohub `MiniMax-H3` generation declaration using `minimax.h3VideoGenerations`
- document text, first/last frame, image/video/audio reference inputs and H3 parameters
- allow the CLI to pass `reference_audio` roles and document the role

## Dependency gate

This declaration requires `@neta-art/generation` 0.1.19, which is being prepared in [generation-sdk PR #28](https://github.com/talesofai/generation-sdk/pull/28). The current Cohub lockfile intentionally remains on 0.1.18 until that package is published; do not deploy the declaration before the adapter release is available.

## Validation

- MiniMax H3 YAML parsed successfully with the installed generation declaration parser
- `packages/protocol` and `packages/infra` build
- Cohub CLI typecheck and build
- Biome check on the changed CLI file
- full web typecheck is currently blocked by existing missing `PUBLIC_*` Svelte env declarations on this checkout