### PR TITLE
chore: upgrade generation SDK to 0.1.20

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -34,7 +34,7 @@
     "@hono/node-server": "2.0.9",
     "@hono/otel": "^1.1.2",
     "@kubernetes/client-node": "^1.4.0",
-    "@neta-art/generation": "^0.1.19",
+    "@neta-art/generation": "^0.1.20",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
     "@opentelemetry/instrumentation": "^0.220.0",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -26,7 +26,7 @@
     "@cohub/protocol": "workspace:*",
     "@cohub/sandbox-controller": "workspace:*",
     "@kubernetes/client-node": "^1.4.0",
-    "@neta-art/generation": "^0.1.19",
+    "@neta-art/generation": "^0.1.20",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
     "@opentelemetry/instrumentation": "^0.220.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@neta-art/cohub": "workspace:*",
-    "@neta-art/generation": "^0.1.19",
+    "@neta-art/generation": "^0.1.20",
     "commander": "^15.0.0",
     "pixi.js": "^8.19.0",
     "sharp": "^0.35.3"

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -85,7 +85,7 @@
   "dependencies": {
     "@cohub/protocol": "workspace:*",
     "@kubiks/otel-drizzle": "^2.1.0",
-    "@neta-art/generation": "^0.1.19",
+    "@neta-art/generation": "^0.1.20",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
     "@opentelemetry/instrumentation": "^0.220.0",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -113,7 +113,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@neta-art/generation": "^0.1.19",
+    "@neta-art/generation": "^0.1.20",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,8 +176,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       '@neta-art/generation':
-        specifier: ^0.1.19
-        version: 0.1.19
+        specifier: ^0.1.20
+        version: 0.1.20
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -528,8 +528,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       '@neta-art/generation':
-        specifier: ^0.1.19
-        version: 0.1.19
+        specifier: ^0.1.20
+        version: 0.1.20
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -618,8 +618,8 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       '@neta-art/generation':
-        specifier: ^0.1.19
-        version: 0.1.19
+        specifier: ^0.1.20
+        version: 0.1.20
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -707,8 +707,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260529.1)(@opentelemetry/api@1.9.1)(postgres@3.4.9))
       '@neta-art/generation':
-        specifier: ^0.1.19
-        version: 0.1.19
+        specifier: ^0.1.20
+        version: 0.1.20
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -762,8 +762,8 @@ importers:
   packages/protocol:
     dependencies:
       '@neta-art/generation':
-        specifier: ^0.1.19
-        version: 0.1.19
+        specifier: ^0.1.20
+        version: 0.1.20
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -2996,8 +2996,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@neta-art/generation@0.1.19':
-    resolution: {integrity: sha512-DM35c7myTqEu5DagsPgb9cOSksHqQJbpiiwFqAjd6r7jgguk2Sw0tSeY6OflbasqqX82WiSCN3ZmEIHyXh7bhg==}
+  '@neta-art/generation@0.1.20':
+    resolution: {integrity: sha512-HPXkvO1kQJPpIUdoBuzfYG5yEaEBLXy4oOhUp/VTTZiKN2oXtYHVEtUopIcUWXgvg1RFbNmCzNOaUEVb6JOdXQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -9297,7 +9297,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@neta-art/generation@0.1.19':
+  '@neta-art/generation@0.1.20':
     dependencies:
       yaml: 2.9.0
 


### PR DESCRIPTION
## What changed

- Upgrade `@neta-art/generation` from `^0.1.19` to `^0.1.20` in API, worker, CLI, infra, and protocol workspaces.
- Refresh the pnpm lockfile to resolve the published `0.1.20` package.

## Why

Cohub needs the Generation SDK release containing the latest MiniMax H3 support and validation fixes.

## Impact

All Cohub generation consumers now resolve the same `0.1.20` SDK version. No Cohub runtime behavior or schema is changed outside the dependency upgrade.

## Validation

- `pnpm lint`
- `pnpm typecheck` with Node 25 and required public Web build variables
- `pnpm build` with Node 25 and required public Web build variables
- Affected workspace typechecks: API, worker, CLI, infra, protocol
- Affected workspace tests: 302 tests passed

Full workspace tests additionally require the unavailable private optional `@talesofai-billing/sdk`; affected workspaces pass independently.
