### PR TITLE
fix(web): allow pointer lock on work pages

### DIFF
--- a/apps/web/src/lib/components/work/WorkSurface.svelte
+++ b/apps/web/src/lib/components/work/WorkSurface.svelte
@@ -116,8 +116,9 @@ const framePreconnectOrigin = $derived.by(() => {
 	if (!frameOrigin || frameOrigin === page.url.origin) return null;
 	return frameOrigin;
 });
-const frameSandbox =
-	"allow-scripts allow-same-origin allow-forms allow-popups allow-downloads allow-modals";
+const frameSandbox = $derived(
+	`allow-scripts allow-same-origin allow-forms allow-popups allow-downloads allow-modals${isBackground ? "" : " allow-pointer-lock"}`,
+);
 const checkoutState = $derived(readWorkCheckoutState(page.url));
 
 // `work` and `isBackground` are constant for the lifetime of this surface


### PR DESCRIPTION
## Why

Published web and port Works are rendered inside a sandboxed iframe. Without the `allow-pointer-lock` sandbox token, first-person Works cannot enter Pointer Lock mode even when `requestPointerLock()` is triggered by a direct user gesture.

## Summary

- allow page-mode Work surfaces to request Pointer Lock
- keep background-mode Work surfaces restricted
- preserve all existing iframe sandbox permissions and restrictions
- avoid adding the unsupported `allow="pointer-lock"` Permissions Policy directive

## Validation

- `corepack pnpm --filter web run lint` — 629 files checked
- `corepack pnpm --filter web run typecheck` with `.env.example` values — 0 errors and 0 warnings
- `git diff --check origin/main..HEAD`