### PR TITLE
feat(worker): make task.updated hookable for space hooks

### DIFF
--- a/apps/worker/src/realtime-events.ts
+++ b/apps/worker/src/realtime-events.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { REALTIME_OUTBOUND_CHANNEL, type RealtimeTaskRecord } from "@cohub/protocol/realtime";
 import type { TaskRunStatus } from "@cohub/protocol/task";
 import { redisCommandClient } from "./redis.js";
+import { enqueueSpaceHookFromEvent } from "./space-hooks.js";
 
 const toIsoOrNull = (value: Date | string | null | undefined) => {
   if (!value) return null;
@@ -57,22 +58,42 @@ async function publishTaskEvent(input: {
   const task = toRealtimeTaskRecord(input.task);
   if (!task.spaceId && !task.userId) return;
 
-  await redisCommandClient.publish(
-    REALTIME_OUTBOUND_CHANNEL,
-    JSON.stringify({
-      id: randomUUID(),
-      timestamp: Date.now(),
-      domain: "space",
-      type: input.type,
-      spaceId: task.spaceId,
-      sessionId: task.sessionId,
-      payload: {
-        task,
-        ...(input.changed ? { changed: input.changed } : {}),
-        ...(task.userId && !task.spaceId ? { userId: task.userId } : {}),
-      },
-    }),
-  );
+  const id = randomUUID();
+  const timestamp = Date.now();
+  const payload = {
+    task,
+    ...(input.changed ? { changed: input.changed } : {}),
+    ...(task.userId && !task.spaceId ? { userId: task.userId } : {}),
+  };
+
+  // Same pattern as publishSpaceEvent: realtime push and hook dispatch run in
+  // parallel; hooks only apply to space-scoped events. Re-entrancy protection
+  // (space_hook tasks and their derived run_command children) lives in
+  // maybeEnqueueSpaceHookTask.
+  await Promise.all([
+    redisCommandClient.publish(
+      REALTIME_OUTBOUND_CHANNEL,
+      JSON.stringify({
+        id,
+        timestamp,
+        domain: "space",
+        type: input.type,
+        spaceId: task.spaceId,
+        sessionId: task.sessionId,
+        payload,
+      }),
+    ),
+    task.spaceId
+      ? enqueueSpaceHookFromEvent({
+          id,
+          type: input.type,
+          timestamp,
+          spaceId: task.spaceId,
+          sessionId: task.sessionId,
+          payload,
+        })
+      : Promise.resolve(null),
+  ]);
 }
 
 export const dispatchTaskCreated = (task: Parameters<typeof toRealtimeTaskRecord>[0]) =>

--- a/docs/space-hooks.md
+++ b/docs/space-hooks.md
@@ -93,6 +93,7 @@ Supported events:
 - `session.turn.finalized` — optional `sessionIds` / `ignoreSessionIds` / `sources`
 - `checkpoint.created`
 - `work.version.published`
+- `task.updated` — fires on task run state transitions (`pending`→`running`→`completed`/`failed`); payload carries the task record and `changed` fields. `space_hook` tasks and the `run_command` children they spawn are filtered out to prevent re-entrant loops.
 
 ## Trigger
 
@@ -179,6 +180,11 @@ COHUB_HOOK_CHECKPOINT_ID      # "" unless checkpoint.created
 COHUB_HOOK_WORK_ID             # "" unless work.version.published
 COHUB_HOOK_WORK_VERSION_ID     # "" unless work.version.published
 COHUB_HOOK_WORK_VERSION        # "" unless work.version.published
+COHUB_HOOK_TASK_ID             # "" unless task.updated
+COHUB_HOOK_TASK_TYPE           # "" unless task.updated
+COHUB_HOOK_TASK_STATUS         # "" unless task.updated
+COHUB_HOOK_TASK_CHANGED        # comma-separated changed fields, "" unless task.updated
+COHUB_HOOK_TASK_ERROR          # "" unless task.updated
 ```
 
 `space.fs.changed` extras (always present for that event; empty string when none):

--- a/packages/core/src/hooks/context.ts
+++ b/packages/core/src/hooks/context.ts
@@ -103,6 +103,18 @@ export function buildSpaceHookEnv(input: SpaceHookContextInput): Record<string, 
     env.COHUB_HOOK_FS_KINDS = summary.kinds.join(",");
   }
 
+  if (event.type === "task.updated") {
+    const task = isRecord(event.payload.task) ? event.payload.task : null;
+    setEnv(env, "COHUB_HOOK_TASK_ID", task ? asString(task.id) : null);
+    setEnv(env, "COHUB_HOOK_TASK_TYPE", task ? asString(task.type) : null);
+    setEnv(env, "COHUB_HOOK_TASK_STATUS", task ? asString(task.status) : null);
+    const changed = Array.isArray(event.payload.changed)
+      ? event.payload.changed.filter((value): value is string => typeof value === "string")
+      : [];
+    setEnv(env, "COHUB_HOOK_TASK_CHANGED", changed.length > 0 ? changed.join(",") : null);
+    setEnv(env, "COHUB_HOOK_TASK_ERROR", task ? asString(task.errorMessage) : null);
+  }
+
   return env;
 }
 
@@ -122,6 +134,11 @@ const PROMPT_CONTEXT_LABELS: Array<{ key: string; label: string }> = [
   { key: "COHUB_HOOK_OCCURRED_AT", label: "occurredAt" },
   { key: "COHUB_HOOK_FS_CHANGE_COUNT", label: "changeCount" },
   { key: "COHUB_HOOK_FS_KINDS", label: "kinds" },
+  { key: "COHUB_HOOK_TASK_ID", label: "taskId" },
+  { key: "COHUB_HOOK_TASK_TYPE", label: "taskType" },
+  { key: "COHUB_HOOK_TASK_STATUS", label: "taskStatus" },
+  { key: "COHUB_HOOK_TASK_CHANGED", label: "taskChanged" },
+  { key: "COHUB_HOOK_TASK_ERROR", label: "taskError" },
 ];
 
 /** Compact prompt appendix mirrored from the shared hook env. */

--- a/packages/core/src/hooks/hooks.test.ts
+++ b/packages/core/src/hooks/hooks.test.ts
@@ -330,6 +330,66 @@ run: echo ok
   );
 });
 
+test("spaceHookMatchesEvent matches task.updated events", () => {
+  const hook = parseSpaceHookDefinition(
+    `
+schema: cohub.space-hook.v1
+on:
+  event: task.updated
+run: echo ok
+`,
+    ".cohub/hooks/on-task.yml",
+  );
+
+  const base = {
+    id: "evt-1",
+    type: "task.updated" as const,
+    timestamp: Date.now(),
+    spaceId: "space-1",
+  };
+
+  // Any task.updated payload matches (status filtering is the script's job,
+  // event payload carries COHUB_HOOK_TASK_STATUS).
+  assert.deepEqual(
+    spaceHookMatchesEvent(hook, {
+      ...base,
+      sessionId: "session-1",
+      payload: {
+        task: { id: "task-1", type: "generation", status: "failed", jobId: "job-1" },
+        changed: ["status"],
+      },
+    }),
+    { matched: true },
+  );
+
+  assert.deepEqual(
+    spaceHookMatchesEvent(hook, {
+      ...base,
+      sessionId: "session-1",
+      payload: { task: { id: "task-2", type: "run_command", status: "completed", jobId: "job-2" } },
+    }),
+    { matched: true },
+  );
+
+  assert.deepEqual(
+    spaceHookMatchesEvent(hook, {
+      ...base,
+      sessionId: "session-1",
+      payload: { task: { id: "task-3", type: "generation", status: "running", jobId: "job-3" } },
+    }),
+    { matched: true },
+  );
+
+  assert.deepEqual(
+    spaceHookMatchesEvent(hook, {
+      ...base,
+      type: "checkpoint.created" as const,
+      payload: { checkpointId: "cp-1" },
+    }),
+    { matched: false, reason: "event_mismatch" },
+  );
+});
+
 test("space hook fingerprints change with executable content", () => {
   const first = parseSpaceHookDefinition(
     `

--- a/packages/infra/src/space-hooks/index.ts
+++ b/packages/infra/src/space-hooks/index.ts
@@ -7,6 +7,7 @@ import {
   SPACE_HOOKS_DIR,
   type SpaceHookEventEnvelope,
 } from "@cohub/protocol";
+import { buildAgentRunCommandJobId } from "../agent-queue/index.js";
 
 export type { SpaceHookEventEnvelope };
 
@@ -133,14 +134,29 @@ export function isReentrantSpaceHookEvent(input: {
   type: string;
   payload?: Record<string, unknown> | null;
 }): boolean {
-  if (input.type !== "session.turn.finalized") return false;
-  const payload = isRecord(input.payload) ? input.payload : null;
-  const turn = isRecord(payload?.turn) ? payload.turn : null;
-  const meta = isRecord(turn?.meta) ? turn.meta : null;
-  if (!meta) return false;
-  if (asString(meta.source) === "space_hook") return true;
-  const context = isRecord(meta.context) ? meta.context : null;
-  return asString(context?.kind) === "space_hook";
+  if (input.type === "session.turn.finalized") {
+    const payload = isRecord(input.payload) ? input.payload : null;
+    const turn = isRecord(payload?.turn) ? payload.turn : null;
+    const meta = isRecord(turn?.meta) ? turn.meta : null;
+    if (!meta) return false;
+    if (asString(meta.source) === "space_hook") return true;
+    const context = isRecord(meta.context) ? meta.context : null;
+    return asString(context?.kind) === "space_hook";
+  }
+  if (input.type === "task.updated") {
+    const payload = isRecord(input.payload) ? input.payload : null;
+    const task = isRecord(payload?.task) ? payload.task : null;
+    if (!task) return false;
+    // Hook execution tasks and the run_command children they spawn must not
+    // re-trigger task hooks, or every hook run would loop forever.
+    if (asString(task.type) === SPACE_HOOK_TASK_TYPE) return true;
+    // Hook-spawned run_command children use jobId `run-command-` + the space_hook
+    // execute task id (space-hook-*), see buildSpaceHookTaskId / runCommandHook.
+    const jobId = asString(task.jobId) ?? "";
+    return asString(task.type) === "run_command"
+      && jobId.startsWith(buildAgentRunCommandJobId("space-hook-"));
+  }
+  return false;
 }
 
 function isDuplicateJobError(error: unknown) {

--- a/packages/infra/src/space-hooks/space-hooks.test.ts
+++ b/packages/infra/src/space-hooks/space-hooks.test.ts
@@ -194,6 +194,119 @@ test("maybeEnqueueSpaceHookTask skips when cache confirms empty definitions", as
   assert.equal(calls.length, 0);
 });
 
+test("isReentrantSpaceHookEvent blocks hook-generated task events", () => {
+  const basePayload = {
+    task: { id: "task-1", type: "generation", status: "completed", jobId: "job-1" },
+    changed: ["status"],
+  };
+  assert.equal(
+    isReentrantSpaceHookEvent({ type: "task.updated", payload: basePayload }),
+    false,
+  );
+  // Hook execution task itself must not re-trigger task hooks.
+  assert.equal(
+    isReentrantSpaceHookEvent({
+      type: "task.updated",
+      payload: {
+        task: {
+          id: "task-2",
+          type: "space_hook",
+          status: "completed",
+          jobId: "space-hook-abc123",
+        },
+        changed: ["status"],
+      },
+    }),
+    true,
+  );
+  // run_command child spawned by a hook must not re-trigger task hooks.
+  assert.equal(
+    isReentrantSpaceHookEvent({
+      type: "task.updated",
+      payload: {
+        task: {
+          id: "task-3",
+          type: "run_command",
+          status: "completed",
+          jobId: "run-command-space-hook-abc123__hooks-gen.yml",
+        },
+        changed: ["status"],
+      },
+    }),
+    true,
+  );
+  // Plain run_command tasks stay hookable.
+  assert.equal(
+    isReentrantSpaceHookEvent({
+      type: "task.updated",
+      payload: {
+        task: {
+          id: "task-4",
+          type: "run_command",
+          status: "failed",
+          jobId: "run-command-other-task",
+        },
+        changed: ["status"],
+      },
+    }),
+    false,
+  );
+});
+
+test("maybeEnqueueSpaceHookTask accepts task.updated and still skips task.created", async () => {
+  const calls: unknown[] = [];
+  const enqueue = async (name: string, payload: unknown, options: unknown) => {
+    calls.push({ name, payload, options });
+    return { id: "job-1" };
+  };
+
+  const result = await maybeEnqueueSpaceHookTask({
+    event: {
+      id: "event-task-1",
+      type: "task.updated",
+      spaceId: "space-1",
+      sessionId: "session-1",
+      payload: {
+        task: {
+          id: "task-1",
+          type: "generation",
+          status: "failed",
+          errorMessage: "boom",
+          jobId: "job-1",
+        },
+        changed: ["status", "errorMessage"],
+      },
+    },
+    enqueue,
+  });
+
+  assert.ok(result);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0] && (calls[0] as { name: string }).name, SPACE_HOOK_DISPATCH_JOB);
+  assert.deepEqual(
+    (calls[0] as { options: { jobId: string } }).options.jobId,
+    buildSpaceHookDispatchJobId({
+      spaceId: "space-1",
+      eventId: "event-task-1",
+      eventType: "task.updated",
+    }),
+  );
+
+  assert.equal(
+    await maybeEnqueueSpaceHookTask({
+      event: {
+        id: "event-task-2",
+        type: "task.created",
+        spaceId: "space-1",
+        payload: { task: { id: "task-2", type: "generation", status: "pending", jobId: "job-2" } },
+      },
+      enqueue,
+    }),
+    null,
+  );
+  assert.equal(calls.length, 1);
+});
+
 test("maybeEnqueueSpaceHookTask invalidates empty cache when hooks path changes", async () => {
   const calls: unknown[] = [];
   const redis = {

--- a/packages/protocol/src/space-hooks.ts
+++ b/packages/protocol/src/space-hooks.ts
@@ -19,6 +19,7 @@ export const SPACE_HOOKABLE_EVENTS = [
   "session.turn.finalized",
   "checkpoint.created",
   "work.version.published",
+  "task.updated",
 ] as const;
 
 export type SpaceHookableEvent = (typeof SPACE_HOOKABLE_EVENTS)[number];


### PR DESCRIPTION
## 背景

Space hooks 目前只有 5 种可监听事件，`task.updated` 不在其中。
## 改动

- **protocol**: `SPACE_HOOKABLE_EVENTS` 新增 `task.updated`，hook 定义 `on.event: task.updated` 即可通过解析。
- **worker**: `publishTaskEvent` 与 `publishSpaceEvent` 同模式，WS 推送与 `space_hook.dispatch` 并行分发（仅 space 级任务触发）。
- **infra**: `isReentrantSpaceHookEvent` 对 `task.updated` 增加防重入——`space_hook` 执行任务自身、以及其派生的 `run_command` 子任务（jobId 前缀 `run-command-space-hook-`）都不会再触发 task hook，避免无限循环。
- **core**: hook env 新增 `COHUB_HOOK_TASK_ID/TYPE/STATUS/CHANGED/ERROR`，run 脚本可直接判断任务类型与终态。
- **docs**: `docs/space-hooks.md` 同步事件列表与 env 说明。
- 测试：infra 30 tests / core 58 tests 全过，biome 检查通过，pre-commit 全量 typecheck 通过。

## 使用示例

```yaml
schema: cohub.space-hook.v1
on:
  event: task.updated
action: run
run: |
  if [ "$COHUB_HOOK_TASK_TYPE" = "generation" ] && [ "$COHUB_HOOK_TASK_STATUS" = "failed" ]; then
    node /mods/neta/neta generate reconcile "$COHUB_HOOK_TASK_ID" --timeout-ms 60000
  fi
```

## 验证

- `pnpm --filter @cohub/infra test`: 30 tests ok
- `pnpm --filter @cohub/core test`: 58 tests ok
- biome check 6 文件：无问题
- pre-commit（lint-staged + typecheck-staged）：全部 Done