### PR TITLE
fix(agent): harden session JSONL unicode separators

### DIFF
--- a/apps/agent/src/runtime/local-session-manager.ts
+++ b/apps/agent/src/runtime/local-session-manager.ts
@@ -111,6 +111,8 @@ function createSessionId() {
 function serializeJsonlEntry(entry: FileEntry): string {
   const json = JSON.stringify(entry);
   if (json === undefined) throw new TypeError("Session entry is not JSON serializable");
+  // JSON permits U+2028/U+2029 in strings, but Node readline treats them as line endings.
+  // Escape these two characters so one LF always represents exactly one JSONL record.
   return json.replace(/\u2028/g, "\\u2028").replace(/\u2029/g, "\\u2029");
 }
 

--- a/apps/agent/src/runtime/local-session-manager.ts
+++ b/apps/agent/src/runtime/local-session-manager.ts
@@ -1,6 +1,5 @@
 import { createReadStream, createWriteStream, type WriteStream } from "node:fs";
 import { access, copyFile, mkdir, open, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { createInterface } from "node:readline";
 import { basename, dirname, join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
@@ -109,6 +108,36 @@ function createSessionId() {
   return randomUUID();
 }
 
+function serializeJsonlEntry(entry: FileEntry): string {
+  const json = JSON.stringify(entry);
+  if (json === undefined) throw new TypeError("Session entry is not JSON serializable");
+  return json.replace(/\u2028/g, "\\u2028").replace(/\u2029/g, "\\u2029");
+}
+
+// Node readline also treats U+2028/U+2029 as line endings, although JSON permits them in strings.
+async function* readLfDelimitedLines(path: string): AsyncGenerator<{ line: string; terminated: boolean }> {
+  const input = createReadStream(path, { encoding: "utf-8" });
+  let fragments: string[] = [];
+
+  for await (const chunk of input) {
+    const text = typeof chunk === "string" ? chunk : chunk.toString("utf-8");
+    let start = 0;
+    while (start < text.length) {
+      const newline = text.indexOf("\n", start);
+      if (newline < 0) break;
+      fragments.push(text.slice(start, newline));
+      let line = fragments.join("");
+      fragments = [];
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+      yield { line, terminated: true };
+      start = newline + 1;
+    }
+    if (start < text.length) fragments.push(text.slice(start));
+  }
+
+  if (fragments.length > 0) yield { line: fragments.join(""), terminated: false };
+}
+
 function getAgentMessageMeta(message: AgentMessage): Record<string, unknown> | null {
   const meta = (message as unknown as { meta?: unknown }).meta;
   return meta && typeof meta === "object" && !Array.isArray(meta) ? meta as Record<string, unknown> : null;
@@ -191,15 +220,10 @@ async function parseEntries(
 ): Promise<FileEntry[]> {
   if (!(await pathExists(path))) return [];
   const entries: FileEntry[] = [];
-  const input = createReadStream(path, { encoding: "utf-8" });
-  let finalByte: number | null = null;
-  input.on("data", (chunk) => {
-    if (chunk.length === 0) return;
-    finalByte = typeof chunk === "string" ? chunk.charCodeAt(chunk.length - 1) : (chunk.at(-1) ?? finalByte);
-  });
-  const lines = createInterface({ input, crlfDelay: Infinity });
+  let finalLineTerminated = true;
   let lineNumber = 0;
-  for await (const line of lines) {
+  for await (const { line, terminated } of readLfDelimitedLines(path)) {
+    finalLineTerminated = terminated;
     lineNumber += 1;
     if (!line.trim()) continue;
     try {
@@ -216,7 +240,7 @@ async function parseEntries(
     }
   }
 
-  if (options.recoverTrailingPartial && options.sessionDir && entries[0]?.type === "session" && finalByte !== 0x0a) {
+  if (options.recoverTrailingPartial && options.sessionDir && entries[0]?.type === "session" && !finalLineTerminated) {
     const archivePath = await repairMissingFinalNewline(path, options.sessionDir);
     if (archivePath) logger.warn(`[SessionManager] repaired missing final JSONL newline path=${path} archive=${archivePath}`);
   }
@@ -725,7 +749,7 @@ export class SessionManager {
       affinity: { sessionId: this.getSessionAffinity().sessionId, threadId: newSessionId },
     };
     await this.ensureSessionDir();
-    const lines = `${[JSON.stringify(header), ...pathEntries.map((entry) => JSON.stringify(entry))].join("\n")}\n`;
+    const lines = `${[serializeJsonlEntry(header), ...pathEntries.map((entry) => serializeJsonlEntry(entry))].join("\n")}\n`;
     await writeFile(newSessionFile, lines, "utf-8");
     return newSessionFile;
   }
@@ -798,7 +822,7 @@ export class SessionManager {
       const stream = this.getAppendStream();
       if (!stream || stream.destroyed) return;
       await new Promise<void>((resolve, reject) => {
-        stream.write(`${JSON.stringify(entry)}\n`, (error) => (error ? reject(error) : resolve()));
+        stream.write(`${serializeJsonlEntry(entry)}\n`, (error) => (error ? reject(error) : resolve()));
       });
     });
   }
@@ -833,7 +857,7 @@ export class SessionManager {
       if (!this.sessionFile || !this.header) return;
       await this.ensureSessionDir();
       await this.closeAppendStream();
-      const lines = [JSON.stringify(this.header), ...this.entries.map((entry) => JSON.stringify(entry))].join("\n");
+      const lines = [serializeJsonlEntry(this.header), ...this.entries.map((entry) => serializeJsonlEntry(entry))].join("\n");
       await writeFile(this.sessionFile, `${lines}${lines ? "\n" : ""}`, "utf-8");
       this.fileReady = true;
     });

--- a/apps/agent/src/tests/local-session-manager.test.ts
+++ b/apps/agent/src/tests/local-session-manager.test.ts
@@ -4,6 +4,13 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { SessionManager } from "../runtime/local-session-manager.js";
 
+function firstMessageText(manager: SessionManager): string | undefined {
+  const message = manager.buildSessionContext().messages[0] as
+    | { content?: Array<{ type?: string; text?: string }> }
+    | undefined;
+  return message?.content?.find((part) => part.type === "text")?.text;
+}
+
 const root = await mkdtemp(join(tmpdir(), "cohub-local-session-manager-"));
 try {
   const sessionsDir = join(root, "sessions");
@@ -45,6 +52,74 @@ try {
   });
   const grandchild = await SessionManager.open(grandchildSessionFile, sessionsDir);
   assert.deepEqual(grandchild.getSessionAffinity(), { sessionId: "session", threadId: "grandchild" });
+
+  const unicodeSeparatorText = "before emoji \u{1f680}\u2028between\u2029after";
+  const legacySeparatorFile = join(sessionsDir, "legacy-unicode-separators.jsonl");
+  const legacySeparatorContent = [
+    JSON.stringify({ type: "session", version: 3, id: "legacy-separators", timestamp: new Date().toISOString(), cwd: root }),
+    JSON.stringify({ type: "message", id: "legacy", parentId: null, timestamp: new Date().toISOString(), message: { role: "user", content: [{ type: "text", text: unicodeSeparatorText }], timestamp: Date.now() } }),
+    JSON.stringify({ type: "message", id: "after-legacy", parentId: "legacy", timestamp: new Date().toISOString(), message: { role: "assistant", content: [{ type: "text", text: "still valid" }], timestamp: Date.now() } }),
+    "",
+  ].join("\n");
+  assert.equal(legacySeparatorContent.includes("\u2028"), true);
+  assert.equal(legacySeparatorContent.includes("\u2029"), true);
+  await writeFile(legacySeparatorFile, legacySeparatorContent);
+  const legacySeparators = await SessionManager.open(legacySeparatorFile, sessionsDir, { recoverTrailingPartial: true });
+  assert.equal(legacySeparators.getEntries().length, 2);
+  assert.equal(firstMessageText(legacySeparators), unicodeSeparatorText);
+
+  const chunkBoundaryFile = join(sessionsDir, "chunk-boundary-unicode-separators.jsonl");
+  const chunkBoundaryText = `${"x".repeat(70_000)}\u2028chunk-boundary\u2029end`;
+  await writeFile(chunkBoundaryFile, [
+    JSON.stringify({ type: "session", version: 3, id: "chunk-boundary", timestamp: new Date().toISOString(), cwd: root }),
+    JSON.stringify({ type: "message", id: "chunk-boundary-entry", parentId: null, timestamp: new Date().toISOString(), message: { role: "user", content: [{ type: "text", text: chunkBoundaryText }], timestamp: Date.now() } }),
+    "",
+  ].join("\r\n"));
+  const chunkBoundary = await SessionManager.open(chunkBoundaryFile, sessionsDir);
+  assert.equal(firstMessageText(chunkBoundary), chunkBoundaryText);
+
+  const appendSeparatorFile = join(sessionsDir, "append-unicode-separators.jsonl");
+  const appendSeparators = SessionManager.create(root, sessionsDir);
+  appendSeparators.newSession({ id: "append-separators" });
+  appendSeparators.setSessionFile(appendSeparatorFile);
+  await appendSeparators.flush();
+  appendSeparators.appendMessage({
+    role: "user",
+    content: [{ type: "text", text: unicodeSeparatorText }],
+    timestamp: Date.now(),
+  } as never);
+  await appendSeparators.close();
+  const appendSeparatorContent = await readFile(appendSeparatorFile, "utf-8");
+  assert.equal(appendSeparatorContent.includes("\u2028"), false);
+  assert.equal(appendSeparatorContent.includes("\u2029"), false);
+  assert.equal(appendSeparatorContent.includes("\\u2028"), true);
+  assert.equal(appendSeparatorContent.includes("\\u2029"), true);
+  assert.equal(firstMessageText(await SessionManager.open(appendSeparatorFile, sessionsDir)), unicodeSeparatorText);
+
+  const rewriteSeparatorFile = join(sessionsDir, "rewrite-unicode-separators.jsonl");
+  const rewriteSeparators = SessionManager.create(root, sessionsDir);
+  rewriteSeparators.newSession({ id: "rewrite-separators" });
+  rewriteSeparators.appendMessage({
+    role: "user",
+    content: [{ type: "text", text: unicodeSeparatorText }],
+    timestamp: Date.now(),
+  } as never);
+  rewriteSeparators.setSessionFile(rewriteSeparatorFile);
+  await rewriteSeparators.close();
+  const rewriteSeparatorContent = await readFile(rewriteSeparatorFile, "utf-8");
+  assert.equal(rewriteSeparatorContent.includes("\u2028"), false);
+  assert.equal(rewriteSeparatorContent.includes("\u2029"), false);
+  assert.equal(firstMessageText(await SessionManager.open(rewriteSeparatorFile, sessionsDir)), unicodeSeparatorText);
+
+  const separatorBranchFile = join(sessionsDir, "branch-unicode-separators.jsonl");
+  await rewriteSeparators.createBranchedSession(rewriteSeparators.getBranchEntries().at(-1)?.id ?? "", {
+    id: "branch-separators",
+    filePath: separatorBranchFile,
+  });
+  const separatorBranchContent = await readFile(separatorBranchFile, "utf-8");
+  assert.equal(separatorBranchContent.includes("\u2028"), false);
+  assert.equal(separatorBranchContent.includes("\u2029"), false);
+  assert.equal(firstMessageText(await SessionManager.open(separatorBranchFile, sessionsDir)), unicodeSeparatorText);
 
   const branchedSessionFile = join(sessionsDir, "branched.jsonl");
   await writeFile(branchedSessionFile, [


### PR DESCRIPTION
## Summary

- escape raw U+2028/U+2029 characters in every agent session JSONL write path
- replace Node `readline` parsing with a streaming LF-delimited reader so valid historical records are not split at Unicode line/paragraph separators
- preserve CRLF support, trailing-partial recovery, and missing-final-newline repair
- add regression coverage for legacy raw separators, append/rewrite/branch serialization, emoji offsets, and a CRLF record larger than one stream chunk

## Root cause

`JSON.stringify` preserves U+2028/U+2029 inside JSON strings, while Node `readline` treats those characters as line terminators. A valid physical JSONL record could therefore be split in the middle of a string and fail with `Unterminated string`. Because later records still existed, trailing-partial recovery could not repair the session.

## Validation

- `pnpm --filter @cohub/agent test` (21 tests)
- `pnpm --filter @cohub/agent lint`
- `pnpm --filter @cohub/agent typecheck`
- `pnpm --filter @cohub/agent... build`
- pre-commit `pnpm -r typecheck` across 15 workspaces
- `git diff --check`

Historical files do not require a migration: the new reader accepts valid records containing raw U+2028/U+2029, while future writes use escaped representations.