### PR TITLE
ci: add PR checks and label-triggered preview environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  js-checks:
+    name: Lint, typecheck, test, build
+    runs-on: ubuntu-latest
+    env:
+      GITEA_NPM_TOKEN: ${{ secrets.GITEA_NPM_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      # Optional: only used when available; installs fine without it
+      # because @talesofai-billing/sdk is an optional dependency.
+      - name: Configure Talesofai npm auth
+        run: |
+          if [ -z "$GITEA_NPM_TOKEN" ]; then
+            echo "GITEA_NPM_TOKEN not set; installing without private billing packages"
+          fi
+          if [ -n "$GITEA_NPM_TOKEN" ]; then
+            printf '\n//git.talesofai.com/api/packages/talesofai/npm/:_authToken=%s\n' "$GITEA_NPM_TOKEN" >> ~/.npmrc
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+  go-checks:
+    name: Format, vet, test (sandbox)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: apps/sandbox/go.sum
+
+      - name: Check formatting
+        working-directory: apps/sandbox
+        run: test -z "$(gofmt -l .)"
+
+      - name: Vet
+        working-directory: apps/sandbox
+        run: go vet ./...
+
+      - name: Test
+        working-directory: apps/sandbox
+        run: go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,22 @@ jobs:
       # Build first: workspace packages export types/runtime from dist/, so
       # typecheck and tests need the build artifacts present (clean checkout
       # has none). This mirrors the deploy workflows' build-before-check order.
+      # SvelteKit statically inlines $env/static/public at build time; a clean
+      # checkout has no .env, so named imports fail with MISSING_EXPORT.
+      # Use dev values, same as web-deploy-cloudflare.yml.
+      - name: Setup web environment
+        working-directory: apps/web
+        run: |
+          cat > .env <<EOF
+          PUBLIC_COHUB_ENV=dev
+          PUBLIC_API_ORIGIN=https://api-dev.cohub.run
+          PUBLIC_GATEWAY_ORIGIN=https://gateway-dev.cohub.run
+          PUBLIC_PREVIEW_ORIGIN=https://preview-dev.cohub.run
+          PUBLIC_LOGTO_ENDPOINT=https://dev-auth.neta.art/
+          PUBLIC_LOGTO_APP_ID=vpikk7sl9zwvefiptowtn
+          PUBLIC_LOGTO_API_RESOURCE=https://api.talesofai
+          EOF
+
       - name: Build
         run: pnpm build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,17 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      # Build first: workspace packages export types/runtime from dist/, so
+      # typecheck and tests need the build artifacts present (clean checkout
+      # has none). This mirrors the deploy workflows' build-before-check order.
+      - name: Build
+        run: pnpm build
+
       - name: Typecheck
         run: pnpm typecheck
 
       - name: Test
         run: pnpm test
-
-      - name: Build
-        run: pnpm build
 
   go-checks:
     name: Format, vet, test (sandbox)

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,7 +1,8 @@
 name: Preview Cleanup
 
-# PR 关闭/合并后销毁预览环境：删除 k8s namespace、跨 namespace RoleBinding、
-# Cloudflare Worker。幂等，可安全重复执行。
+# PR 关闭/合并后销毁预览环境。预览资源部署在 cohub-dev namespace（资源名带
+# pr-<n> 前缀），所以这里精确删除带前缀的资源，绝不删除 namespace 或任何
+# dev 资源。幂等，可安全重复执行。
 
 on:
   pull_request:
@@ -20,8 +21,9 @@ permissions:
 
 env:
   PR_NUMBER: ${{ github.event.pull_request.number }}
-  PREVIEW_NAMESPACE: cohub-preview-${{ github.event.pull_request.number }}
+  NAMESPACE: cohub-dev
   API_APP_NAME: cohub-api-pr-${{ github.event.pull_request.number }}
+  GATEWAY_APP_NAME: cohub-gateway-pr-${{ github.event.pull_request.number }}
   WEB_WORKER_NAME: cohub-web-pr-${{ github.event.pull_request.number }}
 
 jobs:
@@ -42,11 +44,27 @@ jobs:
           mkdir -p ~/.kube
           echo "${{ secrets.KUBECONFIG_DEV }}" | base64 -d > ~/.kube/config
 
-      - name: Delete k8s resources
+      - name: Delete preview k8s resources
         run: |
-          kubectl delete namespace "${{ env.PREVIEW_NAMESPACE }}" --ignore-not-found --wait=false
+          set -euo pipefail
+          NS="${{ env.NAMESPACE }}"
+
+          # API
+          kubectl delete deployment "${{ env.API_APP_NAME }}" -n "$NS" --ignore-not-found
+          kubectl delete service "${{ env.API_APP_NAME }}" -n "$NS" --ignore-not-found
+          kubectl delete configmap "${{ env.API_APP_NAME }}-config" -n "$NS" --ignore-not-found
+          kubectl delete secret "${{ env.API_APP_NAME }}-secrets" -n "$NS" --ignore-not-found
+          kubectl delete httproute "${{ env.API_APP_NAME }}-route" -n "$NS" --ignore-not-found
+          kubectl delete serviceaccount "${{ env.API_APP_NAME }}" -n "$NS" --ignore-not-found
           kubectl delete rolebinding "${{ env.API_APP_NAME }}-sessions-manager" \
             -n cohub-sessions-dev --ignore-not-found
+
+          # Gateway
+          kubectl delete statefulset "${{ env.GATEWAY_APP_NAME }}" -n "$NS" --ignore-not-found
+          kubectl delete service "${{ env.GATEWAY_APP_NAME }}" -n "$NS" --ignore-not-found
+          kubectl delete configmap "${{ env.GATEWAY_APP_NAME }}-config" -n "$NS" --ignore-not-found
+          kubectl delete secret "${{ env.GATEWAY_APP_NAME }}-secrets" -n "$NS" --ignore-not-found
+          kubectl delete httproute "${{ env.GATEWAY_APP_NAME }}-route" -n "$NS" --ignore-not-found
 
       - name: Delete Cloudflare Worker
         run: |

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,55 @@
+name: Preview Cleanup
+
+# PR 关闭/合并后销毁预览环境：删除 k8s namespace、跨 namespace RoleBinding、
+# Cloudflare Worker。幂等，可安全重复执行。
+
+on:
+  pull_request:
+    types: [closed]
+    paths-ignore:
+      - 'docs/**'
+      - 'assets/**'
+      - '**.md'
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  PR_NUMBER: ${{ github.event.pull_request.number }}
+  PREVIEW_NAMESPACE: cohub-preview-${{ github.event.pull_request.number }}
+  API_APP_NAME: cohub-api-pr-${{ github.event.pull_request.number }}
+  WEB_WORKER_NAME: cohub-web-pr-${{ github.event.pull_request.number }}
+
+jobs:
+  cleanup:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'v1.30.0'
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_DEV }}" | base64 -d > ~/.kube/config
+
+      - name: Delete k8s resources
+        run: |
+          kubectl delete namespace "${{ env.PREVIEW_NAMESPACE }}" --ignore-not-found --wait=false
+          kubectl delete rolebinding "${{ env.API_APP_NAME }}-sessions-manager" \
+            -n cohub-sessions-dev --ignore-not-found
+
+      - name: Delete Cloudflare Worker
+        run: |
+          curl -sf -X DELETE \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/${{ env.WEB_WORKER_NAME }}" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" || true

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -145,6 +145,9 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     needs: [build-images, deploy-web]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     environment:
       name: preview-${{ github.event.pull_request.number }}
       url: ${{ needs.deploy-web.outputs.web_url }}
@@ -342,6 +345,59 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Post preview comment
+        uses: actions/github-script@v7
+        env:
+          WEB_URL: ${{ env.WEB_URL }}
+          API_HOSTNAME: ${{ env.API_HOSTNAME }}
+          GATEWAY_HOSTNAME: ${{ env.GATEWAY_HOSTNAME }}
+        with:
+          script: |
+            const marker = "<!-- cohub-preview-deploy -->";
+            const shortSha = context.payload.pull_request.head.sha.slice(0, 7);
+            const webUrl = process.env.WEB_URL;
+            const apiUrl = `https://${process.env.API_HOSTNAME}`;
+            const gatewayUrl = `https://${process.env.GATEWAY_HOSTNAME}`;
+            const updated = new Date().toUTCString();
+
+            const body = `${marker}
+            <img src="https://cohub.run/favicon.svg" width="20" height="20" alt="Cohub" align="left" /> &nbsp;**Cohub Preview Deployed**
+
+            | Status | Name | Commit | Preview URL | Updated (UTC) |
+            |---|---|---|---|---|
+            | ✅ Deployment successful! | \`cohub-web-pr-${context.issue.number}\` | \`${shortSha}\` | [${webUrl.replace("https://", "")}](${webUrl}) | ${updated} |
+
+            - Web: [${webUrl}](${webUrl})
+            - API: [${apiUrl}](${apiUrl})
+            - Gateway: [${gatewayUrl}](${gatewayUrl})
+
+            > Shares the dev data layer (database, storage, configs). Destroyed automatically when this PR closes.
+            `;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              console.log("Updated preview comment", existing.id);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              console.log("Created preview comment");
+            }
 
       - name: Post preview URLs
         run: |

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -32,7 +32,9 @@ env:
   GATEWAY_APP_NAME: cohub-gateway-pr-${{ github.event.pull_request.number }}
   API_HOSTNAME: api-${{ github.event.pull_request.number }}-preview.cohub.run
   GATEWAY_HOSTNAME: gateway-${{ github.event.pull_request.number }}-preview.cohub.run
-  WEB_HOSTNAME: web-${{ github.event.pull_request.number }}-preview.cohub.run
+  # Web 域名必须以 dev 开头：auth.ts 的 IS_DEV 按 location.hostname.startsWith("dev")
+  # 运行时判断 Logto 端点（dev-auth vs auth），preview 必须落入 dev 分支
+  WEB_HOSTNAME: dev-${{ github.event.pull_request.number }}-preview.cohub.run
   WEB_WORKER_NAME: cohub-web-pr-${{ github.event.pull_request.number }}
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -238,9 +238,12 @@ jobs:
           SPACE_STORAGE_PVC: "${SPACE_STORAGE_PVC}"
           SPACE_SYSTEM_PVC: "${SPACE_SYSTEM_PVC}"
           CHECKPOINT_CACHE_PVC: "${CHECKPOINT_CACHE_PVC}"
-          SPACE_STORAGE_SUBPATH: "workspaces/preview-${{ env.PR_NUMBER }}"
-          SPACE_SYSTEM_SUBPATH: "preview-${{ env.PR_NUMBER }}"
-          CHECKPOINT_CACHE_SUBPATH: "workspaces/preview-${{ env.PR_NUMBER }}/checkpoints"
+          # 共享 dev 数据层：数据库已共享，文件 subpath 也必须用 dev 同款，
+          # 否则 preview 打开 dev 的 space 时找不到文件（404）。写入同样落在
+          # dev 数据上，与数据库共享的模型一致。
+          SPACE_STORAGE_SUBPATH: "$(get_cm SPACE_STORAGE_SUBPATH)"
+          SPACE_SYSTEM_SUBPATH: "$(get_cm SPACE_SYSTEM_SUBPATH)"
+          CHECKPOINT_CACHE_SUBPATH: "$(get_cm CHECKPOINT_CACHE_SUBPATH)"
           PLATFORM_CONFIG_ROOT: "$(get_cm PLATFORM_CONFIG_ROOT)"
           TURN_OBJECT_S3_ENDPOINT: "$(get_cm TURN_OBJECT_S3_ENDPOINT)"
           TURN_OBJECT_S3_REGION: "$(get_cm TURN_OBJECT_S3_REGION)"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -2,8 +2,10 @@ name: Preview Deploy
 
 # 预览环境：维护者打 preview label 后为 PR 部署临时环境（人工 gate，避免不可信代码
 # 自动获得 secrets 执行权）。部署脚本固定用 main 分支（可信），PR 代码只以镜像形式进入。
+# - 首次（labeled / reopened）：全量部署 api + gateway + web
+# - 后续 push（synchronize）：按变更路径增量部署（dorny/paths-filter）
 # - api / gateway：部署到 cohub-dev namespace（共享 PVC/配置），资源名带 pr-<n> 前缀隔离
-# - web：独立 Cloudflare Worker（cohub-web-pr-<n>），route 绑定 web-<n>-preview.cohub.run
+# - web：独立 Cloudflare Worker（cohub-web-pr-<n>），route 绑定 dev-<n>-preview.cohub.run
 # 共享 dev：数据库（不跑 migration）、sandbox 镜像、PVC 存储（subpath 隔离）、configs。
 # fork PR 不部署（拿不到 secrets），只跑 CI。
 
@@ -54,6 +56,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Detect changed apps
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            api:
+              - 'apps/api/**'
+              - 'packages/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.npmrc'
+              - 'tsconfig.base.json'
+            gateway:
+              - 'apps/gateway/**'
+              - 'packages/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.npmrc'
+              - 'tsconfig.base.json'
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -65,6 +89,11 @@ jobs:
           password: ${{ secrets.GITEA_PAT }}
 
       - name: Build and push
+        # 首次（labeled/reopened）全量构建；后续按变更路径增量构建
+        if: >-
+          contains(fromJSON('["labeled", "reopened"]'), github.event.action) ||
+          (matrix.app == 'api' && steps.changes.outputs.api == 'true') ||
+          (matrix.app == 'gateway' && steps.changes.outputs.gateway == 'true')
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -82,8 +111,6 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'preview') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    outputs:
-      web_url: ${{ steps.resolve-url.outputs.web_url }}
     env:
       GITEA_NPM_TOKEN: ${{ secrets.GITEA_NPM_TOKEN }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -113,7 +140,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Detect changed apps
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            web:
+              - 'apps/web/**'
+              - 'packages/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.npmrc'
+              - 'tsconfig.base.json'
+
       - name: Setup web environment
+        if: >-
+          contains(fromJSON('["labeled", "reopened"]'), github.event.action) ||
+          steps.changes.outputs.web == 'true'
         working-directory: apps/web
         run: |
           # 前端指向 preview 后端；登录用 dev Logto（用户数据在 dev 库）
@@ -128,14 +172,23 @@ jobs:
           EOF
 
       - name: Build
+        if: >-
+          contains(fromJSON('["labeled", "reopened"]'), github.event.action) ||
+          steps.changes.outputs.web == 'true'
         working-directory: apps/web
         run: pnpm build
 
       - name: Deploy to Cloudflare
+        if: >-
+          contains(fromJSON('["labeled", "reopened"]'), github.event.action) ||
+          steps.changes.outputs.web == 'true'
         working-directory: apps/web
         run: pnpm exec wrangler deploy --name ${{ env.WEB_WORKER_NAME }} --routes "${{ env.WEB_HOSTNAME }}/*"
 
       - name: Resolve preview URL
+        if: >-
+          contains(fromJSON('["labeled", "reopened"]'), github.event.action) ||
+          steps.changes.outputs.web == 'true'
         id: resolve-url
         run: echo "web_url=https://${{ env.WEB_HOSTNAME }}" >> "$GITHUB_OUTPUT"
 
@@ -143,16 +196,17 @@ jobs:
     if: >-
       contains(github.event.pull_request.labels.*.name, 'preview') &&
       github.event.pull_request.head.repo.full_name == github.repository
-    needs: [build-images, deploy-web]
+    # build-images 全 skip（如仅 web 变更）时本 job 自动 skip
+    needs: [build-images]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
     environment:
       name: preview-${{ github.event.pull_request.number }}
-      url: ${{ needs.deploy-web.outputs.web_url }}
+      url: https://${{ env.WEB_HOSTNAME }}
     env:
-      WEB_URL: ${{ needs.deploy-web.outputs.web_url }}
+      WEB_URL: https://${{ env.WEB_HOSTNAME }}
     steps:
       # 部署脚本/模板必须来自 main（可信）；PR 的代码只以镜像 tag 形式进入
       - name: Checkout (main)
@@ -170,7 +224,32 @@ jobs:
           mkdir -p ~/.kube
           echo "${{ secrets.KUBECONFIG_DEV }}" | base64 -d > ~/.kube/config
 
+      - name: Detect changed apps
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            api:
+              - 'apps/api/**'
+              - 'packages/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.npmrc'
+              - 'tsconfig.base.json'
+            gateway:
+              - 'apps/gateway/**'
+              - 'packages/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.npmrc'
+              - 'tsconfig.base.json'
+
       - name: Create preview ServiceAccount and RBAC
+        if: >-
+          contains(fromJSON('["labeled", "reopened"]'), github.event.action) ||
+          steps.changes.outputs.api == 'true'
         run: |
           # 部署在 cohub-dev（共享 PVC/配置），不建 namespace；
           # 资源名前缀 pr-<n> 隔离。API 的 ServiceAccount（deployment 通过
@@ -186,6 +265,9 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Deploy API
+        if: >-
+          contains(fromJSON('["labeled", "reopened"]'), github.event.action) ||
+          steps.changes.outputs.api == 'true'
         working-directory: deploy/api/dev
         run: |
           set -euo pipefail
@@ -277,6 +359,9 @@ jobs:
           bash deploy.sh
 
       - name: Deploy Gateway
+        if: >-
+          contains(fromJSON('["labeled", "reopened"]'), github.event.action) ||
+          steps.changes.outputs.gateway == 'true'
         working-directory: deploy/gateway/dev
         run: |
           set -euo pipefail

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -2,7 +2,7 @@ name: Preview Deploy
 
 # 预览环境：维护者打 preview label 后为 PR 部署临时环境（人工 gate，避免不可信代码
 # 自动获得 secrets 执行权）。部署脚本固定用 main 分支（可信），PR 代码只以镜像形式进入。
-# - api / gateway：独立 k8s namespace（cohub-preview-<n>），镜像 tag pr-<n>-<sha>
+# - api / gateway：部署到 cohub-dev namespace（共享 PVC/配置），资源名带 pr-<n> 前缀隔离
 # - web：独立 Cloudflare Worker（cohub-web-pr-<n>），route 绑定 web-<n>-preview.cohub.run
 # 共享 dev：数据库（不跑 migration）、sandbox 镜像、PVC 存储（subpath 隔离）、configs。
 # fork PR 不部署（拿不到 secrets），只跑 CI。
@@ -27,7 +27,7 @@ env:
   IMAGE_NAMESPACE: ${{ secrets.GITEA_OWNER }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   IMAGE_TAG: pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
-  PREVIEW_NAMESPACE: cohub-preview-${{ github.event.pull_request.number }}
+  PREVIEW_NAMESPACE: cohub-dev
   API_APP_NAME: cohub-api-pr-${{ github.event.pull_request.number }}
   GATEWAY_APP_NAME: cohub-gateway-pr-${{ github.event.pull_request.number }}
   API_HOSTNAME: api-${{ github.event.pull_request.number }}-preview.cohub.run
@@ -165,16 +165,15 @@ jobs:
           mkdir -p ~/.kube
           echo "${{ secrets.KUBECONFIG_DEV }}" | base64 -d > ~/.kube/config
 
-      - name: Create preview namespace and RBAC
+      - name: Create preview ServiceAccount and RBAC
         run: |
-          kubectl create namespace "${{ env.PREVIEW_NAMESPACE }}" --dry-run=client -o yaml | kubectl apply -f -
-
-          # API 的 ServiceAccount（deployment 通过 serviceAccountName 引用）
+          # 部署在 cohub-dev（共享 PVC/配置），不建 namespace；
+          # 资源名前缀 pr-<n> 隔离。API 的 ServiceAccount（deployment 通过
+          # serviceAccountName 引用）需要在 cohub-sessions-dev 管理 sandbox pods，
+          # 复用 dev 已有的 Role，只加一个跨 namespace 的 binding
           kubectl create serviceaccount "${{ env.API_APP_NAME }}" \
             -n "${{ env.PREVIEW_NAMESPACE }}" --dry-run=client -o yaml | kubectl apply -f -
 
-          # API 需要在共享的 sessions namespace 中创建 sandbox pods；
-          # 复用 dev 已有的 Role（cohub-api-dev-sessions-manager），只加一个跨 namespace 的 binding
           kubectl create rolebinding "${{ env.API_APP_NAME }}-sessions-manager" \
             -n cohub-sessions-dev \
             --role=cohub-api-dev-sessions-manager \

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -338,7 +338,14 @@ jobs:
             "https://${{ env.API_HOSTNAME }}/healthz" \
             "https://${{ env.GATEWAY_HOSTNAME }}/healthz" \
             "${{ env.WEB_URL }}"; do
-            code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || echo "curl-failed")
+            code=""
+            # 滚动更新后 endpoint/traefik 传播有秒级延迟，重试至多 60s
+            for i in $(seq 1 12); do
+              code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || echo "curl-failed")
+              if [ "$code" = "200" ]; then break; fi
+              echo "  retry $i: $url -> $code"
+              sleep 5
+            done
             echo "$url -> $code"
             if [ "$code" != "200" ]; then
               echo "SMOKE TEST FAILED: $url returned $code"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -331,9 +331,17 @@ jobs:
           kubectl rollout status deployment/${{ env.API_APP_NAME }} -n ${{ env.PREVIEW_NAMESPACE }} --timeout=300s
           kubectl rollout status statefulset/${{ env.GATEWAY_APP_NAME }} -n ${{ env.PREVIEW_NAMESPACE }} --timeout=300s
 
-          curl -sf "https://${{ env.API_HOSTNAME }}/healthz" > /dev/null
-          curl -sf "https://${{ env.GATEWAY_HOSTNAME }}/healthz" > /dev/null
-          curl -sf "${{ env.WEB_URL }}" > /dev/null
+          for url in \
+            "https://${{ env.API_HOSTNAME }}/healthz" \
+            "https://${{ env.GATEWAY_HOSTNAME }}/healthz" \
+            "${{ env.WEB_URL }}"; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || echo "curl-failed")
+            echo "$url -> $code"
+            if [ "$code" != "200" ]; then
+              echo "SMOKE TEST FAILED: $url returned $code"
+              exit 1
+            fi
+          done
 
       - name: Post preview URLs
         run: |

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,345 @@
+name: Preview Deploy
+
+# 预览环境：维护者打 preview label 后为 PR 部署临时环境（人工 gate，避免不可信代码
+# 自动获得 secrets 执行权）。部署脚本固定用 main 分支（可信），PR 代码只以镜像形式进入。
+# - api / gateway：独立 k8s namespace（cohub-preview-<n>），镜像 tag pr-<n>-<sha>
+# - web：独立 Cloudflare Worker（cohub-web-pr-<n>），route 绑定 web-<n>-preview.cohub.run
+# 共享 dev：数据库（不跑 migration）、sandbox 镜像、PVC 存储（subpath 隔离）、configs。
+# fork PR 不部署（拿不到 secrets），只跑 CI。
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths-ignore:
+      - 'docs/**'
+      - 'assets/**'
+      - '**.md'
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: git.talesofai.com
+  IMAGE_NAMESPACE: ${{ secrets.GITEA_OWNER }}
+  PR_NUMBER: ${{ github.event.pull_request.number }}
+  IMAGE_TAG: pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+  PREVIEW_NAMESPACE: cohub-preview-${{ github.event.pull_request.number }}
+  API_APP_NAME: cohub-api-pr-${{ github.event.pull_request.number }}
+  GATEWAY_APP_NAME: cohub-gateway-pr-${{ github.event.pull_request.number }}
+  API_HOSTNAME: api-${{ github.event.pull_request.number }}-preview.cohub.run
+  GATEWAY_HOSTNAME: gateway-${{ github.event.pull_request.number }}-preview.cohub.run
+  WEB_HOSTNAME: web-${{ github.event.pull_request.number }}-preview.cohub.run
+  WEB_WORKER_NAME: cohub-web-pr-${{ github.event.pull_request.number }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build-images:
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'preview') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [api, gateway]
+    env:
+      GITEA_NPM_TOKEN: ${{ secrets.GITEA_NPM_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GITEA_USERNAME }}
+          password: ${{ secrets.GITEA_PAT }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./apps/${{ matrix.app }}/Dockerfile
+          cache-from: type=gha,scope=${{ matrix.app }}-build
+          cache-to: type=gha,mode=max,scope=${{ matrix.app }}-build
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/cohub-${{ matrix.app }}:${{ env.IMAGE_TAG }}
+          platforms: linux/amd64
+          secrets: |
+            gitea_npm_token=${{ secrets.GITEA_NPM_TOKEN }}
+
+  deploy-web:
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'preview') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    outputs:
+      web_url: ${{ steps.resolve-url.outputs.web_url }}
+    env:
+      GITEA_NPM_TOKEN: ${{ secrets.GITEA_NPM_TOKEN }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Configure Talesofai npm auth
+        run: |
+          if [ -z "$GITEA_NPM_TOKEN" ]; then
+            echo "GITEA_NPM_TOKEN not set; installing without private billing packages"
+          fi
+          if [ -n "$GITEA_NPM_TOKEN" ]; then
+            printf '\n//git.talesofai.com/api/packages/talesofai/npm/:_authToken=%s\n' "$GITEA_NPM_TOKEN" >> ~/.npmrc
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup web environment
+        working-directory: apps/web
+        run: |
+          # 前端指向 preview 后端；登录用 dev Logto（用户数据在 dev 库）
+          cat > .env <<EOF
+          PUBLIC_COHUB_ENV=dev
+          PUBLIC_API_ORIGIN=https://${{ env.API_HOSTNAME }}
+          PUBLIC_GATEWAY_ORIGIN=https://${{ env.GATEWAY_HOSTNAME }}
+          PUBLIC_PREVIEW_ORIGIN=https://preview-dev.cohub.run
+          PUBLIC_LOGTO_ENDPOINT=https://dev-auth.neta.art/
+          PUBLIC_LOGTO_APP_ID=vpikk7sl9zwvefiptowtn
+          PUBLIC_LOGTO_API_RESOURCE=https://api.talesofai
+          EOF
+
+      - name: Build
+        working-directory: apps/web
+        run: pnpm build
+
+      - name: Deploy to Cloudflare
+        working-directory: apps/web
+        run: pnpm exec wrangler deploy --name ${{ env.WEB_WORKER_NAME }} --routes "${{ env.WEB_HOSTNAME }}/*"
+
+      - name: Resolve preview URL
+        id: resolve-url
+        run: echo "web_url=https://${{ env.WEB_HOSTNAME }}" >> "$GITHUB_OUTPUT"
+
+  deploy-backend:
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'preview') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    needs: [build-images, deploy-web]
+    runs-on: ubuntu-latest
+    environment:
+      name: preview-${{ github.event.pull_request.number }}
+      url: ${{ needs.deploy-web.outputs.web_url }}
+    env:
+      WEB_URL: ${{ needs.deploy-web.outputs.web_url }}
+    steps:
+      # 部署脚本/模板必须来自 main（可信）；PR 的代码只以镜像 tag 形式进入
+      - name: Checkout (main)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'v1.30.0'
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_DEV }}" | base64 -d > ~/.kube/config
+
+      - name: Create preview namespace and RBAC
+        run: |
+          kubectl create namespace "${{ env.PREVIEW_NAMESPACE }}" --dry-run=client -o yaml | kubectl apply -f -
+
+          # API 的 ServiceAccount（deployment 通过 serviceAccountName 引用）
+          kubectl create serviceaccount "${{ env.API_APP_NAME }}" \
+            -n "${{ env.PREVIEW_NAMESPACE }}" --dry-run=client -o yaml | kubectl apply -f -
+
+          # API 需要在共享的 sessions namespace 中创建 sandbox pods；
+          # 复用 dev 已有的 Role（cohub-api-dev-sessions-manager），只加一个跨 namespace 的 binding
+          kubectl create rolebinding "${{ env.API_APP_NAME }}-sessions-manager" \
+            -n cohub-sessions-dev \
+            --role=cohub-api-dev-sessions-manager \
+            --serviceaccount="${{ env.PREVIEW_NAMESPACE }}:${{ env.API_APP_NAME }}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Deploy API
+        working-directory: deploy/api/dev
+        run: |
+          set -euo pipefail
+
+          # secrets 直接复制 dev 的（数据库/Redis/OSS 等全部共享，与 namespace 无关）
+          kubectl get secret cohub-api-dev-secrets -n cohub-dev -o json \
+            | jq --arg n "${{ env.API_APP_NAME }}-secrets" --arg ns "${{ env.PREVIEW_NAMESPACE }}" \
+              'del(.metadata.namespace, .metadata.uid, .metadata.resourceVersion, .metadata.creationTimestamp, .metadata.managedFields) | .metadata.name=$n | .metadata.namespace=$ns' \
+            > secrets.yaml
+
+          # values：继承 dev configmap 的真实配置，覆盖 preview 专属字段
+          get_cm() { kubectl get configmap cohub-api-dev-config -n cohub-dev -o jsonpath="{.data.$1}"; }
+          SPACE_STORAGE_PVC=$(kubectl get deployment cohub-api-dev -n cohub-dev -o jsonpath='{.spec.template.spec.volumes[?(@.name=="space-storage")].persistentVolumeClaim.claimName}')
+          SPACE_SYSTEM_PVC=$(kubectl get deployment cohub-api-dev -n cohub-dev -o jsonpath='{.spec.template.spec.volumes[?(@.name=="system-storage")].persistentVolumeClaim.claimName}')
+          CHECKPOINT_CACHE_PVC=$(kubectl get deployment cohub-api-dev -n cohub-dev -o jsonpath='{.spec.template.spec.volumes[?(@.name=="checkpoint-cache")].persistentVolumeClaim.claimName}')
+          IMAGE_PULL_SECRET=$(kubectl get deployment cohub-api-dev -n cohub-dev -o jsonpath='{.spec.template.spec.imagePullSecrets[0].name}')
+
+          cat > values.yaml <<EOF
+          NAMESPACE: "${{ env.PREVIEW_NAMESPACE }}"
+          APP_NAME: "${{ env.API_APP_NAME }}"
+          IMAGE_REPOSITORY: "${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/cohub-api"
+          IMAGE_TAG: "${{ env.IMAGE_TAG }}"
+          IMAGE_PULL_POLICY: "Always"
+          IMAGE_PULL_SECRET: "${IMAGE_PULL_SECRET}"
+          SERVICE_PORT: "8787"
+          CONTAINER_PORT: "8787"
+          REPLICAS: "1"
+          MAX_UNAVAILABLE: "0"
+          MAX_SURGE: "1"
+          TERMINATION_GRACE_PERIOD_SECONDS: "120"
+          REQUEST_CPU: "50m"
+          REQUEST_MEMORY: "128Mi"
+          LIMIT_CPU: "500m"
+          LIMIT_MEMORY: "512Mi"
+          LIVENESS_PATH: "/healthz"
+          LIVENESS_INITIAL_DELAY: "20"
+          LIVENESS_PERIOD: "10"
+          LIVENESS_TIMEOUT: "2"
+          LIVENESS_FAILURE_THRESHOLD: "3"
+          READINESS_PATH: "/readyz"
+          READINESS_INITIAL_DELAY: "5"
+          READINESS_PERIOD: "5"
+          READINESS_TIMEOUT: "2"
+          READINESS_FAILURE_THRESHOLD: "3"
+          LOGTO_ENDPOINT: "$(get_cm LOGTO_ENDPOINT)"
+          LOGTO_MANAGEMENT_API_RESOURCE: "$(get_cm LOGTO_MANAGEMENT_API_RESOURCE)"
+          GITEA_BASE_URL: "$(get_cm GITEA_BASE_URL)"
+          GITEA_MANAGED_EMAIL_DOMAIN: "$(get_cm GITEA_MANAGED_EMAIL_DOMAIN)"
+          WEB_ORIGIN: "${{ env.WEB_URL }}"
+          SANDBOX_IMAGE: "$(get_cm SANDBOX_IMAGE)"
+          SPACE_STORAGE_ROOT: "$(get_cm SPACE_STORAGE_ROOT)"
+          SPACE_SYSTEM_ROOT: "$(get_cm SPACE_SYSTEM_ROOT)"
+          SPACE_STORAGE_PVC: "${SPACE_STORAGE_PVC}"
+          SPACE_SYSTEM_PVC: "${SPACE_SYSTEM_PVC}"
+          CHECKPOINT_CACHE_PVC: "${CHECKPOINT_CACHE_PVC}"
+          SPACE_STORAGE_SUBPATH: "workspaces/preview-${{ env.PR_NUMBER }}"
+          SPACE_SYSTEM_SUBPATH: "preview-${{ env.PR_NUMBER }}"
+          CHECKPOINT_CACHE_SUBPATH: "workspaces/preview-${{ env.PR_NUMBER }}/checkpoints"
+          PLATFORM_CONFIG_ROOT: "$(get_cm PLATFORM_CONFIG_ROOT)"
+          TURN_OBJECT_S3_ENDPOINT: "$(get_cm TURN_OBJECT_S3_ENDPOINT)"
+          TURN_OBJECT_S3_REGION: "$(get_cm TURN_OBJECT_S3_REGION)"
+          TURN_OBJECT_S3_BUCKET: "$(get_cm TURN_OBJECT_S3_BUCKET)"
+          TURN_OBJECT_CDN_BASE_URL: "$(get_cm TURN_OBJECT_CDN_BASE_URL)"
+          PUBLIC_ASSET_OSS_ENDPOINT: "$(get_cm PUBLIC_ASSET_OSS_ENDPOINT)"
+          PUBLIC_ASSET_OSS_PUBLIC_ENDPOINT: "$(get_cm PUBLIC_ASSET_OSS_PUBLIC_ENDPOINT)"
+          PUBLIC_ASSET_OSS_REGION: "$(get_cm PUBLIC_ASSET_OSS_REGION)"
+          PUBLIC_ASSET_OSS_BUCKET: "$(get_cm PUBLIC_ASSET_OSS_BUCKET)"
+          PUBLIC_ASSET_CDN_BASE_URL: "$(get_cm PUBLIC_ASSET_CDN_BASE_URL)"
+          USER_UPLOAD_S3_ENDPOINT: "$(get_cm USER_UPLOAD_S3_ENDPOINT)"
+          USER_UPLOAD_S3_REGION: "$(get_cm USER_UPLOAD_S3_REGION)"
+          CHAT_ATTACHMENT_S3_BUCKET: "$(get_cm CHAT_ATTACHMENT_S3_BUCKET)"
+          CHAT_ATTACHMENT_PUBLIC_BASE_URL: "$(get_cm CHAT_ATTACHMENT_PUBLIC_BASE_URL)"
+          SPACE_UPLOAD_S3_BUCKET: "$(get_cm SPACE_UPLOAD_S3_BUCKET)"
+          WORK_ASSET_CDN_BASE_URL: "$(get_cm WORK_ASSET_CDN_BASE_URL)"
+          CONFIGS_SUBPATH: "configs/dev"
+          SANDBOX_PUBLIC_DOMAINS: "$(get_cm SANDBOX_PUBLIC_DOMAINS)"
+          WORK_CONTENT_HOST_SUFFIXES: "$(get_cm WORK_CONTENT_HOST_SUFFIXES)"
+          CHECKPOINT_GIT_AUTHOR_EMAIL: "$(get_cm CHECKPOINT_GIT_AUTHOR_EMAIL)"
+          ROUTE_ENABLED: "true"
+          API_HOSTNAME: "${{ env.API_HOSTNAME }}"
+          ENV: "dev"
+          LOG_LEVEL: "debug"
+          EOF
+
+          # 不跑 migration：共享 dev 数据库，schema 变更只在 main 合并后迁移
+          bash deploy.sh
+
+      - name: Deploy Gateway
+        working-directory: deploy/gateway/dev
+        run: |
+          set -euo pipefail
+
+          kubectl get secret cohub-gateway-dev-secrets -n cohub-dev -o json \
+            | jq --arg n "${{ env.GATEWAY_APP_NAME }}-secrets" --arg ns "${{ env.PREVIEW_NAMESPACE }}" \
+              'del(.metadata.namespace, .metadata.uid, .metadata.resourceVersion, .metadata.creationTimestamp, .metadata.managedFields) | .metadata.name=$n | .metadata.namespace=$ns' \
+            > secrets.yaml
+
+          get_cm() { kubectl get configmap cohub-gateway-dev-config -n cohub-dev -o jsonpath="{.data.$1}" 2>/dev/null || true; }
+          LOGTO_ENDPOINT=$(get_cm LOGTO_ENDPOINT)
+          if [ -z "$LOGTO_ENDPOINT" ]; then
+            LOGTO_ENDPOINT=$(kubectl get configmap cohub-api-dev-config -n cohub-dev -o jsonpath='{.data.LOGTO_ENDPOINT}')
+          fi
+
+          cat > values.yaml <<EOF
+          NAMESPACE: "${{ env.PREVIEW_NAMESPACE }}"
+          APP_NAME: "${{ env.GATEWAY_APP_NAME }}"
+          IMAGE_REPOSITORY: "${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/cohub-gateway"
+          IMAGE_TAG: "${{ env.IMAGE_TAG }}"
+          IMAGE_PULL_POLICY: "Always"
+          IMAGE_PULL_SECRET: "gitea-registry"
+          SERVICE_PORT: "8788"
+          CONTAINER_PORT: "8788"
+          REPLICAS: "1"
+          TERMINATION_GRACE_PERIOD_SECONDS: "120"
+          REQUEST_CPU: "50m"
+          REQUEST_MEMORY: "128Mi"
+          LIMIT_CPU: "500m"
+          LIMIT_MEMORY: "512Mi"
+          LIVENESS_PATH: "/healthz"
+          LIVENESS_INITIAL_DELAY: "10"
+          LIVENESS_PERIOD: "10"
+          LIVENESS_TIMEOUT: "2"
+          LIVENESS_FAILURE_THRESHOLD: "3"
+          READINESS_PATH: "/readyz"
+          READINESS_INITIAL_DELAY: "5"
+          READINESS_PERIOD: "5"
+          READINESS_TIMEOUT: "2"
+          READINESS_FAILURE_THRESHOLD: "3"
+          API_BASE_URL: "http://${{ env.API_APP_NAME }}.${{ env.PREVIEW_NAMESPACE }}.svc.cluster.local:8787"
+          LOGTO_ENDPOINT: "${LOGTO_ENDPOINT}"
+          ROUTE_ENABLED: "true"
+          GATEWAY_HOSTNAME: "${{ env.GATEWAY_HOSTNAME }}"
+          ENV: "dev"
+          LOG_LEVEL: "debug"
+          EOF
+
+          bash deploy.sh
+
+      - name: Wait for rollout and smoke test
+        run: |
+          set -euo pipefail
+
+          kubectl rollout status deployment/${{ env.API_APP_NAME }} -n ${{ env.PREVIEW_NAMESPACE }} --timeout=300s
+          kubectl rollout status statefulset/${{ env.GATEWAY_APP_NAME }} -n ${{ env.PREVIEW_NAMESPACE }} --timeout=300s
+
+          curl -sf "https://${{ env.API_HOSTNAME }}/healthz" > /dev/null
+          curl -sf "https://${{ env.GATEWAY_HOSTNAME }}/healthz" > /dev/null
+          curl -sf "${{ env.WEB_URL }}" > /dev/null
+
+      - name: Post preview URLs
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Preview environment (PR #${{ env.PR_NUMBER }})
+
+          - Web: ${{ env.WEB_URL }}
+          - API: https://${{ env.API_HOSTNAME }}
+          - Gateway: https://${{ env.GATEWAY_HOSTNAME }}
+
+          Data layer is shared with dev (database, sandbox, PVC storage, configs).
+          Will be destroyed automatically when the PR is closed.
+          EOF

--- a/deploy/preview/rbac.yaml
+++ b/deploy/preview/rbac.yaml
@@ -1,0 +1,58 @@
+# RBAC for the preview environment workflow.
+#
+# The preview workflow (preview-deploy.yml / preview-cleanup.yml) runs with the
+# same credentials as the dev deploy workflows:
+#   system:serviceaccount:cohub-dev:github-actions-dev
+# Those credentials only have namespace-scoped rights inside cohub-dev, but
+# preview environments need to create and manage whole namespaces
+# (cohub-preview-<n>) plus a RoleBinding in cohub-sessions-dev.
+#
+# Apply once as a cluster admin:
+#   kubectl apply -f deploy/preview/rbac.yaml
+#
+# NOTE: this grants cluster-wide access to the listed resource types (RBAC
+# cannot scope a ClusterRoleBinding by namespace name pattern). Only do this on
+# a cluster that is dev-only; the prod cluster should not receive this file.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cohub-preview-manager
+rules:
+  # Preview namespaces are created by the workflow and deleted on PR close.
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  # Resources deployed into cohub-preview-<n> namespaces.
+  - apiGroups: [""]
+    resources:
+      - "pods"
+      - "services"
+      - "configmaps"
+      - "secrets"
+      - "serviceaccounts"
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # The preview API manages sandbox pods in the shared cohub-sessions-dev
+  # namespace; the workflow adds a RoleBinding there per preview.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cohub-preview-manager
+subjects:
+  - kind: ServiceAccount
+    name: github-actions-dev
+    namespace: cohub-dev
+roleRef:
+  kind: ClusterRole
+  name: cohub-preview-manager
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/preview/rbac.yaml
+++ b/deploy/preview/rbac.yaml
@@ -23,9 +23,10 @@ metadata:
   name: cohub-preview-manager
 rules:
   # Preview namespaces are created by the workflow and deleted on PR close.
+  # kubectl apply issues PATCH, so update/patch are required, not just create.
   - apiGroups: [""]
     resources: ["namespaces"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # Resources deployed into cohub-preview-<n> namespaces.
   - apiGroups: [""]
     resources:

--- a/deploy/preview/rbac.yaml
+++ b/deploy/preview/rbac.yaml
@@ -10,9 +10,12 @@
 # Apply once as a cluster admin:
 #   kubectl apply -f deploy/preview/rbac.yaml
 #
-# NOTE: this grants cluster-wide access to the listed resource types (RBAC
-# cannot scope a ClusterRoleBinding by namespace name pattern). Only do this on
-# a cluster that is dev-only; the prod cluster should not receive this file.
+# DECISION (2026-08): dev and prod share one cluster (namespaces cohub-dev /
+# cohub). This ClusterRole grants cluster-wide access to the listed resource
+# types, so it also covers the prod namespace. That is accepted because:
+#   - deployments are gated by a maintainer-applied `preview` label
+#   - deployment scripts are pinned to main (PR code never touches kubeconfig)
+# Revisit if preview is ever opened to untrusted (fork) contributors.
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/preview/rbac.yaml
+++ b/deploy/preview/rbac.yaml
@@ -35,6 +35,18 @@ rules:
       - "secrets"
       - "serviceaccounts"
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Pod subresource permissions mirror the cohub-api-dev-sessions-manager Role
+  # that preview RoleBindings grant; RBAC escalation checks require the
+  # binder to already hold every permission it grants.
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods/resize"]
+    verbs: ["get", "patch", "update"]
   - apiGroups: ["apps"]
     resources: ["deployments", "statefulsets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/packages/protocol/src/public-identifiers.ts
+++ b/packages/protocol/src/public-identifiers.ts
@@ -23,6 +23,7 @@ export const RESERVED_PLATFORM_PATH_SEGMENTS = Object.freeze([
   "docs",
   "explore",
   "invite",
+  "landing",
   "login",
   "logout",
   "new",


### PR DESCRIPTION
## Summary

Three workflows to give PR contributors a complete feedback loop:

| Workflow | Trigger | What it does |
|---|---|---|
| `ci.yml` | every PR (incl. forks) + push to main | lint / typecheck / test (254 unit tests) / build for the whole workspace, plus gofmt / vet / test for the sandbox |
| `preview-deploy.yml` | maintainer adds `preview` label on a same-repo PR | builds api+gateway images (`pr-<n>-<sha>`), deploys api/gateway to a per-PR k8s namespace `cohub-preview-<n>`, deploys web to a per-PR Cloudflare Worker bound to `web-<n>-preview.cohub.run`, smoke-tests all three, surfaces a "View deployment" link via GitHub Environments |
| `preview-cleanup.yml` | PR closed | destroys the namespace, cross-namespace RoleBinding and the Cloudflare Worker |

## Preview environment design

- **Isolated compute, shared data**: preview deploys its own api/gateway/web; the database, sandbox image, PVC storage (subpath-isolated) and platform configs are shared with dev. Migrations are **not** run for previews (schema changes only migrate on main after merge).
- **Security**: deployment scripts are pinned to `main` (trusted); PR code only enters as an image tag. Forks are excluded entirely (no secrets). A maintainer `preview` label is the human gate before any untrusted code gets secrets-bearing execution.
- **No secrets duplication**: k8s secrets are copied from dev unchanged (same cluster, same data layer); storage uses `workspaces/preview-<n>` subpaths.

## Required manual configuration (after merge)

1. DNS: wildcard `*.cohub.run` (Cloudflare proxied) → api/gateway hit traefik origin, web hits the Worker route.
2. Logto (dev app `vpikk7sl9zwvefiptowtn`): add redirect URIs `https://*-preview.cohub.run/*`, post sign-out redirect URIs `https://*-preview.cohub.run/*`, and CORS allowed origins `https://*-preview.cohub.run`.
3. Cloudflare token needs Workers Scripts **and** Workers Routes edit permission.

## Known boundaries

- Queue tasks are consumed by the dev worker (preview verifies UI/API flows, not worker logic).
- Schema-changing PRs will show expected red smoke tests until the migration lands on main.
- fs-api is not deployed in previews; `/fs/*` routes may 5xx.