### PR TITLE
fix(auth): coordinate concurrent token refreshes

### DIFF
--- a/.changeset/calm-tokens-refresh.md
+++ b/.changeset/calm-tokens-refresh.md
@@ -1,0 +1,5 @@
+---
+"@neta-art/cohub": patch
+---
+
+Deduplicate concurrent access-token refreshes and identify stale unauthorized requests so clients can preserve a newer session.

--- a/apps/web/src/lib/auth-redirect.ts
+++ b/apps/web/src/lib/auth-redirect.ts
@@ -1,10 +1,12 @@
-import { HttpError } from "@neta-art/cohub";
+import { HttpError, matchesUnauthorizedErrorToken } from "@neta-art/cohub";
 import {
 	clearAuthJustCompleted,
 	clearAuthToken,
 	clearBrokenAuthSession,
+	getAuthSessionSnapshot,
 	hasRecentAuthCompletion,
 	sanitizeRedirectPath,
+	signInAfterUnauthorized,
 	signInWithRedirectPath,
 } from "$lib/auth";
 
@@ -15,7 +17,26 @@ export const getCurrentRedirectPath = () => {
 	);
 };
 
-let signInRedirectPromise: Promise<void> | null = null;
+type SignInRedirectOptions = {
+	clearSession?: boolean;
+	expectedGeneration?: number;
+	rejectedToken?: string | null;
+};
+
+type SignInRedirectAttempt = {
+	options: SignInRedirectOptions;
+	promise: Promise<void>;
+};
+
+let signInRedirectAttempt: SignInRedirectAttempt | null = null;
+
+const isSameRedirectAttempt = (
+	left: SignInRedirectOptions,
+	right: SignInRedirectOptions,
+) =>
+	Boolean(left.clearSession) === Boolean(right.clearSession) &&
+	left.expectedGeneration === right.expectedGeneration &&
+	left.rejectedToken === right.rejectedToken;
 
 /**
  * Start OAuth sign-in. Guards against silent SSO loops after a just-completed
@@ -24,11 +45,22 @@ let signInRedirectPromise: Promise<void> | null = null;
  */
 export const redirectToSignIn = async (
 	redirectPath = getCurrentRedirectPath(),
-	options?: { clearSession?: boolean },
-) => {
-	if (signInRedirectPromise) return signInRedirectPromise;
+	options: SignInRedirectOptions = {},
+): Promise<void> => {
+	const activeAttempt = signInRedirectAttempt;
+	if (activeAttempt) {
+		if (isSameRedirectAttempt(activeAttempt.options, options)) {
+			return activeAttempt.promise;
+		}
+		try {
+			await activeAttempt.promise;
+		} catch {
+			// A different session guard still needs its own attempt.
+		}
+		return redirectToSignIn(redirectPath, options);
+	}
 
-	signInRedirectPromise = (async () => {
+	const promise = (async () => {
 		const safePath = sanitizeRedirectPath(redirectPath);
 
 		// After callback, another 401 is almost always a broken/misconfigured
@@ -36,25 +68,36 @@ export const redirectToSignIn = async (
 		// Always hard-navigate home so in-memory stores drop with the page,
 		// even when already on "/" (common post-callback destination).
 		if (hasRecentAuthCompletion()) {
+			const cleared = await clearBrokenAuthSession({
+				expectedGeneration: options.expectedGeneration,
+				rejectedToken: options.rejectedToken,
+			});
+			if (!cleared) return;
 			clearAuthJustCompleted();
-			await clearBrokenAuthSession();
 			if (typeof window !== "undefined") {
 				window.location.replace("/");
 			}
 			return;
 		}
 
-		if (options?.clearSession) {
-			await clearBrokenAuthSession();
+		if (options.clearSession) {
+			const started = await signInAfterUnauthorized(safePath, {
+				expectedGeneration: options.expectedGeneration,
+				rejectedToken: options.rejectedToken,
+			});
+			if (!started) return;
 		} else {
 			clearAuthToken();
+			await signInWithRedirectPath(safePath);
 		}
-		await signInWithRedirectPath(safePath);
 	})().finally(() => {
-		signInRedirectPromise = null;
+		if (signInRedirectAttempt?.promise === promise) {
+			signInRedirectAttempt = null;
+		}
 	});
+	signInRedirectAttempt = { options, promise };
 
-	return signInRedirectPromise;
+	return promise;
 };
 
 export const handleUnauthorizedError = async (
@@ -62,6 +105,25 @@ export const handleUnauthorizedError = async (
 	redirectPath?: string,
 ): Promise<boolean> => {
 	if (!(error instanceof HttpError) || error.status !== 401) return false;
-	await redirectToSignIn(redirectPath, { clearSession: true });
+	// HttpTransport's configured handler already performed guarded cleanup and
+	// redirect. Do not run an unguarded second cleanup from the page catch path.
+	if (error.unauthorizedHandled) return true;
+	const current = getAuthSessionSnapshot();
+	const rejectedGeneration =
+		typeof error.authSessionVersion === "number"
+			? error.authSessionVersion
+			: current.generation;
+	if (current.generation !== rejectedGeneration) return true;
+	const tokenMatches = matchesUnauthorizedErrorToken(error, current.token);
+	if (tokenMatches === false) return true;
+	await redirectToSignIn(redirectPath, {
+		clearSession: true,
+		...(tokenMatches
+			? {
+					expectedGeneration: rejectedGeneration,
+					rejectedToken: current.token,
+				}
+			: {}),
+	});
 	return true;
 };

--- a/apps/web/src/lib/auth-refresh-coordinator.ts
+++ b/apps/web/src/lib/auth-refresh-coordinator.ts
@@ -1,0 +1,193 @@
+export type AuthSessionSnapshot = {
+	generation: number;
+	attempt: number;
+	token: string | null;
+	updatedAt: number;
+	lastResolutionSucceeded: boolean;
+};
+
+export type AuthTokenRequestOptions = {
+	forceRefresh?: boolean;
+	rejectedToken?: string | null;
+};
+
+export type ClearBrokenSessionOptions = {
+	expectedGeneration?: number;
+	rejectedToken?: string | null;
+};
+
+type AuthSessionState = {
+	read(): AuthSessionSnapshot;
+	commitResolution(token: string | null, forceRefresh: boolean): void;
+	clear(): void;
+};
+
+type AuthRefreshLock = {
+	runExclusive<T>(task: () => Promise<T>): Promise<T>;
+};
+
+type AuthRefreshCoordinatorOptions = {
+	state: AuthSessionState;
+	lock: AuthRefreshLock;
+	isReusable: (snapshot: AuthSessionSnapshot) => boolean;
+	resolveToken: (forceRefresh: boolean) => Promise<string | null>;
+	clearSession: () => Promise<void>;
+};
+
+function cleanToken(token: string | null | undefined): string | null {
+	if (typeof token !== "string") return null;
+	const cleaned = token.replace(/[\r\n\t\0]/g, "").trim();
+	return cleaned || null;
+}
+
+/**
+ * Coordinates Logto token resolution within one page and across same-origin
+ * pages. Cross-page mutual exclusion is supplied by the browser Web Locks
+ * adapter; the shared snapshot hands the winning token to waiters.
+ */
+export function createAuthRefreshCoordinator(
+	options: AuthRefreshCoordinatorOptions,
+) {
+	let resolutionInFlight: {
+		forceRefresh: boolean;
+		promise: Promise<string | null>;
+	} | null = null;
+	let pendingMutations = 0;
+
+	const sessionMatches = (
+		current: AuthSessionSnapshot,
+		request: ClearBrokenSessionOptions,
+	) => {
+		if (
+			request.expectedGeneration !== undefined &&
+			current.generation !== request.expectedGeneration
+		) {
+			return false;
+		}
+		if (
+			request.rejectedToken !== undefined &&
+			current.token !== cleanToken(request.rejectedToken)
+		) {
+			return false;
+		}
+		return true;
+	};
+
+	const trackMutation = <T>(operation: () => Promise<T>): Promise<T> => {
+		pendingMutations += 1;
+		return operation().finally(() => {
+			pendingMutations -= 1;
+		});
+	};
+
+	const resolveToken = async (
+		request: AuthTokenRequestOptions = {},
+	): Promise<string | null> => {
+		const forceRefresh = Boolean(request.forceRefresh);
+		const hasRejectedToken = request.rejectedToken !== undefined;
+		const rejectedToken = cleanToken(request.rejectedToken);
+
+		const inFlight = resolutionInFlight;
+		if (inFlight && pendingMutations === 0) {
+			const resolved = await inFlight.promise;
+			// A forced request only needs another pass when an in-flight normal
+			// lookup returned the exact token that the API already rejected.
+			if (
+				!forceRefresh ||
+				inFlight.forceRefresh ||
+				(hasRejectedToken && (resolved === null || resolved !== rejectedToken))
+			) {
+				return resolved;
+			}
+		}
+
+		const requestedSnapshot = options.state.read();
+		const task = options.lock.runExclusive(async () => {
+			const current = options.state.read();
+			const anotherAttemptCompleted =
+				current.attempt !== requestedSnapshot.attempt;
+
+			if (forceRefresh) {
+				// A different token means another request or tab already recovered
+				// from the rejected credential while this caller was waiting.
+				if (
+					hasRejectedToken &&
+					current.token !== rejectedToken &&
+					(current.token === null ||
+						(current.lastResolutionSucceeded &&
+							(anotherAttemptCompleted || options.isReusable(current))))
+				) {
+					return current.token;
+				}
+
+				// A completed attempt with no new token represents a shared failure.
+				// Do not let every waiting tab repeat the same exchange immediately.
+				if (anotherAttemptCompleted) {
+					return current.lastResolutionSucceeded ? current.token : null;
+				}
+			} else {
+				if (options.isReusable(current)) return current.token;
+				if (anotherAttemptCompleted) {
+					return current.lastResolutionSucceeded ? current.token : null;
+				}
+			}
+
+			let resolvedToken: string | null = null;
+			try {
+				resolvedToken = cleanToken(await options.resolveToken(forceRefresh));
+				return resolvedToken;
+			} finally {
+				// Record every completed attempt so lock waiters can share either its
+				// token or failure without invalidating the session generation.
+				options.state.commitResolution(resolvedToken, forceRefresh);
+			}
+		});
+
+		const entry = { forceRefresh, promise: task };
+		resolutionInFlight = entry;
+		try {
+			return await task;
+		} finally {
+			if (resolutionInFlight === entry) resolutionInFlight = null;
+		}
+	};
+
+	const clearBrokenSession = async (
+		request: ClearBrokenSessionOptions = {},
+	): Promise<boolean> =>
+		trackMutation(() =>
+			options.lock.runExclusive(async () => {
+				const current = options.state.read();
+				if (!sessionMatches(current, request)) return false;
+
+				try {
+					await options.clearSession();
+				} finally {
+					options.state.clear();
+				}
+				return true;
+			}),
+		);
+
+	const runExclusiveMutation = <T>(task: () => Promise<T>): Promise<T> =>
+		trackMutation(() => options.lock.runExclusive(task));
+
+	const runGuardedMutation = (
+		request: ClearBrokenSessionOptions,
+		task: () => Promise<void>,
+	): Promise<boolean> =>
+		trackMutation(() =>
+			options.lock.runExclusive(async () => {
+				if (!sessionMatches(options.state.read(), request)) return false;
+				await task();
+				return true;
+			}),
+		);
+
+	return {
+		resolveToken,
+		clearBrokenSession,
+		runExclusiveMutation,
+		runGuardedMutation,
+	};
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,4 +1,10 @@
 import LogtoClient, { type IdTokenClaims } from "@logto/browser";
+import {
+	type AuthSessionSnapshot,
+	type AuthTokenRequestOptions,
+	type ClearBrokenSessionOptions,
+	createAuthRefreshCoordinator,
+} from "$lib/auth-refresh-coordinator";
 
 const IS_DEV =
 	(typeof location !== "undefined" && location.hostname.startsWith("dev")) ||
@@ -64,20 +70,28 @@ export const logtoClient: LogtoClient = new Proxy({} as LogtoClient, {
 });
 
 export const AUTH_TOKEN_STORAGE_KEY = "cohub_token";
+const AUTH_SESSION_SNAPSHOT_STORAGE_KEY = "cohub:auth-session:v1";
 /** Lightweight flag for first-paint home redirect (not an auth token). */
 export const SESSION_HINT_STORAGE_KEY = "cohub:session-hint";
 /** Set after OAuth callback succeeds; used to break silent SSO redirect loops. */
 export const AUTH_JUST_COMPLETED_KEY = "cohub:auth-just-completed";
 const AUTH_JUST_COMPLETED_TTL_MS = 30_000;
+const AUTH_REFRESH_LOCK_NAME = `cohub:logto-token:${LOGTO_APP_ID}`;
+const OPAQUE_TOKEN_RECHECK_MS = 30_000;
+const TOKEN_EXPIRY_SKEW_MS = 1_000;
 
 function hasLogtoSessionResidue(): boolean {
 	if (typeof localStorage === "undefined") return false;
-	// Logto BrowserStorage keys: logto:<appId>:<item>
-	const prefix = `logto:${LOGTO_APP_ID}:`;
-	return Boolean(
-		localStorage.getItem(`${prefix}refreshToken`) ||
-			localStorage.getItem(`${prefix}idToken`),
-	);
+	try {
+		// Logto BrowserStorage keys: logto:<appId>:<item>
+		const prefix = `logto:${LOGTO_APP_ID}:`;
+		return Boolean(
+			localStorage.getItem(`${prefix}refreshToken`) ||
+				localStorage.getItem(`${prefix}idToken`),
+		);
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -184,62 +198,221 @@ export function sanitizeRedirectPath(path?: string | null): string {
 	}
 }
 
+function sanitizeClientToken(token: string | null | undefined): string | null {
+	if (typeof token !== "string") return null;
+	const cleaned = token.replace(/[\r\n\t\0]/g, "").trim();
+	return cleaned.length > 0 ? cleaned : null;
+}
+
 type LogtoClientWithRefreshFallback = {
 	getAccessTokenByRefreshToken?: (resource?: string) => Promise<string>;
 };
 
-const getAccessTokenByRefreshToken = async (): Promise<string | null> => {
+async function resolveLogtoAccessToken(forceRefresh: boolean) {
 	const client = getLogtoClient();
-	const refreshToken = await client.getRefreshToken().catch(() => null);
-	const refreshWithToken = (client as unknown as LogtoClientWithRefreshFallback)
-		.getAccessTokenByRefreshToken;
+	if (forceRefresh) await client.clearAccessToken();
+	if (await client.isAuthenticated()) {
+		return client.getAccessToken(API_RESOURCE);
+	}
 
+	// Logto's public API requires an ID token. Preserve origin/main's private
+	// fallback only for the recoverable missing-ID-token case.
+	const refreshToken = await client.getRefreshToken().catch(() => null);
 	if (!refreshToken) return null;
 
+	const refreshWithToken = (client as unknown as LogtoClientWithRefreshFallback)
+		.getAccessTokenByRefreshToken;
 	if (typeof refreshWithToken !== "function") {
 		console.warn(
 			"[auth] Logto refresh-token fallback is unavailable; upgrade auth integration before relying on missing-ID-token recovery.",
 		);
 		return null;
 	}
+	return refreshWithToken.call(client, API_RESOURCE);
+}
 
-	return await refreshWithToken.call(client, API_RESOURCE);
+function readLegacyAuthToken(): string | null {
+	if (typeof localStorage === "undefined") return null;
+	try {
+		return sanitizeClientToken(localStorage.getItem(AUTH_TOKEN_STORAGE_KEY));
+	} catch {
+		return null;
+	}
+}
+
+export function getAuthSessionSnapshot(): AuthSessionSnapshot {
+	const fallback = {
+		generation: 0,
+		attempt: 0,
+		token: readLegacyAuthToken(),
+		updatedAt: 0,
+		lastResolutionSucceeded: false,
+	};
+	if (typeof localStorage === "undefined") return fallback;
+
+	try {
+		const raw = localStorage.getItem(AUTH_SESSION_SNAPSHOT_STORAGE_KEY);
+		if (!raw) return fallback;
+		const parsed = JSON.parse(raw) as Partial<AuthSessionSnapshot>;
+		if (
+			!Number.isSafeInteger(parsed.generation) ||
+			(parsed.generation ?? -1) < 0 ||
+			!Number.isSafeInteger(parsed.attempt) ||
+			(parsed.attempt ?? -1) < 0 ||
+			!Number.isFinite(parsed.updatedAt) ||
+			(parsed.updatedAt ?? -1) < 0 ||
+			typeof parsed.lastResolutionSucceeded !== "boolean" ||
+			(parsed.token !== null && typeof parsed.token !== "string")
+		) {
+			return fallback;
+		}
+		return {
+			generation: parsed.generation as number,
+			attempt: parsed.attempt as number,
+			token: sanitizeClientToken(parsed.token) ?? null,
+			updatedAt: parsed.updatedAt as number,
+			lastResolutionSucceeded: parsed.lastResolutionSucceeded,
+		};
+	} catch {
+		return fallback;
+	}
+}
+
+function writeAuthSessionSnapshot(snapshot: AuthSessionSnapshot) {
+	if (typeof localStorage === "undefined") return;
+	try {
+		localStorage.setItem(
+			AUTH_SESSION_SNAPSHOT_STORAGE_KEY,
+			JSON.stringify(snapshot),
+		);
+		if (snapshot.token) {
+			localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, snapshot.token);
+		} else {
+			localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+		}
+	} catch {
+		// Storage can be unavailable in private browsing. The coordinator still
+		// provides same-page single-flight behavior in that case.
+	}
+}
+
+function nextGeneration(current: number) {
+	return Number.isSafeInteger(current) && current < Number.MAX_SAFE_INTEGER
+		? current + 1
+		: 1;
+}
+
+function commitTokenResolution(token: string | null, forceRefresh: boolean) {
+	const current = getAuthSessionSnapshot();
+	if (
+		token &&
+		!forceRefresh &&
+		token === current.token &&
+		current.lastResolutionSucceeded
+	) {
+		return;
+	}
+	writeAuthSessionSnapshot({
+		generation:
+			token &&
+			(forceRefresh ||
+				token !== current.token ||
+				!current.lastResolutionSucceeded)
+				? nextGeneration(current.generation)
+				: current.generation,
+		attempt: nextGeneration(current.attempt),
+		token: token ?? current.token,
+		updatedAt: token ? Date.now() : current.updatedAt,
+		lastResolutionSucceeded: token !== null,
+	});
+	if (token) setSessionHint(true);
+}
+
+function decodeJwtExpiry(token: string): number | null {
+	const payload = token.split(".")[1];
+	if (!payload || typeof atob === "undefined") return null;
+	try {
+		const padded = payload
+			.replace(/-/g, "+")
+			.replace(/_/g, "/")
+			.padEnd(Math.ceil(payload.length / 4) * 4, "=");
+		const parsed = JSON.parse(atob(padded)) as { exp?: unknown };
+		return typeof parsed.exp === "number" && Number.isFinite(parsed.exp)
+			? parsed.exp * 1_000
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function isReusableAuthSnapshot(snapshot: AuthSessionSnapshot) {
+	if (
+		!snapshot.token ||
+		!snapshot.lastResolutionSucceeded ||
+		!hasLogtoSessionResidue()
+	) {
+		return false;
+	}
+	const expiresAt = decodeJwtExpiry(snapshot.token);
+	if (expiresAt !== null) return expiresAt > Date.now() + TOKEN_EXPIRY_SKEW_MS;
+	return snapshot.updatedAt > Date.now() - OPAQUE_TOKEN_RECHECK_MS;
+}
+
+let localAuthLockTail: Promise<void> = Promise.resolve();
+
+const authRefreshLock = {
+	async runExclusive<T>(task: () => Promise<T>): Promise<T> {
+		const previous = localAuthLockTail;
+		let release = () => {};
+		localAuthLockTail = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		await previous;
+		try {
+			if (typeof navigator !== "undefined" && navigator.locks?.request) {
+				return await navigator.locks.request(
+					AUTH_REFRESH_LOCK_NAME,
+					{ mode: "exclusive" },
+					task,
+				);
+			}
+			return await task();
+		} finally {
+			release();
+		}
+	},
 };
 
-type GetAuthTokenOptions = { forceRefresh?: boolean };
+const authRefreshCoordinator = createAuthRefreshCoordinator({
+	state: {
+		read: getAuthSessionSnapshot,
+		commitResolution: commitTokenResolution,
+		clear: clearAuthToken,
+	},
+	lock: authRefreshLock,
+	isReusable: isReusableAuthSnapshot,
+	resolveToken: resolveLogtoAccessToken,
+	clearSession: async () => {
+		try {
+			await getLogtoClient().clearAllTokens();
+		} catch {
+			// Local cleanup remains authoritative if provider cleanup fails.
+		}
+	},
+});
 
-/**
- * Resolve a valid API access token.
- *
- * This function is intentionally side-effect-light: it does not redirect or
- * mutate UI state. It lets Logto refresh expired access tokens, and also falls
- * back to the refresh-token path for the rare case where the ID token is gone
- * but the refresh token is still valid.
- */
+/** Resolve a valid API token without allowing parallel refresh exchanges. */
 export const getAuthToken = async (
-	options?: GetAuthTokenOptions,
+	options?: AuthTokenRequestOptions,
 ): Promise<string | null> => {
 	if (typeof window === "undefined") return null;
 	try {
-		const token = options?.forceRefresh
-			? await getAccessTokenByRefreshToken()
-			: await getLogtoClient().getAccessToken(API_RESOURCE);
-		return sanitizeClientToken(token);
-	} catch {
-		try {
-			return sanitizeClientToken(await getAccessTokenByRefreshToken());
-		} catch (error) {
-			console.warn("[auth] Failed to resolve access token:", error);
-			return null;
-		}
+		return await authRefreshCoordinator.resolveToken(options);
+	} catch (error) {
+		console.warn("[auth] Failed to resolve access token:", error);
+		return null;
 	}
 };
-
-function sanitizeClientToken(token: string | null | undefined): string | null {
-	if (typeof token !== "string") return null;
-	const cleaned = token.replace(/[\r\n\t\0]/g, "").trim();
-	return cleaned.length > 0 ? cleaned : null;
-}
 
 export const getCurrentIdTokenClaims =
 	async (): Promise<IdTokenClaims | null> => {
@@ -262,33 +435,70 @@ export const hasRecoverableAuthSession = async (): Promise<boolean> => {
 	return hasIdToken || Boolean(refreshToken);
 };
 
-export const clearBrokenAuthSession = async () => {
-	clearAuthToken();
-	if (typeof window === "undefined") return;
+export const clearBrokenAuthSession = async (
+	options?: ClearBrokenSessionOptions,
+): Promise<boolean> => {
+	if (typeof window === "undefined") {
+		clearAuthToken();
+		return true;
+	}
 	try {
-		await getLogtoClient().clearAllTokens();
+		return await authRefreshCoordinator.clearBrokenSession(options);
 	} catch {
-		// Ignore cleanup failures.
+		// Lock acquisition or another coordinator-level failure must not be
+		// reported as a successful clear.
+		return false;
 	}
 };
 
-export const setAuthToken = (token: string) => {
-	if (typeof localStorage === "undefined") return;
+export function setAuthToken(token: string) {
 	// Keep stored token free of CR/LF so later Authorization headers stay valid
 	// (Safari: "The string did not match the expected pattern.").
-	const cleaned = token.replace(/[\r\n\t\0]/g, "").trim();
+	const cleaned = sanitizeClientToken(token);
 	if (!cleaned) return;
-	localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, cleaned);
+	const current = getAuthSessionSnapshot();
+	writeAuthSessionSnapshot({
+		generation:
+			current.token === cleaned && current.lastResolutionSucceeded
+				? current.generation
+				: nextGeneration(current.generation),
+		attempt: nextGeneration(current.attempt),
+		token: cleaned,
+		updatedAt: Date.now(),
+		lastResolutionSucceeded: true,
+	});
 	setSessionHint(true);
-};
+}
 
-export const clearAuthToken = () => {
-	if (typeof localStorage === "undefined") return;
-	localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
-	// Single source of truth for hint teardown — covers clearBrokenAuthSession
+export function clearAuthToken() {
+	const current = getAuthSessionSnapshot();
+	writeAuthSessionSnapshot({
+		generation: nextGeneration(current.generation),
+		attempt: nextGeneration(current.attempt),
+		token: null,
+		updatedAt: Date.now(),
+		lastResolutionSucceeded: true,
+	});
+	// Single source of truth for hint teardown — covers broken-session cleanup
 	// and redirectToSignIn({ clearSession }) via clearAuthToken().
 	setSessionHint(false);
-};
+}
+
+/** Complete the OAuth callback under the refresh/recovery lock. */
+export const completeSignInCallback = async (
+	callbackUri: string,
+): Promise<string | null> =>
+	authRefreshCoordinator.runExclusiveMutation(async () => {
+		const client = getLogtoClient();
+		await client.handleSignInCallback(callbackUri);
+		// The callback has replaced the Logto session. Invalidate the previous
+		// request generation before resolving its resource access token so a late
+		// 401 cannot clear the new session if token resolution fails.
+		clearAuthToken();
+		const token = sanitizeClientToken(await resolveLogtoAccessToken(false));
+		if (token) commitTokenResolution(token, true);
+		return token;
+	});
 
 const createRedirectState = (redirectPath?: string) => {
 	const searchParams = new URLSearchParams();
@@ -320,6 +530,21 @@ export const signInWithRedirectPath = async (redirectPath?: string) => {
 		client.adapter.generateState = originalGenerateState;
 	}
 };
+
+/** Clear and restart only the session whose token was actually rejected. */
+export const signInAfterUnauthorized = async (
+	redirectPath: string | undefined,
+	guard: ClearBrokenSessionOptions,
+): Promise<boolean> =>
+	authRefreshCoordinator.runGuardedMutation(guard, async () => {
+		try {
+			await getLogtoClient().clearAllTokens();
+		} catch {
+			// Continue with local cleanup and a clean authorization round trip.
+		}
+		clearAuthToken();
+		await signInWithRedirectPath(redirectPath);
+	});
 
 export const ensureAuth = async (options?: { redirectPath?: string }) => {
 	const token = await getAuthToken();

--- a/apps/web/src/lib/sdk.ts
+++ b/apps/web/src/lib/sdk.ts
@@ -2,17 +2,33 @@ import { type CohubClientOptions, createCohubClient } from "@neta-art/cohub";
 import { PUBLIC_API_ORIGIN, PUBLIC_GATEWAY_ORIGIN } from "$env/static/public";
 import {
 	clearAuthToken,
+	getAuthSessionSnapshot,
 	getAuthToken as resolveAccessToken,
 	setAuthToken,
 } from "$lib/auth";
 import { getCurrentRedirectPath, redirectToSignIn } from "$lib/auth-redirect";
 import { billingConversion } from "$lib/stores/billing-conversion.svelte";
 
-const handleUnauthorized = async () => {
+type UnauthorizedContext = Parameters<
+	NonNullable<CohubClientOptions["onUnauthorized"]>
+>[0];
+
+const handleUnauthorized = async (context: UnauthorizedContext) => {
 	if (typeof window === "undefined") return;
+	const rejectedSnapshot = getAuthSessionSnapshot();
+	const rejectedGeneration =
+		typeof context.authSessionVersion === "number"
+			? context.authSessionVersion
+			: rejectedSnapshot.generation;
+	if (rejectedSnapshot.generation !== rejectedGeneration) return;
+	if (!context.matchesRejectedToken(rejectedSnapshot.token)) return;
 	// Refresh already failed in transport — drop local Logto residue so the
 	// next sign-in is a clean round-trip instead of a silent SSO bounce.
-	await redirectToSignIn(getCurrentRedirectPath(), { clearSession: true });
+	await redirectToSignIn(getCurrentRedirectPath(), {
+		clearSession: true,
+		expectedGeneration: rejectedGeneration,
+		rejectedToken: rejectedSnapshot.token,
+	});
 };
 
 function shouldInspectBillingResponse(
@@ -54,6 +70,9 @@ const createWebSdk = (options: Partial<CohubClientOptions> = {}) => {
 	return createCohubClient({
 		baseUrl: options.baseUrl ?? PUBLIC_API_ORIGIN ?? "",
 		getAccessToken: options.getAccessToken ?? resolveAccessToken,
+		getAuthSessionVersion:
+			options.getAuthSessionVersion ??
+			(() => getAuthSessionSnapshot().generation),
 		onUnauthorized: options.onUnauthorized ?? handleUnauthorized,
 		setStoredAuthToken: options.setStoredAuthToken ?? setAuthToken,
 		clearStoredAuthToken: options.clearStoredAuthToken ?? clearAuthToken,

--- a/apps/web/src/lib/stores/auth.svelte.ts
+++ b/apps/web/src/lib/stores/auth.svelte.ts
@@ -1,7 +1,12 @@
 import type { IdTokenClaims } from "@logto/browser";
-import { HttpError, type UserProfile } from "@neta-art/cohub";
+import {
+	HttpError,
+	matchesUnauthorizedErrorToken,
+	type UserProfile,
+} from "@neta-art/cohub";
 import {
 	clearBrokenAuthSession,
+	getAuthSessionSnapshot,
 	getAuthToken,
 	getCurrentIdTokenClaims,
 	hasRecoverableAuthSession,
@@ -38,9 +43,13 @@ const restoreAuthSession = async (
 		return unauthenticatedSession();
 	}
 
+	const tokenStart = getAuthSessionSnapshot();
 	const token = await getAuthToken();
 	if (!token) {
-		await clearBrokenAuthSession();
+		await clearBrokenAuthSession({
+			expectedGeneration: tokenStart.generation,
+			rejectedToken: tokenStart.token,
+		});
 		return unauthenticatedSession();
 	}
 
@@ -104,7 +113,18 @@ const restoreAuthSession = async (
 	} catch (error) {
 		if (error instanceof HttpError && error.status === 401) {
 			clearCachedMeProfile(subject);
-			await clearBrokenAuthSession();
+			const current = getAuthSessionSnapshot();
+			const rejectedGeneration =
+				typeof error.authSessionVersion === "number"
+					? error.authSessionVersion
+					: current.generation;
+			const tokenMatches = matchesUnauthorizedErrorToken(error, current.token);
+			if (current.generation === rejectedGeneration && tokenMatches !== false) {
+				await clearBrokenAuthSession({
+					expectedGeneration: rejectedGeneration,
+					rejectedToken: tokenMatches ? current.token : token,
+				});
+			}
 			return unauthenticatedSession();
 		}
 		console.warn("[auth] Failed to load current user profile:", error);

--- a/apps/web/src/routes/(public)/callback/+page.svelte
+++ b/apps/web/src/routes/(public)/callback/+page.svelte
@@ -2,11 +2,9 @@
 import { HttpError } from "@neta-art/cohub";
 import { onMount } from "svelte";
 import {
-	getAuthToken,
-	logtoClient,
+	completeSignInCallback,
 	markAuthJustCompleted,
 	sanitizeRedirectPath,
-	setAuthToken,
 } from "$lib/auth";
 import CenteredLoading from "$lib/components/CenteredLoading.svelte";
 import { sdk } from "$lib/sdk";
@@ -23,19 +21,16 @@ onMount(async () => {
 		);
 
 		// Exchange the authorization code from the URL for tokens.
-		await logtoClient.handleSignInCallback(window.location.href);
-
-		// Ensure a resource access token is available AND accepted by the API
-		// before leaving the callback. A wrong audience/claim still yields a
-		// token string — without this check the app 401-loops via silent SSO.
-		const token = await getAuthToken();
+		// Callback exchange and token publication share the refresh/recovery lock.
+		const token = await completeSignInCallback(window.location.href);
 		if (!token) {
 			error =
 				"Signed in, but no API access token was issued. Check Logto API resource configuration, then try again.";
 			return;
 		}
-		setAuthToken(token);
 
+		// Ensure the resource access token is accepted by the API before leaving
+		// the callback. A wrong audience/claim can still yield a token string.
 		try {
 			await sdk.user.getMe({ skipUnauthorizedHandler: true });
 		} catch (err) {

--- a/apps/web/src/tests/auth-refresh-coordinator.test.ts
+++ b/apps/web/src/tests/auth-refresh-coordinator.test.ts
@@ -1,0 +1,593 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+	type AuthSessionSnapshot,
+	createAuthRefreshCoordinator,
+} from "../lib/auth-refresh-coordinator.ts";
+
+class SerialLock {
+	private tail: Promise<void> = Promise.resolve();
+
+	async runExclusive<T>(task: () => Promise<T>): Promise<T> {
+		const previous = this.tail;
+		let release = () => {};
+		this.tail = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		await previous;
+		try {
+			return await task();
+		} finally {
+			release();
+		}
+	}
+}
+
+function createSharedState(initialToken: string | null) {
+	let snapshot: AuthSessionSnapshot = {
+		generation: 0,
+		attempt: 0,
+		token: initialToken,
+		updatedAt: 1,
+		lastResolutionSucceeded: true,
+	};
+	return {
+		read: () => ({ ...snapshot }),
+		commitResolution: (token: string | null) => {
+			snapshot = {
+				generation: token ? snapshot.generation + 1 : snapshot.generation,
+				attempt: snapshot.attempt + 1,
+				token: token ?? snapshot.token,
+				updatedAt: token ? snapshot.updatedAt + 1 : snapshot.updatedAt,
+				lastResolutionSucceeded: token !== null,
+			};
+		},
+		clear: () => {
+			snapshot = {
+				generation: snapshot.generation + 1,
+				attempt: snapshot.attempt + 1,
+				token: null,
+				updatedAt: snapshot.updatedAt + 1,
+				lastResolutionSucceeded: true,
+			};
+		},
+	};
+}
+
+function createTab(options: {
+	state: ReturnType<typeof createSharedState>;
+	lock: SerialLock;
+	counters: { resolve: number; clear: number };
+}) {
+	return createAuthRefreshCoordinator({
+		state: options.state,
+		lock: options.lock,
+		isReusable: (snapshot) =>
+			snapshot.token === "fresh" && snapshot.lastResolutionSucceeded,
+		resolveToken: async () => {
+			options.counters.resolve += 1;
+			return "fresh";
+		},
+		clearSession: async () => {
+			options.counters.clear += 1;
+		},
+	});
+}
+
+test("two tabs share one forced token exchange", async () => {
+	const state = createSharedState("stale");
+	const lock = new SerialLock();
+	const counters = { resolve: 0, clear: 0 };
+	const firstTab = createTab({ state, lock, counters });
+	const secondTab = createTab({ state, lock, counters });
+
+	const tokens = await Promise.all([
+		firstTab.resolveToken({ forceRefresh: true, rejectedToken: "stale" }),
+		secondTab.resolveToken({ forceRefresh: true, rejectedToken: "stale" }),
+	]);
+
+	assert.deepEqual(tokens, ["fresh", "fresh"]);
+	assert.equal(counters.resolve, 1);
+	assert.equal(state.read().token, "fresh");
+});
+
+test("a forced waiter without a rejected token reuses a new winner", async () => {
+	const state = createSharedState(null);
+	const lock = new SerialLock();
+	const counters = { resolve: 0, clear: 0 };
+	const tab = createTab({ state, lock, counters });
+
+	const tokens = await Promise.all([
+		tab.resolveToken({ forceRefresh: true }),
+		tab.resolveToken({ forceRefresh: true }),
+	]);
+
+	assert.deepEqual(tokens, ["fresh", "fresh"]);
+	assert.equal(counters.resolve, 1);
+	assert.equal(counters.clear, 0);
+});
+
+test("a forced request does not reuse an in-flight normal lookup", async () => {
+	const state = createSharedState("stale");
+	const lock = new SerialLock();
+	const calls: boolean[] = [];
+	let markNormalStarted = () => {};
+	let releaseNormal = () => {};
+	const normalStarted = new Promise<void>((resolve) => {
+		markNormalStarted = resolve;
+	});
+	const normalCanFinish = new Promise<void>((resolve) => {
+		releaseNormal = resolve;
+	});
+	const coordinator = createAuthRefreshCoordinator({
+		state,
+		lock,
+		isReusable: () => false,
+		resolveToken: async (forceRefresh) => {
+			calls.push(forceRefresh);
+			if (!forceRefresh) {
+				markNormalStarted();
+				await normalCanFinish;
+				return "stale";
+			}
+			return "fresh";
+		},
+		clearSession: async () => {},
+	});
+
+	const normal = coordinator.resolveToken();
+	await normalStarted;
+	const forced = coordinator.resolveToken({ forceRefresh: true });
+	releaseNormal();
+
+	assert.equal(await normal, "stale");
+	assert.equal(await forced, "fresh");
+	assert.deepEqual(calls, [false, true]);
+});
+
+test("an unauthenticated rejection reuses a session established before recovery", async () => {
+	const state = createSharedState("fresh");
+	const lock = new SerialLock();
+	const counters = { resolve: 0, clear: 0 };
+	const tab = createTab({ state, lock, counters });
+
+	const token = await tab.resolveToken({
+		forceRefresh: true,
+		rejectedToken: null,
+	});
+
+	assert.equal(token, "fresh");
+	assert.equal(counters.resolve, 0);
+	assert.equal(counters.clear, 0);
+});
+
+test("an unauthenticated rejection ignores a non-reusable stale snapshot", async () => {
+	const state = createSharedState("stale");
+	const lock = new SerialLock();
+	let resolveCalls = 0;
+	const coordinator = createAuthRefreshCoordinator({
+		state,
+		lock,
+		isReusable: () => false,
+		resolveToken: async () => {
+			resolveCalls += 1;
+			return null;
+		},
+		clearSession: async () => {},
+	});
+
+	assert.equal(
+		await coordinator.resolveToken({
+			forceRefresh: true,
+			rejectedToken: null,
+		}),
+		null,
+	);
+	assert.equal(resolveCalls, 1);
+});
+
+test("two tabs share one normal refresh after the cached token expires", async () => {
+	const state = createSharedState("stale");
+	const lock = new SerialLock();
+	const counters = { resolve: 0, clear: 0 };
+	const firstTab = createTab({ state, lock, counters });
+	const secondTab = createTab({ state, lock, counters });
+
+	const tokens = await Promise.all([
+		firstTab.resolveToken(),
+		secondTab.resolveToken(),
+	]);
+
+	assert.deepEqual(tokens, ["fresh", "fresh"]);
+	assert.equal(counters.resolve, 1);
+	assert.equal(counters.clear, 0);
+});
+
+test("a later tab reuses a shared refresh winner instead of its stale local token", async () => {
+	const state = createSharedState("stale");
+	const lock = new SerialLock();
+	let winnerCalls = 0;
+	let staleCalls = 0;
+	const isReusable = (snapshot: AuthSessionSnapshot) =>
+		snapshot.token === "fresh" && snapshot.lastResolutionSucceeded;
+	const winnerTab = createAuthRefreshCoordinator({
+		state,
+		lock,
+		isReusable,
+		resolveToken: async () => {
+			winnerCalls += 1;
+			return "fresh";
+		},
+		clearSession: async () => {},
+	});
+	const staleTab = createAuthRefreshCoordinator({
+		state,
+		lock,
+		isReusable,
+		resolveToken: async () => {
+			staleCalls += 1;
+			return "stale";
+		},
+		clearSession: async () => {},
+	});
+
+	assert.equal(
+		await winnerTab.resolveToken({
+			forceRefresh: true,
+			rejectedToken: "stale",
+		}),
+		"fresh",
+	);
+	assert.equal(await staleTab.resolveToken(), "fresh");
+	assert.equal(winnerCalls, 1);
+	assert.equal(staleCalls, 0);
+	assert.equal(state.read().token, "fresh");
+});
+
+test("a reader in another tab waits for an in-progress session replacement", async () => {
+	const state = createSharedState("current");
+	const lock = new SerialLock();
+	let markMutationStarted = () => {};
+	let releaseMutation = () => {};
+	const mutationStarted = new Promise<void>((resolve) => {
+		markMutationStarted = resolve;
+	});
+	const mutationCanFinish = new Promise<void>((resolve) => {
+		releaseMutation = resolve;
+	});
+	const callbackTab = createAuthRefreshCoordinator({
+		state,
+		lock,
+		isReusable: (snapshot) => Boolean(snapshot.token),
+		resolveToken: async () => {
+			throw new Error("callback tab should not resolve a token");
+		},
+		clearSession: async () => {},
+	});
+	const readerTab = createAuthRefreshCoordinator({
+		state,
+		lock,
+		isReusable: (snapshot) => Boolean(snapshot.token),
+		resolveToken: async () => {
+			throw new Error("callback winner should be reused");
+		},
+		clearSession: async () => {},
+	});
+
+	const mutation = callbackTab.runExclusiveMutation(async () => {
+		markMutationStarted();
+		await mutationCanFinish;
+		state.commitResolution("replacement");
+	});
+	await mutationStarted;
+	let readerSettled = false;
+	const reader = readerTab.resolveToken().then((token) => {
+		readerSettled = true;
+		return token;
+	});
+	await Promise.resolve();
+	await Promise.resolve();
+	assert.equal(readerSettled, false);
+
+	releaseMutation();
+	await mutation;
+	assert.equal(await reader, "replacement");
+});
+
+test("a token reader queued after a session mutation observes the mutation", async () => {
+	const state = createSharedState("stale");
+	const lock = new SerialLock();
+	let markRefreshStarted = () => {};
+	let releaseRefresh = () => {};
+	const refreshStarted = new Promise<void>((resolve) => {
+		markRefreshStarted = resolve;
+	});
+	const refreshCanFinish = new Promise<void>((resolve) => {
+		releaseRefresh = resolve;
+	});
+	const coordinator = createAuthRefreshCoordinator({
+		state,
+		lock,
+		isReusable: (snapshot) => snapshot.token !== "stale",
+		resolveToken: async () => {
+			markRefreshStarted();
+			await refreshCanFinish;
+			return "refresh-winner";
+		},
+		clearSession: async () => {},
+	});
+
+	const refresh = coordinator.resolveToken({
+		forceRefresh: true,
+		rejectedToken: "stale",
+	});
+	await refreshStarted;
+	const mutation = coordinator.runExclusiveMutation(async () => {
+		state.commitResolution("callback-winner");
+	});
+	const reader = coordinator.resolveToken();
+	releaseRefresh();
+
+	assert.equal(await refresh, "refresh-winner");
+	await mutation;
+	assert.equal(await reader, "callback-winner");
+});
+
+test("a guarded sign-in queued after a callback cannot clear its winner", async () => {
+	const state = createSharedState("stale");
+	const lock = new SerialLock();
+	const counters = { resolve: 0, clear: 0 };
+	const coordinator = createTab({ state, lock, counters });
+	const rejected = state.read();
+	let releaseBlocker = () => {};
+	let markBlockerStarted = () => {};
+	const blockerCanFinish = new Promise<void>((resolve) => {
+		releaseBlocker = resolve;
+	});
+	const blockerStarted = new Promise<void>((resolve) => {
+		markBlockerStarted = resolve;
+	});
+
+	const blocker = coordinator.runExclusiveMutation(async () => {
+		markBlockerStarted();
+		await blockerCanFinish;
+	});
+	await blockerStarted;
+	const callback = coordinator.runExclusiveMutation(async () => {
+		state.commitResolution("fresh");
+	});
+	let signInStarted = false;
+	const signIn = coordinator.runGuardedMutation(
+		{
+			expectedGeneration: rejected.generation,
+			rejectedToken: rejected.token,
+		},
+		async () => {
+			signInStarted = true;
+			state.clear();
+		},
+	);
+	releaseBlocker();
+
+	await blocker;
+	await callback;
+	assert.equal(await signIn, false);
+	assert.equal(signInStarted, false);
+	assert.equal(state.read().token, "fresh");
+});
+
+test("a callback replacement blocks stale cleanup when token resolution fails", async () => {
+	const state = createSharedState("stale");
+	const lock = new SerialLock();
+	const counters = { resolve: 0, clear: 0 };
+	const coordinator = createTab({ state, lock, counters });
+	const rejected = state.read();
+
+	await assert.rejects(
+		coordinator.runExclusiveMutation(async () => {
+			// Mirrors callback completion invalidating the previous request
+			// generation before resource-token resolution.
+			state.clear();
+			throw new Error("resource token unavailable");
+		}),
+		/resource token unavailable/,
+	);
+
+	assert.equal(
+		await coordinator.clearBrokenSession({
+			expectedGeneration: rejected.generation,
+			rejectedToken: rejected.token,
+		}),
+		false,
+	);
+	assert.equal(counters.clear, 0);
+	assert.equal(state.read().token, null);
+});
+
+test("a callback replacement blocks stale unauthenticated cleanup", async () => {
+	const state = createSharedState(null);
+	const lock = new SerialLock();
+	const counters = { resolve: 0, clear: 0 };
+	const coordinator = createTab({ state, lock, counters });
+	const rejected = state.read();
+
+	await assert.rejects(
+		coordinator.runExclusiveMutation(async () => {
+			state.clear();
+			throw new Error("resource token unavailable");
+		}),
+		/resource token unavailable/,
+	);
+
+	assert.equal(
+		await coordinator.clearBrokenSession({
+			expectedGeneration: rejected.generation,
+			rejectedToken: rejected.token,
+		}),
+		false,
+	);
+	assert.equal(counters.clear, 0);
+	assert.equal(state.read().token, null);
+});
+
+test("a cached-token reader waits for a queued session replacement", async () => {
+	const state = createSharedState("current");
+	const lock = new SerialLock();
+	let releaseBlocker = () => {};
+	let markBlockerStarted = () => {};
+	const blockerCanFinish = new Promise<void>((resolve) => {
+		releaseBlocker = resolve;
+	});
+	const blockerStarted = new Promise<void>((resolve) => {
+		markBlockerStarted = resolve;
+	});
+	const coordinator = createAuthRefreshCoordinator({
+		state,
+		lock,
+		isReusable: (snapshot) => Boolean(snapshot.token),
+		resolveToken: async () => {
+			throw new Error("queued mutation winner should be reused");
+		},
+		clearSession: async () => {},
+	});
+
+	const blocker = coordinator.runExclusiveMutation(async () => {
+		markBlockerStarted();
+		await blockerCanFinish;
+	});
+	await blockerStarted;
+	const replacement = coordinator.runExclusiveMutation(async () => {
+		state.commitResolution("replacement");
+	});
+	const reader = coordinator.resolveToken();
+	releaseBlocker();
+
+	await blocker;
+	await replacement;
+	assert.equal(await reader, "replacement");
+});
+
+test("waiting tabs do not repeat the same failed refresh", async () => {
+	const state = createSharedState("stale");
+	const lock = new SerialLock();
+	let exchanges = 0;
+	const createFailingTab = () =>
+		createAuthRefreshCoordinator({
+			state,
+			lock,
+			isReusable: () => false,
+			resolveToken: async () => {
+				exchanges += 1;
+				throw new Error("refresh unavailable");
+			},
+			clearSession: async () => {},
+		});
+	const firstTab = createFailingTab();
+	const secondTab = createFailingTab();
+
+	const results = await Promise.allSettled([
+		firstTab.resolveToken({ forceRefresh: true, rejectedToken: "stale" }),
+		secondTab.resolveToken({ forceRefresh: true, rejectedToken: "stale" }),
+	]);
+
+	assert.equal(results[0]?.status, "rejected");
+	assert.deepEqual(results[1], { status: "fulfilled", value: null });
+	assert.equal(exchanges, 1);
+	assert.equal(state.read().token, "stale");
+
+	const failedAttempt = state.read();
+	assert.equal(
+		await firstTab.clearBrokenSession({
+			expectedGeneration: failedAttempt.generation,
+			rejectedToken: "stale",
+		}),
+		true,
+	);
+	assert.equal(state.read().token, null);
+});
+
+test("a later failed attempt does not invalidate the rejected-session guard", async () => {
+	const state = createSharedState("stale");
+	const lock = new SerialLock();
+	let exchanges = 0;
+	let clears = 0;
+	const coordinator = createAuthRefreshCoordinator({
+		state,
+		lock,
+		isReusable: () => false,
+		resolveToken: async () => {
+			exchanges += 1;
+			throw new Error("refresh unavailable");
+		},
+		clearSession: async () => {
+			clears += 1;
+		},
+	});
+
+	await assert.rejects(
+		coordinator.resolveToken({ forceRefresh: true, rejectedToken: "stale" }),
+	);
+	const rejectedSession = state.read();
+	await assert.rejects(
+		coordinator.resolveToken({ forceRefresh: true, rejectedToken: "stale" }),
+	);
+
+	assert.equal(
+		await coordinator.clearBrokenSession({
+			expectedGeneration: rejectedSession.generation,
+			rejectedToken: rejectedSession.token,
+		}),
+		true,
+	);
+	assert.equal(exchanges, 2);
+	assert.equal(clears, 1);
+});
+
+test("late cleanup cannot clear a newer session", async () => {
+	const state = createSharedState("stale");
+	const lock = new SerialLock();
+	const counters = { resolve: 0, clear: 0 };
+	const tab = createTab({ state, lock, counters });
+	const rejectedSnapshot = state.read();
+
+	state.commitResolution("fresh");
+	assert.equal(
+		await tab.clearBrokenSession({
+			expectedGeneration: rejectedSnapshot.generation,
+			rejectedToken: "stale",
+		}),
+		false,
+	);
+	assert.equal(counters.clear, 0);
+	assert.equal(state.read().token, "fresh");
+
+	const current = state.read();
+	assert.equal(
+		await tab.clearBrokenSession({
+			expectedGeneration: current.generation,
+			rejectedToken: "fresh",
+		}),
+		true,
+	);
+	assert.equal(counters.clear, 1);
+	assert.equal(state.read().token, null);
+});
+
+test("late unauthenticated cleanup cannot clear a newly established session", async () => {
+	const state = createSharedState(null);
+	const lock = new SerialLock();
+	const counters = { resolve: 0, clear: 0 };
+	const tab = createTab({ state, lock, counters });
+
+	state.commitResolution("fresh");
+	assert.equal(await tab.clearBrokenSession({ rejectedToken: null }), false);
+	assert.equal(counters.clear, 0);
+	assert.equal(state.read().token, "fresh");
+
+	assert.equal(
+		await tab.clearBrokenSession({ rejectedToken: undefined }),
+		true,
+	);
+	assert.equal(counters.clear, 1);
+	assert.equal(state.read().token, null);
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -32,7 +32,7 @@ export {
   isFeatureNotEntitledError,
   isHttpErrorCode,
 } from "./http-error.js";
-export { HttpError, joinApiUrl, sanitizeAccessToken } from "./transport.js";
+export { HttpError, joinApiUrl, matchesUnauthorizedErrorToken, sanitizeAccessToken } from "./transport.js";
 export {
   COHUB_SOURCE_HEADER,
   COHUB_SOURCE_HEADER_NAMES,

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -38,11 +38,27 @@ export type RawHttpResponse = {
   json(): Promise<unknown>;
 };
 
+export type AccessTokenRequestOptions = {
+  forceRefresh?: boolean;
+  /** Token used by the request that received 401. */
+  rejectedToken?: string | null;
+};
+
+export type AuthSessionVersion = string | number | null;
+
+export type UnauthorizedContext = {
+  /** Compare a known candidate without exposing the rejected bearer token. */
+  matchesRejectedToken(candidate: string | null | undefined): boolean;
+  /** Auth state observed before the rejected request resolved its token. */
+  authSessionVersion?: AuthSessionVersion;
+};
+
 export type CohubClientOptions = {
   env?: CohubEnvironment;
   baseUrl?: string;
-  getAccessToken?: (options?: { forceRefresh?: boolean }) => Promise<string | null> | string | null;
-  onUnauthorized?: () => Promise<void> | void;
+  getAccessToken?: (options?: AccessTokenRequestOptions) => Promise<string | null> | string | null;
+  getAuthSessionVersion?: () => AuthSessionVersion;
+  onUnauthorized?: (context: UnauthorizedContext) => Promise<void> | void;
   setStoredAuthToken?: (token: string) => void;
   clearStoredAuthToken?: () => void;
   fetch?: Fetch;
@@ -101,27 +117,63 @@ export class HttpError extends Error {
   readonly status: number;
   readonly body: unknown;
   readonly code: string | null;
+  /** The configured unauthorized callback already handled this 401. */
+  readonly unauthorizedHandled: boolean;
+  /** Auth state observed before the rejected request resolved its token. */
+  readonly authSessionVersion?: AuthSessionVersion;
 
-  constructor(message: string, status: number, body: unknown) {
+  constructor(
+    message: string,
+    status: number,
+    body: unknown,
+    options?: {
+      unauthorizedHandled?: boolean;
+      authSessionVersion?: AuthSessionVersion;
+    },
+  ) {
     super(message);
     this.name = "HttpError";
     this.status = status;
     this.body = body;
     this.code = errorCodeFromBody(body);
+    this.unauthorizedHandled = Boolean(options?.unauthorizedHandled);
+    this.authSessionVersion = options?.authSessionVersion;
   }
+}
+
+const rejectedTokenByError = new WeakMap<HttpError, string | null>();
+
+/**
+ * Compare a known candidate with the credential rejected by a transport 401.
+ * Returns undefined for HttpErrors that were not created by HttpTransport.
+ */
+export function matchesUnauthorizedErrorToken(
+  error: unknown,
+  candidate: string | null | undefined,
+): boolean | undefined {
+  if (!(error instanceof HttpError) || !rejectedTokenByError.has(error)) {
+    return undefined;
+  }
+  return rejectedTokenByError.get(error) === sanitizeAccessToken(candidate);
 }
 
 export class HttpTransport {
   private readonly baseUrl: string;
   private readonly fetcher: Fetch;
-  private readonly getAccessToken?: (options?: { forceRefresh?: boolean }) => Promise<string | null> | string | null;
-  private readonly onUnauthorized?: () => Promise<void> | void;
+  private readonly getAccessToken?: (options?: AccessTokenRequestOptions) => Promise<string | null> | string | null;
+  private readonly getAuthSessionVersion?: () => AuthSessionVersion;
+  private readonly onUnauthorized?: (context: UnauthorizedContext) => Promise<void> | void;
   private readonly requestSource?: RequestSource | null | (() => RequestSource | null | undefined);
+  private refreshInFlight: {
+    rejectedToken: string | null;
+    promise: Promise<string | null>;
+  } | null = null;
 
   constructor(options: CohubClientOptions = {}) {
     this.baseUrl = resolveApiBaseUrl(options);
     this.fetcher = options.fetch ?? fetch;
     this.getAccessToken = options.getAccessToken;
+    this.getAuthSessionVersion = options.getAuthSessionVersion;
     this.onUnauthorized = options.onUnauthorized;
     this.requestSource = options.requestSource;
   }
@@ -142,12 +194,26 @@ export class HttpTransport {
     }
   }
 
+  private readAuthSessionVersion(): AuthSessionVersion | undefined {
+    try {
+      return this.getAuthSessionVersion?.();
+    } catch {
+      // Versioning is an optional cleanup guard and must not block requests.
+      return undefined;
+    }
+  }
+
   private async withAuthorization(
     init?: RequestInitWithFetch,
     tokenOverride?: string | null,
-  ): Promise<RequestInit> {
+  ): Promise<{
+    requestInit: RequestInit;
+    token: string | null;
+    authSessionVersion?: AuthSessionVersion;
+  }> {
     const { fetch: _fetch, skipUnauthorizedHandler: _skip, ...requestInit } = init ?? {};
     const headers = new Headers(requestInit.headers);
+    let authSessionVersion = this.readAuthSessionVersion();
     const rawToken =
       tokenOverride !== undefined
         ? tokenOverride
@@ -155,6 +221,13 @@ export class HttpTransport {
           ? await this.getAccessToken()
           : null;
     const token = sanitizeAccessToken(rawToken);
+    if (token) {
+      // A token lookup may refresh the session itself. Bind a non-null bearer
+      // to the resulting version; retain the starting version for null so an
+      // unrelated callback cannot make an old unauthenticated request current.
+      const resolvedVersion = this.readAuthSessionVersion();
+      if (resolvedVersion !== undefined) authSessionVersion = resolvedVersion;
+    }
 
     if (token) {
       headers.set("Authorization", `Bearer ${token}`);
@@ -165,9 +238,55 @@ export class HttpTransport {
     this.applyRequestSourceHeaders(headers);
 
     return {
-      ...requestInit,
-      headers,
+      requestInit: {
+        ...requestInit,
+        headers,
+      },
+      token,
+      authSessionVersion,
     };
+  }
+
+  private async refreshAccessToken(rejectedToken: string | null): Promise<string | null> {
+    if (!this.getAccessToken) return null;
+    const inFlight = this.refreshInFlight;
+    if (inFlight) {
+      const resolved = await inFlight.promise;
+      if (inFlight.rejectedToken === rejectedToken) return resolved;
+      // A different credential was rejected while this refresh was running.
+      // Re-evaluate it against the provider's current state instead of retrying
+      // the request with a token resolved for another rejection.
+      return this.refreshAccessToken(rejectedToken);
+    }
+
+    const getAccessToken = this.getAccessToken;
+    const task = (async () => {
+      try {
+        const currentToken = sanitizeAccessToken(await getAccessToken());
+        if (currentToken && currentToken !== rejectedToken) {
+          return currentToken;
+        }
+      } catch {
+        // Continue to the explicit refresh path.
+      }
+
+      try {
+        return sanitizeAccessToken(
+          await getAccessToken({ forceRefresh: true, rejectedToken }),
+        );
+      } catch {
+        return null;
+      }
+    })();
+
+
+    const entry = { rejectedToken, promise: task };
+    this.refreshInFlight = entry;
+    try {
+      return await task;
+    } finally {
+      if (this.refreshInFlight === entry) this.refreshInFlight = null;
+    }
   }
 
   private async send(path: string, init?: RequestInitWithFetch) {
@@ -176,8 +295,13 @@ export class HttpTransport {
     const skipUnauthorizedHandler = Boolean(init?.skipUnauthorizedHandler);
 
     let response: Response;
+    let rejectedToken: string | null = null;
+    let rejectedAuthSessionVersion: AuthSessionVersion | undefined;
     try {
-      response = await fetcher(url, await this.withAuthorization(init));
+      const authorized = await this.withAuthorization(init);
+      rejectedToken = authorized.token;
+      rejectedAuthSessionVersion = authorized.authSessionVersion;
+      response = await fetcher(url, authorized.requestInit);
     } catch (error) {
       if (isBrowserRequestConstructionError(error)) {
         throw new Error(
@@ -188,19 +312,15 @@ export class HttpTransport {
       throw error;
     }
 
-    const getAccessToken = this.getAccessToken;
-    if (response.status === 401 && getAccessToken) {
-      const refreshedToken = await (async () => {
-        try {
-          return sanitizeAccessToken(await getAccessToken({ forceRefresh: true }));
-        } catch {
-          return null;
-        }
-      })();
+    if (response.status === 401 && this.getAccessToken) {
+      const refreshedToken = await this.refreshAccessToken(rejectedToken);
       if (refreshedToken) {
         let retryResponse: Response;
         try {
-          retryResponse = await fetcher(url, await this.withAuthorization(init, refreshedToken));
+          const authorizedRetry = await this.withAuthorization(init, refreshedToken);
+          rejectedToken = authorizedRetry.token;
+          rejectedAuthSessionVersion = authorizedRetry.authSessionVersion;
+          retryResponse = await fetcher(url, authorizedRetry.requestInit);
         } catch (error) {
           if (isBrowserRequestConstructionError(error)) {
             throw new Error(
@@ -225,10 +345,21 @@ export class HttpTransport {
     }
 
     if (response.status === 401) {
-      if (!skipUnauthorizedHandler) {
-        await this.onUnauthorized?.();
+      let unauthorizedHandled = false;
+      if (!skipUnauthorizedHandler && this.onUnauthorized) {
+        await this.onUnauthorized({
+          matchesRejectedToken: (candidate) =>
+            sanitizeAccessToken(candidate) === rejectedToken,
+          authSessionVersion: rejectedAuthSessionVersion,
+        });
+        unauthorizedHandled = true;
       }
-      throw new HttpError("unauthorized", 401, null);
+      const error = new HttpError("unauthorized", 401, null, {
+        unauthorizedHandled,
+        authSessionVersion: rejectedAuthSessionVersion,
+      });
+      rejectedTokenByError.set(error, rejectedToken);
+      throw error;
     }
 
     if (!response.ok) {

--- a/packages/sdk/tests/transport-auth-refresh.test.ts
+++ b/packages/sdk/tests/transport-auth-refresh.test.ts
@@ -1,0 +1,350 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+	HttpError,
+	HttpTransport,
+	matchesUnauthorizedErrorToken,
+} from "../src/transport.js";
+
+const jsonResponse = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const authorization = (init?: RequestInit) =>
+  new Headers(init?.headers).get("Authorization");
+
+test("concurrent 401 responses share one token refresh", async () => {
+  const concurrency = 8;
+  let currentToken = "stale";
+  let forceRefreshCalls = 0;
+  let staleRequests = 0;
+  let releaseStaleRequests = () => {};
+  const allStaleRequestsArrived = new Promise<void>((resolve) => {
+    releaseStaleRequests = resolve;
+  });
+  const retryHeaders: Array<string | null> = [];
+  let unauthorizedCalls = 0;
+
+  const transport = new HttpTransport({
+    baseUrl: "https://api.example.com",
+    getAccessToken: async (options) => {
+      if (options?.forceRefresh) {
+        forceRefreshCalls += 1;
+        currentToken = "fresh";
+      }
+      return currentToken;
+    },
+    onUnauthorized: () => {
+      unauthorizedCalls += 1;
+    },
+    fetch: async (_input, init) => {
+      const auth = authorization(init);
+      if (auth === "Bearer stale") {
+        staleRequests += 1;
+        if (staleRequests === concurrency) releaseStaleRequests();
+        await allStaleRequestsArrived;
+        return jsonResponse(401, { message: "expired" });
+      }
+      retryHeaders.push(auth);
+      return jsonResponse(200, { ok: true });
+    },
+  });
+
+  const results = await Promise.all(
+    Array.from({ length: concurrency }, (_, index) =>
+      transport.request<{ ok: boolean }>(`/request/${index}`),
+    ),
+  );
+
+  assert.equal(forceRefreshCalls, 1);
+  assert.equal(unauthorizedCalls, 0);
+  assert.equal(results.every((result) => result.ok), true);
+  assert.deepEqual(retryHeaders, Array(concurrency).fill("Bearer fresh"));
+});
+
+test("a late 401 for an old token reuses the completed refresh", async () => {
+  let currentToken = "stale";
+  let forceRefreshCalls = 0;
+  let releaseLateRequest = () => {};
+  let markLateRequestStarted = () => {};
+  const lateRequestCanReturn = new Promise<void>((resolve) => {
+    releaseLateRequest = resolve;
+  });
+  const lateRequestStarted = new Promise<void>((resolve) => {
+    markLateRequestStarted = resolve;
+  });
+  let unauthorizedCalls = 0;
+
+  const transport = new HttpTransport({
+    baseUrl: "https://api.example.com",
+    getAccessToken: async (options) => {
+      if (options?.forceRefresh) {
+        forceRefreshCalls += 1;
+        currentToken = "fresh";
+      }
+      return currentToken;
+    },
+    onUnauthorized: () => {
+      unauthorizedCalls += 1;
+    },
+    fetch: async (input, init) => {
+      const url = String(input);
+      const auth = authorization(init);
+      if (auth === "Bearer stale" && url.endsWith("/late")) {
+        markLateRequestStarted();
+        await lateRequestCanReturn;
+        return jsonResponse(401, { message: "expired" });
+      }
+      if (auth === "Bearer stale") {
+        return jsonResponse(401, { message: "expired" });
+      }
+      return jsonResponse(200, { ok: true });
+    },
+  });
+
+  const late = transport.request<{ ok: boolean }>("/late");
+  await lateRequestStarted;
+  const first = await transport.request<{ ok: boolean }>("/first");
+  releaseLateRequest();
+  const second = await late;
+
+  assert.deepEqual([first.ok, second.ok], [true, true]);
+  assert.equal(forceRefreshCalls, 1);
+  assert.equal(unauthorizedCalls, 0);
+});
+
+test("a late unauthenticated 401 reuses a newly established session", async () => {
+  let currentToken: string | null = null;
+  let forceRefreshCalls = 0;
+  let releaseInitialRequest = () => {};
+  let markInitialRequestStarted = () => {};
+  const initialRequestCanReturn = new Promise<void>((resolve) => {
+    releaseInitialRequest = resolve;
+  });
+  const initialRequestStarted = new Promise<void>((resolve) => {
+    markInitialRequestStarted = resolve;
+  });
+  const requestHeaders: Array<string | null> = [];
+
+  const transport = new HttpTransport({
+    baseUrl: "https://api.example.com",
+    getAccessToken: async (options) => {
+      if (options?.forceRefresh) {
+        forceRefreshCalls += 1;
+        currentToken = "unnecessary-refresh";
+      }
+      return currentToken;
+    },
+    fetch: async (_input, init) => {
+      const auth = authorization(init);
+      requestHeaders.push(auth);
+      if (!auth) {
+        markInitialRequestStarted();
+        await initialRequestCanReturn;
+        return jsonResponse(401, { message: "sign in required" });
+      }
+      return jsonResponse(200, { ok: true });
+    },
+  });
+
+  const request = transport.request<{ ok: boolean }>("/late-login");
+  await initialRequestStarted;
+  currentToken = "new-login";
+  releaseInitialRequest();
+
+  assert.equal((await request).ok, true);
+  assert.equal(forceRefreshCalls, 0);
+  assert.deepEqual(requestHeaders, [null, "Bearer new-login"]);
+});
+
+test("different rejected tokens do not share an in-flight refresh result", async () => {
+  let currentToken = "a-stale";
+  let releaseA = () => {};
+  let markAStarted = () => {};
+  let markBRejected = () => {};
+  const aStarted = new Promise<void>((resolve) => {
+    markAStarted = resolve;
+  });
+  const aCanFinish = new Promise<void>((resolve) => {
+    releaseA = resolve;
+  });
+  const bRejected = new Promise<void>((resolve) => {
+    markBRejected = resolve;
+  });
+  const forceRefreshes: Array<string | null | undefined> = [];
+  const retries = new Map<string, string | null>();
+
+  const transport = new HttpTransport({
+    baseUrl: "https://api.example.com",
+    getAccessToken: async (options) => {
+      if (!options?.forceRefresh) return currentToken;
+      forceRefreshes.push(options.rejectedToken);
+      if (options.rejectedToken === "a-stale") {
+        markAStarted();
+        await aCanFinish;
+        return "a-fresh";
+      }
+      assert.equal(options.rejectedToken, "b-stale");
+      return "b-fresh";
+    },
+    fetch: async (input, init) => {
+      const path = new URL(String(input)).pathname;
+      const auth = authorization(init);
+      if (auth === "Bearer a-stale") return jsonResponse(401, null);
+      if (auth === "Bearer b-stale") {
+        markBRejected();
+        return jsonResponse(401, null);
+      }
+      retries.set(path, auth);
+      return jsonResponse(200, { ok: true });
+    },
+  });
+
+  const requestA = transport.request("/a");
+  await aStarted;
+  currentToken = "b-stale";
+  const requestB = transport.request("/b");
+  await bRejected;
+  await Promise.resolve();
+  releaseA();
+  await Promise.all([requestA, requestB]);
+
+  assert.deepEqual(forceRefreshes, ["a-stale", "b-stale"]);
+  assert.deepEqual(Object.fromEntries(retries), {
+    "/a": "Bearer a-fresh",
+    "/b": "Bearer b-fresh",
+  });
+});
+
+test("an unauthenticated 401 keeps the request's original auth version", async () => {
+  let sessionVersion = 1;
+  let markRequestStarted = () => {};
+  let releaseRequest = () => {};
+  const requestStarted = new Promise<void>((resolve) => {
+    markRequestStarted = resolve;
+  });
+  const requestCanFinish = new Promise<void>((resolve) => {
+    releaseRequest = resolve;
+  });
+  let handledVersion: string | number | null | undefined;
+
+  const transport = new HttpTransport({
+    baseUrl: "https://api.example.com",
+    getAccessToken: async () => null,
+    getAuthSessionVersion: () => sessionVersion,
+    onUnauthorized: (context) => {
+      handledVersion = context.authSessionVersion;
+    },
+    fetch: async () => {
+      markRequestStarted();
+      await requestCanFinish;
+      return jsonResponse(401, null);
+    },
+  });
+
+  const request = transport.request("/late-unauthenticated");
+  await requestStarted;
+  sessionVersion = 2;
+  releaseRequest();
+
+  await assert.rejects(
+    request,
+    (error: unknown) =>
+      error instanceof HttpError && error.authSessionVersion === 1,
+  );
+  assert.equal(handledVersion, 1);
+});
+
+test("a resolved bearer uses the auth version produced by token resolution", async () => {
+  let sessionVersion = 0;
+  let normalCalls = 0;
+  let handledVersion: string | number | null | undefined;
+  const transport = new HttpTransport({
+    baseUrl: "https://api.example.com",
+    getAuthSessionVersion: () => sessionVersion,
+    getAccessToken: async (options) => {
+      if (options?.forceRefresh) return null;
+      normalCalls += 1;
+      if (normalCalls === 1) sessionVersion = 1;
+      return "resolved-token";
+    },
+    onUnauthorized: (context) => {
+      handledVersion = context.authSessionVersion;
+    },
+    fetch: async () => jsonResponse(401, null),
+  });
+
+  await assert.rejects(
+    transport.request("/resolved-token-rejected"),
+    (error: unknown) =>
+      error instanceof HttpError && error.authSessionVersion === 1,
+  );
+  assert.equal(handledVersion, 1);
+});
+
+test("final unauthorized callback identifies the rejected retry token", async () => {
+	let currentToken = "stale";
+	let sessionVersion = 0;
+	const rejectedTokenMatches: boolean[] = [];
+	let rejectedSessionVersion: string | number | null | undefined;
+	const transport = new HttpTransport({
+		baseUrl: "https://api.example.com",
+		getAccessToken: async (options) => {
+			if (options?.forceRefresh) {
+				currentToken = "fresh";
+				sessionVersion = 1;
+			}
+			return currentToken;
+		},
+		getAuthSessionVersion: () => sessionVersion,
+		onUnauthorized: ({ authSessionVersion, matchesRejectedToken }) => {
+			rejectedSessionVersion = authSessionVersion;
+			rejectedTokenMatches.push(
+				matchesRejectedToken("fresh"),
+				matchesRejectedToken("stale"),
+			);
+    },
+    fetch: async () => jsonResponse(401, { message: "unauthorized" }),
+  });
+
+	await assert.rejects(
+		() => transport.request("/still-unauthorized"),
+		(error: unknown) =>
+			error instanceof HttpError &&
+			error.status === 401 &&
+			error.unauthorizedHandled &&
+			error.authSessionVersion === 1 &&
+			!Object.hasOwn(error, "rejectedToken") &&
+			matchesUnauthorizedErrorToken(error, "fresh") === true &&
+			matchesUnauthorizedErrorToken(error, "stale") === false,
+	);
+	assert.deepEqual(rejectedTokenMatches, [true, false]);
+	assert.equal(rejectedSessionVersion, 1);
+});
+
+test("a skipped unauthorized callback leaves the error unhandled", async () => {
+	let unauthorizedCalls = 0;
+	const transport = new HttpTransport({
+		baseUrl: "https://api.example.com",
+		getAccessToken: async () => null,
+		onUnauthorized: () => {
+			unauthorizedCalls += 1;
+		},
+		fetch: async () => jsonResponse(401, { message: "unauthorized" }),
+	});
+
+	await assert.rejects(
+		() =>
+			transport.request("/bootstrap", {
+				skipUnauthorizedHandler: true,
+			}),
+		(error: unknown) =>
+			error instanceof HttpError &&
+			error.status === 401 &&
+			!error.unauthorizedHandled &&
+			matchesUnauthorizedErrorToken(error, null) === true,
+	);
+	assert.equal(unauthorizedCalls, 0);
+});


### PR DESCRIPTION
## Why this change

This PR fixes a client-side race in Cohub’s HTTP 401 recovery flow.

Previously, when several API requests received 401 responses at the same time, each request could independently force a Logto token refresh. Because refresh tokens may rotate, concurrent exchanges could cause some requests to fail with `invalid_grant`.

A failed request would then clear the entire local Logto session without checking whether another request had already refreshed it. As a result, a late failure could delete a newer valid session and send the user back through the sign-in flow.

The externally visible symptoms included:

- Bursts of `ExchangeTokenBy.RefreshToken` events in Logto;
- Repeated refreshes for the same user;
- Intermittent session loss or unexpected sign-in redirects;
- Higher reproduction probability during page bootstrap, concurrent API calls, or multi-tab usage.

## What this PR changes

The HTTP recovery sequence is now:

`HTTP 401 → check for a newer token → coalesce refresh → retry once → clean up only if token and session version still match`

The implementation ensures that:

- Concurrent 401 responses for the same rejected token share one refresh.
- Different rejected tokens do not incorrectly share a refresh result.
- A late 401 reuses a newer token when another request or tab has already recovered.
- Waiting requests share refresh failures instead of immediately repeating the exchange.
- The token and session version used by the rejected request are preserved through the retry flow.
- Final cleanup or sign-in only runs if the rejected token and session version still represent the current session.
- OAuth callback processing uses the same lock as refresh and cleanup, so an older request cannot delete a newly established session.

Expected impact:

- Significantly fewer duplicate Logto refresh exchanges during HTTP 401 bursts.
- No session loss caused by a late refresh failure clearing a newer session.
- More predictable recovery across concurrent requests and browser tabs.

## Scope

This PR is intentionally limited to the confirmed HTTP 401 refresh and session-cleanup race.

It does not change:

- WebSocket reconnect behavior;
- Voice token handling;
- Work Bridge or Work Runtime protocols;
- User-initiated sign-in or sign-out behavior;
- Logto server configuration or token lifetime settings.

WebSocket, Voice, and Work still use the shared coordinated Logto resolver, so overlapping refreshes are serialized. However, a force refresh without a rejected-token identity that starts after an earlier winner has completed remains outside this PR’s scope.

## Non-test file changes

| File | Purpose |
| --- | --- |
| `.changeset/calm-tokens-refresh.md` | Records the fix as an SDK patch release and documents concurrent refresh deduplication and stale unauthorized-request protection. |
| `packages/sdk/src/transport.ts` | Implements the HTTP-side fix. It captures the bearer token and auth-session version used by each request, coalesces refreshes for the same rejected token, isolates different rejected tokens, retries once, and exposes safe context for final 401 handling. |
| `packages/sdk/src/index.ts` | Exports the rejected-token matcher used by the Web client to determine whether an HTTP error still belongs to the current session without exposing the rejected token itself. |
| `apps/web/src/lib/auth-refresh-coordinator.ts` | Adds the auth concurrency coordinator. It provides same-page single-flight behavior, cross-tab mutual exclusion, refresh-result sharing, and generation/token-based guarded cleanup. |
| `apps/web/src/lib/auth.ts` | Integrates the coordinator with Logto. It maintains the shared auth-session snapshot, serializes token exchanges with Web Locks, prefers Logto’s public token API, preserves the missing-ID-token fallback, and provides guarded cleanup, recovery sign-in, and callback completion. |
| `apps/web/src/lib/sdk.ts` | Supplies the current auth-session generation to the HTTP transport. Final unauthorized handling only starts cleanup when both the rejected token and original generation still match. |
| `apps/web/src/lib/auth-redirect.ts` | Makes automatic sign-in redirects generation-aware, prevents duplicate cleanup, prevents a stale redirect from suppressing a current recovery attempt, and preserves the post-callback silent-SSO loop breaker until cleanup actually succeeds. |
| `apps/web/src/lib/stores/auth.svelte.ts` | Binds session restoration and `/api/me` 401 cleanup to the generation observed when restoration started, preventing an older bootstrap request from deleting a concurrently established session. |
| `apps/web/src/routes/(public)/callback/+page.svelte` | Runs authorization-code exchange and resource-token publication through the coordinated callback operation instead of independently handling and storing tokens. |

## Validation

The regression coverage includes:

- Eight concurrent HTTP 401 responses sharing one refresh;
- A late 401 reusing a completed refresh winner;
- Different rejected tokens receiving their correct refresh results;
- Multi-tab refresh coordination;
- A tab with a stale in-memory Logto token reusing the shared winner;
- Shared refresh failures without repeated exchanges;
- Callback success followed by resource-token failure;
- Late unauthenticated requests with no bearer token;
- Stale cleanup and redirect attempts not affecting a newer session.

Final verification:

- Web: 604 tests passed
- SDK: 166 tests passed
- Web and SDK type checks passed
- Web and SDK lint passed
- Web and SDK production builds passed