### PR TITLE
[codex] fix: align Seedance ratio declarations

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -34,7 +34,7 @@
     "@hono/node-server": "2.0.9",
     "@hono/otel": "^1.1.2",
     "@kubernetes/client-node": "^1.4.0",
-    "@neta-art/generation": "^0.1.18",
+    "@neta-art/generation": "^0.1.19",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
     "@opentelemetry/instrumentation": "^0.220.0",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -26,7 +26,7 @@
     "@cohub/protocol": "workspace:*",
     "@cohub/sandbox-controller": "workspace:*",
     "@kubernetes/client-node": "^1.4.0",
-    "@neta-art/generation": "^0.1.18",
+    "@neta-art/generation": "^0.1.19",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
     "@opentelemetry/instrumentation": "^0.220.0",

--- a/docs/examples/generations/seedance-2-0-fast.yaml
+++ b/docs/examples/generations/seedance-2-0-fast.yaml
@@ -33,12 +33,17 @@ parameters:
     default: 720p
     enum: [480p, 720p]
     description: Output video resolution.
-  aspect_ratio:
+  ratio:
     type: string
     optional: true
     default: "16:9"
-    enum: ["16:9", "9:16", "1:1", "4:3", "3:2", "2:3", "3:4", "21:9", adaptive]
-    description: Output aspect ratio. Use adaptive to let the model choose.
+    enum: ["16:9", "9:16"]
+    description: Supported output aspect ratios are 16:9 and 9:16.
+  aspect_ratio:
+    type: string
+    optional: true
+    enum: ["16:9", "9:16"]
+    description: Deprecated compatibility alias for ratio. Use ratio.
   fps:
     type: integer
     optional: true
@@ -94,4 +99,4 @@ examples:
       parameters:
         duration: 5
         resolution: 720p
-        aspect_ratio: "16:9"
+        ratio: "16:9"

--- a/docs/examples/generations/seedance-2-0.yaml
+++ b/docs/examples/generations/seedance-2-0.yaml
@@ -33,12 +33,17 @@ parameters:
     default: 1080p
     enum: [480p, 720p, 1080p, 2K]
     description: Output video resolution.
-  aspect_ratio:
+  ratio:
     type: string
     optional: true
     default: "16:9"
-    enum: ["16:9", "9:16", "1:1", "4:3", "3:2", "2:3", "3:4", "21:9", adaptive]
-    description: Output aspect ratio. Use adaptive to let the model choose.
+    enum: ["16:9", "9:16"]
+    description: Supported output aspect ratios are 16:9 and 9:16.
+  aspect_ratio:
+    type: string
+    optional: true
+    enum: ["16:9", "9:16"]
+    description: Deprecated compatibility alias for ratio. Use ratio.
   fps:
     type: integer
     optional: true
@@ -94,4 +99,4 @@ examples:
       parameters:
         duration: 5
         resolution: 1080p
-        aspect_ratio: "16:9"
+        ratio: "16:9"

--- a/docs/generations.md
+++ b/docs/generations.md
@@ -121,6 +121,8 @@ Generation declarations live in:
 
 Platform declarations are loaded from `platform/.cohub/generations`, and user declarations from `users/<userId>/.cohub/generations`. User declarations override platform declarations with the same `model`.
 
+Seedance 2.0 and Seedance 2.0 Fast accept `ratio: "16:9"` or `ratio: "9:16"`. The legacy `aspect_ratio` parameter remains accepted as a compatibility alias and is normalized to `ratio`; new requests and declarations should use `ratio`.
+
 Declarations use `neta.generation.model.v1`. Adapter credentials and provider base URLs are not stored in model declarations. Worker execution uses `NETA_ROUTER_API_KEY`, while provider routing defaults are handled by `@neta-art/generation`.
 
 Minimal shape:
@@ -190,7 +192,8 @@ cohub generate "a vibrant infographic explaining photosynthesis" \
 cohub generate "a cat playing piano in a cozy jazz club" \
   --model seedance-2-0-fast \
   --param duration=5 \
-  --param resolution=720p
+  --param resolution=720p \
+  --param ratio=16:9
 
 cohub generate "smoothly transition from the first frame to the last frame" \
   --model seedance-2-0-fast \

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@neta-art/cohub": "workspace:*",
-    "@neta-art/generation": "^0.1.18",
+    "@neta-art/generation": "^0.1.19",
     "commander": "^15.0.0",
     "pixi.js": "^8.19.0",
     "sharp": "^0.35.3"

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -89,7 +89,7 @@
   "dependencies": {
     "@cohub/protocol": "workspace:*",
     "@kubiks/otel-drizzle": "^2.1.0",
-    "@neta-art/generation": "^0.1.18",
+    "@neta-art/generation": "^0.1.19",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
     "@opentelemetry/instrumentation": "^0.220.0",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -101,7 +101,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@neta-art/generation": "^0.1.18",
+    "@neta-art/generation": "^0.1.19",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,8 +176,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       '@neta-art/generation':
-        specifier: ^0.1.18
-        version: 0.1.18
+        specifier: ^0.1.19
+        version: 0.1.19
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -528,8 +528,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       '@neta-art/generation':
-        specifier: ^0.1.18
-        version: 0.1.18
+        specifier: ^0.1.19
+        version: 0.1.19
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -618,8 +618,8 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       '@neta-art/generation':
-        specifier: ^0.1.18
-        version: 0.1.18
+        specifier: ^0.1.19
+        version: 0.1.19
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -707,8 +707,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260529.1)(@opentelemetry/api@1.9.1)(postgres@3.4.9))
       '@neta-art/generation':
-        specifier: ^0.1.18
-        version: 0.1.18
+        specifier: ^0.1.19
+        version: 0.1.19
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -762,8 +762,8 @@ importers:
   packages/protocol:
     dependencies:
       '@neta-art/generation':
-        specifier: ^0.1.18
-        version: 0.1.18
+        specifier: ^0.1.19
+        version: 0.1.19
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -2996,8 +2996,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@neta-art/generation@0.1.18':
-    resolution: {integrity: sha512-MdtqnC8L/dHBu4CuidGav0fZ9husNF1phD05DpYxVkIOmGdEsSGougnomQ4CieHAExb3hrTfImiReEu4iXRC6A==}
+  '@neta-art/generation@0.1.19':
+    resolution: {integrity: sha512-EuPBxFp19KAmtbJ+R8MzWcPVrs0KlOVSEermdyEvChBvZMB0OVcJSYbDa4sfiBKYeNhPLy6B25Df3xgLleixQA==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -9297,7 +9297,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@neta-art/generation@0.1.18':
+  '@neta-art/generation@0.1.19':
     dependencies:
       yaml: 2.9.0
 


### PR DESCRIPTION
## Summary

- Align the Cohub Seedance examples and generation dependency contract with the provider-supported `16:9` and `9:16` ratios.
- Keep `aspect_ratio` as an optional deprecated compatibility alias while making `ratio` canonical.
- Update all five Cohub packages and the lockfile to `@neta-art/generation` `0.1.19`.

## Root cause

Platform documentation and runtime clients advertised unsupported Seedance ratios, allowing invalid values to reach GoToken and fail with HTTP 400.

## Checks

- YAML declarations validated against the new ratio contract.
- Runtime platform Space declaration verified separately after checkpoint publication.

## Dependency

This PR depends on publishing `@neta-art/generation@0.1.19` from the Generation SDK change. The package is not available in the registry yet, so a frozen install will remain blocked until that release exists.