### PR TITLE
feat(sandbox): serialize same-file writes with optimistic concurrency

### DIFF
--- a/apps/agent/src/runtime/tools/basic-tools.ts
+++ b/apps/agent/src/runtime/tools/basic-tools.ts
@@ -22,6 +22,13 @@ export interface EditOperations {
   readFile: (absolutePath: string) => Promise<Buffer>;
   writeFile: (absolutePath: string, content: string) => Promise<void>;
   access: (absolutePath: string) => Promise<void>;
+  /**
+   * Optional atomic read-apply-write: applies the edits to the latest file
+   * content in one operation (e.g. sandbox fs.edit, which runs under a
+   * per-path lock). When absent, the edit tool falls back to a plain
+   * read-modify-write cycle.
+   */
+  applyEdits?: (absolutePath: string, edits: Array<{ oldText: string; newText: string }>) => Promise<number>;
 }
 
 export interface ToolFailureDetails {
@@ -152,6 +159,27 @@ function resolveToCwd(path: string, cwd: string): string {
   return `${cwd.replace(/\/$/, "")}/${path}`;
 }
 
+/**
+ * Apply exact-text replacements to content, matching each oldText exactly
+ * once. Throws when an oldText is missing or not unique. Shared by the edit
+ * tool's fallback path and sandbox capability-degraded applyEdits so the
+ * matching semantics and error messages never diverge.
+ */
+export function applyEditsToContent(
+  content: string,
+  edits: Array<{ oldText: string; newText: string }>,
+  path: string,
+): string {
+  for (const edit of edits) {
+    const occurrences = content.split(edit.oldText).length - 1;
+    if (occurrences !== 1) {
+      throw new Error(`oldText must match exactly one region in ${path}, found ${occurrences}`);
+    }
+    content = content.replace(edit.oldText, edit.newText);
+  }
+  return content;
+}
+
 export function createReadTool(cwd: string, options: { operations: ReadOperations }): AgentTool {
   const parameters = Type.Object({
     path: Type.String({ description: "Path to the file to read (relative or absolute)" }),
@@ -256,15 +284,16 @@ export function createEditTool(cwd: string, options: { operations: EditOperation
       const params = rawParams as Static<typeof parameters>;
       const absolutePath = resolveToCwd(params.path, cwd);
       await options.operations.access(absolutePath);
-      let content = (await options.operations.readFile(absolutePath)).toString("utf-8");
-      for (const edit of params.edits) {
-        const occurrences = content.split(edit.oldText).length - 1;
-        if (occurrences !== 1) {
-          throw new Error(`oldText must match exactly one region in ${params.path}, found ${occurrences}`);
-        }
-        content = content.replace(edit.oldText, edit.newText);
+      if (options.operations.applyEdits) {
+        // Atomic read-apply-write in the sandbox: edits always apply to the
+        // latest content, so concurrent edits compose instead of losing
+        // updates.
+        await options.operations.applyEdits(absolutePath, params.edits);
+      } else {
+        let content = (await options.operations.readFile(absolutePath)).toString("utf-8");
+        content = applyEditsToContent(content, params.edits, params.path);
+        await options.operations.writeFile(absolutePath, content);
       }
-      await options.operations.writeFile(absolutePath, content);
       return {
         content: [{ type: "text", text: `Applied ${params.edits.length} edit(s) to ${params.path}` }],
         details: undefined,

--- a/apps/agent/src/runtime/tools/index.ts
+++ b/apps/agent/src/runtime/tools/index.ts
@@ -16,6 +16,7 @@ export {
 export {
   createToolFailure,
   isToolFailureDetails,
+  applyEditsToContent,
   createBashTool,
   createEditTool,
   createFindTool,

--- a/apps/agent/src/sandbox-fs-mutation.ts
+++ b/apps/agent/src/sandbox-fs-mutation.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { Job } from "bullmq";
-import { matchesSpaceFsVersion } from "@cohub/protocol/fs";
+import { matchesSpaceFsVersion, spaceFsVersionMatches } from "@cohub/protocol/fs";
 import type { RpcEventPayload, RpcMethod, RpcRequestMap } from "@cohub/protocol/sandbox";
 import { SandboxRpcError, type SandboxConnection } from "@cohub/sandbox-client";
 import { getAgentTracer, wrapToolCall } from "@cohub/infra/tracing/agent";
@@ -76,18 +76,28 @@ async function writeMutation(connection: SandboxConnection, mutation: Extract<Ag
     ? await statOrNull(connection, mutation.path)
     : null;
   if (mutation.expected) {
-    if (!current?.exists || current.isDirectory || !matchesSpaceFsVersion(current, mutation.expected)) {
+    if (!spaceFsVersionMatches(current, mutation.expected)) {
       return { ok: false, status: 409, code: "file_conflict", message: "File changed since it was opened." };
     }
   }
   const legacyCreatedDirs = supportsDisposition
     ? []
     : await collectMissingDirectories(connection, parentPath(mutation.path));
+  // Pass expected through to the sandbox: the version check and the write run
+  // atomically under the sandbox's per-path lock, closing the TOCTOU window
+  // between the stat above and the write. mtimeMs is truncated to whole
+  // milliseconds to match the Go RPC's int64 field (see matchesSpaceFsVersion).
+  // Only forwarded when the sandbox advertises fsWriteExpected: older sandboxes
+  // silently ignore unknown fields, which would downgrade a conditional write
+  // to an unconditional one.
   const result = await rpc(connection, "fs.write", {
     path: mutation.path,
     content: mutation.content,
     ...(mutation.encoding ? { encoding: mutation.encoding } : {}),
     ...(mutation.exclusive ? { exclusive: true } : {}),
+    ...(mutation.expected && connection.capabilities?.fsWriteExpected === true
+      ? { expected: { size: mutation.expected.size, mtimeMs: Math.trunc(mutation.expected.mtimeMs) } }
+      : {}),
   });
   return {
     ok: true,
@@ -203,6 +213,8 @@ function mapMutationRpcError(error: unknown): AgentSandboxFsMutationJobResult | 
         return { ok: false, status: 400, code: "path_invalid", message: "Invalid path." };
       case "READ_ONLY_FILESYSTEM":
         return { ok: false, status: 403, code: "read_only", message: "This path is read-only." };
+      case "CONFLICT":
+        return { ok: false, status: 409, code: "file_conflict", message: "File changed since it was opened." };
       case "IO_ERROR":
         return null;
       default:

--- a/apps/agent/src/sandbox/tools.ts
+++ b/apps/agent/src/sandbox/tools.ts
@@ -10,6 +10,7 @@ import {
   createLsTool,
   createReadTool,
   createWriteTool,
+  applyEditsToContent,
   type BashOperations,
   type BashExecutionResult,
   type EditOperations,
@@ -433,6 +434,25 @@ function createRemoteEditOperations(): EditOperations {
       await readOps.access(absolutePath);
     },
     writeFile: writeOps.writeFile,
+    // fs.edit runs the read-apply-write atomically inside the sandbox's
+    // per-path lock, so edits always apply to the latest content. Infra
+    // retries are disabled: an edit that succeeded but lost its response must
+    // not be replayed (the oldText would no longer match).
+    async applyEdits(absolutePath, edits) {
+      const path = mapLocalAbsolutePathToSandboxPath(absolutePath);
+      const connection = await getCurrentConnection();
+      if (connection.capabilities?.fsEdit !== true) {
+        // Older sandboxes (e.g. a pinned local sandboxd) do not support
+        // fs.edit: fall back to the plain read-modify-write cycle, matching
+        // the pre-fs.edit behavior.
+        let content = (await readOps.readFile(absolutePath)).toString("utf-8");
+        content = applyEditsToContent(content, edits, absolutePath);
+        await writeOps.writeFile(absolutePath, content);
+        return edits.length;
+      }
+      const result = await tracedRpc(connection, "fs.edit", { path, edits }, undefined, false);
+      return result.applied;
+    },
   };
 }
 

--- a/apps/agent/src/tests/tool-optimistic-concurrency.test.ts
+++ b/apps/agent/src/tests/tool-optimistic-concurrency.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createEditTool, createWriteTool, type EditOperations, type WriteOperations } from "../runtime/tools/basic-tools.js";
+
+const CWD = "/workspace";
+const PATH = "/workspace/a.ts";
+
+test("edit delegates to applyEdits when the operations provide it", async () => {
+  let applyCalls = 0;
+  const tool = createEditTool(CWD, {
+    operations: {
+      async access() {},
+      async readFile() {
+        throw new Error("readFile must not be called when applyEdits is available");
+      },
+      async writeFile() {
+        throw new Error("writeFile must not be called when applyEdits is available");
+      },
+      async applyEdits(absolutePath, edits) {
+        applyCalls += 1;
+        assert.equal(absolutePath, PATH);
+        assert.deepEqual(edits, [{ oldText: "alpha", newText: "ALPHA" }]);
+        return 1;
+      },
+    },
+  });
+
+  const result = await tool.execute("call-1", { path: PATH, edits: [{ oldText: "alpha", newText: "ALPHA" }] });
+  assert.equal(applyCalls, 1);
+  const text = (result.content as { type: string; text: string }[]).find((c) => c.type === "text")?.text;
+  assert.match(text ?? "", /Applied 1 edit\(s\)/);
+});
+
+test("edit falls back to read-modify-write without applyEdits", async () => {
+  let reads = 0;
+  let writes = 0;
+  const tool = createEditTool(CWD, {
+    operations: {
+      async access() {},
+      async readFile() {
+        reads += 1;
+        return Buffer.from("alpha\nbeta\n", "utf8");
+      },
+      async writeFile(absolutePath, content) {
+        writes += 1;
+        assert.equal(absolutePath, PATH);
+        assert.equal(content, "ALPHA\nbeta\n");
+      },
+    },
+  });
+
+  await tool.execute("call-1", { path: PATH, edits: [{ oldText: "alpha", newText: "ALPHA" }] });
+  assert.equal(reads, 1);
+  assert.equal(writes, 1);
+});
+
+test("write stays a plain write", async () => {
+  let writes = 0;
+  const tool = createWriteTool(CWD, {
+    operations: {
+      async mkdir() {},
+      async writeFile(absolutePath, content) {
+        writes += 1;
+        assert.equal(absolutePath, PATH);
+        assert.equal(content, "hello");
+      },
+    },
+  });
+
+  await tool.execute("call-1", { path: PATH, content: "hello" });
+  assert.equal(writes, 1);
+});
+
+// Type-level sanity: minimal implementations still satisfy the interfaces.
+const minimalEdit: EditOperations = {
+  async readFile() {
+    return Buffer.from("");
+  },
+  async writeFile() {},
+  async access() {},
+};
+void minimalEdit;
+
+const minimalWrite: WriteOperations = {
+  async writeFile() {},
+  async mkdir() {},
+};
+void minimalWrite;

--- a/apps/api/src/space-fs-remote.ts
+++ b/apps/api/src/space-fs-remote.ts
@@ -1,7 +1,7 @@
 import { basename } from "node:path";
 import { SandboxRpcError } from "@cohub/sandbox-client";
 import {
-  matchesSpaceFsVersion,
+  spaceFsVersionMatches,
   type SpaceFsEntry,
   type SpaceFsFileResponse,
   type SpaceFsMoveInput,
@@ -60,6 +60,8 @@ function mapRpcError(error: unknown): never {
         throw new SpaceFsError(400, "path_invalid", "Invalid path.");
       case "READ_ONLY_FILESYSTEM":
         throw new SpaceFsError(403, "read_only", "This path is read-only.");
+      case "CONFLICT":
+        throw new SpaceFsError(409, "file_conflict", "File changed since it was opened.");
       default:
         throw new SpaceFsError(500, "space_fs_error", error.message);
     }
@@ -284,21 +286,28 @@ export async function writeSpaceFile(spaceId: string, input: SpaceFsWriteFileInp
       ? await callSandboxRpc(spaceId, "fs.stat", { path })
       : null;
     if (input.expected) {
-      if (
-        !current?.exists ||
-        current.isDirectory ||
-        !matchesSpaceFsVersion(current, input.expected)
-      ) {
+      if (!spaceFsVersionMatches(current, input.expected)) {
         throw new SpaceFsError(409, "file_conflict", "File changed since it was opened.");
       }
     }
     const legacyCreatedDirs = supportsDisposition
       ? []
       : await collectMissingRemoteDirectories(spaceId, parentPath(path));
+    // Pass expected through to the sandbox: the version check and the write
+    // run atomically under the sandbox's per-path lock, closing the TOCTOU
+    // window between the stat above and the write. mtimeMs is truncated to
+    // whole milliseconds to match the Go RPC's int64 field (see
+    // matchesSpaceFsVersion). Only forwarded when the sandbox advertises
+    // fsWriteExpected: older sandboxes silently ignore unknown fields, which
+    // would downgrade a conditional write to an unconditional one.
+    const supportsExpected = capabilities?.fsWriteExpected === true;
     const result = await callSandboxRpc(spaceId, "fs.write", {
       path,
       content: input.content,
       encoding: input.encoding,
+      ...(input.expected && supportsExpected
+        ? { expected: { size: input.expected.size, mtimeMs: Math.trunc(input.expected.mtimeMs) } }
+        : {}),
     });
     return {
       path,

--- a/apps/sandbox/protocol/types.go
+++ b/apps/sandbox/protocol/types.go
@@ -45,6 +45,8 @@ type SandboxCapabilities struct {
 	FSRead             bool `json:"fsRead"`
 	FSWrite            bool `json:"fsWrite"`
 	FSWriteDisposition bool `json:"fsWriteDisposition,omitempty"`
+	FSWriteExpected    bool `json:"fsWriteExpected,omitempty"`
+	FSEdit             bool `json:"fsEdit,omitempty"`
 	FSMkdir            bool `json:"fsMkdir,omitempty"`
 	FSStat             bool `json:"fsStat"`
 	FSLs               bool `json:"fsLs"`

--- a/apps/sandbox/rpc/dispatcher.go
+++ b/apps/sandbox/rpc/dispatcher.go
@@ -129,6 +129,8 @@ func (d *Dispatcher) Handle(request protocol.RPCRequest, ownerIdentity string) (
 		return accepted, d.complete(request, accepted.OpID, d.handleFSRead(request))
 	case "fs.write":
 		return accepted, d.complete(request, accepted.OpID, d.handleFSWrite(request))
+	case "fs.edit":
+		return accepted, d.complete(request, accepted.OpID, d.handleFSEdit(request))
 	case "fs.mkdir":
 		return accepted, d.complete(request, accepted.OpID, d.handleFSMkdir(request))
 	case "fs.stat":
@@ -159,11 +161,39 @@ type fsReadParams struct {
 }
 
 type fsWriteParams struct {
-	Path      string `json:"path"`
-	CWD       string `json:"cwd"`
-	Content   string `json:"content"`
-	Encoding  string `json:"encoding"`
-	Exclusive bool   `json:"exclusive"`
+	Path      string          `json:"path"`
+	CWD       string          `json:"cwd"`
+	Content   string          `json:"content"`
+	Encoding  string          `json:"encoding"`
+	Exclusive bool            `json:"exclusive"`
+	Expected  *fsWriteVersion `json:"expected"`
+}
+
+// fsWriteVersion is the caller's baseline for optimistic concurrency: reject
+// the write when the file no longer matches this version (size + mtimeMs).
+type fsWriteVersion struct {
+	Size    int64 `json:"size"`
+	MtimeMs int64 `json:"mtimeMs"`
+}
+
+type fsEditItem struct {
+	OldText string `json:"oldText"`
+	NewText string `json:"newText"`
+}
+
+type fsEditParams struct {
+	Path  string       `json:"path"`
+	CWD   string       `json:"cwd"`
+	Edits []fsEditItem `json:"edits"`
+}
+
+// editMatchError reports an oldText that matches 0 or multiple regions.
+type editMatchError struct {
+	matches int
+}
+
+func (e *editMatchError) Error() string {
+	return fmt.Sprintf("oldText matched %d regions", e.matches)
 }
 
 type fsMkdirParams struct {
@@ -345,22 +375,57 @@ func (d *Dispatcher) handleFSWrite(request protocol.RPCRequest) interface{} {
 		}
 		data = decoded
 	}
-	createdDirs, err := ensureParentDirs(d.cfg.WorkspaceDir, resolved.path)
-	if err != nil {
-		return d.failedFSMutation(request, err)
-	}
-	created := true
-	if params.Exclusive {
-		// Atomic create: O_EXCL fails if the path already exists, so concurrent
-		// exclusive creates cannot clobber each other.
-		if err := osWriteFileExclusive(resolved.path, data); err != nil {
-			if os.IsExist(err) {
-				return d.failed(request, "", "ALREADY_EXISTS", fmt.Sprintf("path already exists: %s", resolved.path))
+
+	// The version check and the write must be atomic with respect to other
+	// writes to the same path, otherwise a concurrent mutation can land between
+	// the stat and the write (TOCTOU) and the check is meaningless. The
+	// response version (mtimeMs) is also captured under the lock so it cannot
+	// belong to a subsequent writer.
+	var created bool
+	var createdDirs []string
+	var mtimeMs int64
+	lockErr := withPathLock(resolved.path, func() error {
+		if params.Expected != nil && !params.Exclusive {
+			info, err := os.Stat(resolved.path)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return errPathConflict
+				}
+				return err
 			}
-			return d.failedFSMutation(request, err)
+			if info.Size() != params.Expected.Size || info.ModTime().UnixMilli() != params.Expected.MtimeMs {
+				return errPathConflict
+			}
 		}
-	} else if created, err = writeFileWithDisposition(resolved.path, data); err != nil {
-		return d.failedFSMutation(request, err)
+		var err error
+		createdDirs, err = ensureParentDirs(d.cfg.WorkspaceDir, resolved.path)
+		if err != nil {
+			return err
+		}
+		if params.Exclusive {
+			// Atomic create: O_EXCL fails if the path already exists, so concurrent
+			// exclusive creates cannot clobber each other.
+			if err := osWriteFileExclusive(resolved.path, data); err != nil {
+				return err
+			}
+			created = true
+		} else {
+			created, err = writeFileWithDisposition(resolved.path, data)
+			if err != nil {
+				return err
+			}
+		}
+		mtimeMs = statMtimeMs(resolved.path)
+		return nil
+	})
+	if lockErr != nil {
+		if errors.Is(lockErr, errPathConflict) {
+			return d.failed(request, "", "CONFLICT", "file changed since it was opened")
+		}
+		if errors.Is(lockErr, os.ErrExist) {
+			return d.failed(request, "", "ALREADY_EXISTS", fmt.Sprintf("path already exists: %s", resolved.path))
+		}
+		return d.failedFSMutation(request, lockErr)
 	}
 
 	result := map[string]interface{}{
@@ -369,8 +434,84 @@ func (d *Dispatcher) handleFSWrite(request protocol.RPCRequest) interface{} {
 		"created":      created,
 		"createdDirs":  createdDirs,
 	}
-	if info, statErr := os.Stat(resolved.path); statErr == nil {
-		result["mtimeMs"] = info.ModTime().UnixMilli()
+	if mtimeMs > 0 {
+		result["mtimeMs"] = mtimeMs
+	}
+	return result
+}
+
+func (d *Dispatcher) handleFSEdit(request protocol.RPCRequest) interface{} {
+	var params fsEditParams
+	if err := json.Unmarshal(request.Params, &params); err != nil {
+		return d.failed(request, "", "BAD_REQUEST", err.Error())
+	}
+	if len(params.Edits) == 0 {
+		return d.failed(request, "", "BAD_REQUEST", "edits must contain at least one replacement")
+	}
+
+	resolved, errResponse, ok := d.resolvePathForRequest(request, params.Path, params.CWD)
+	if !ok {
+		return errResponse
+	}
+	if isReadOnlyPath(d.cfg, resolved.path) {
+		return d.failed(request, "", "READ_ONLY_FILESYSTEM", fmt.Sprintf("path is read-only: %s", resolved.path))
+	}
+	if info, err := os.Stat(resolved.path); err == nil && info.IsDir() {
+		return d.failed(request, "", "NOT_DIRECTORY", fmt.Sprintf("cannot edit a directory: %s", resolved.path))
+	}
+
+	// Read, edit application, and write run atomically under the per-path
+	// lock: edits are always applied to the latest content, so concurrent
+	// edits to disjoint regions compose instead of losing updates. Each
+	// oldText is matched incrementally against the result of the previous
+	// edit, mirroring the tool-layer semantics it replaces. The response
+	// version (bytesWritten/mtimeMs) is captured under the lock so it cannot
+	// belong to a subsequent writer.
+	var applied int
+	var bytesWritten int64
+	var mtimeMs int64
+	lockErr := withPathLock(resolved.path, func() error {
+		content, err := os.ReadFile(resolved.path)
+		if err != nil {
+			return err
+		}
+		text := string(content)
+		for _, edit := range params.Edits {
+			matches := strings.Count(text, edit.OldText)
+			if matches != 1 {
+				return &editMatchError{matches: matches}
+			}
+			text = strings.Replace(text, edit.OldText, edit.NewText, 1)
+		}
+		applied = len(params.Edits)
+		if err := os.WriteFile(resolved.path, []byte(text), 0o644); err != nil {
+			return err
+		}
+		bytesWritten = int64(len(text))
+		mtimeMs = statMtimeMs(resolved.path)
+		return nil
+	})
+	if lockErr != nil {
+		var matchErr *editMatchError
+		if errors.As(lockErr, &matchErr) {
+			if matchErr.matches == 0 {
+				return d.failed(request, "", "EDIT_NOT_FOUND", fmt.Sprintf("oldText must match exactly one region in %s, found 0", resolved.path))
+			}
+			return d.failed(request, "", "EDIT_NOT_UNIQUE", fmt.Sprintf("oldText must match exactly one region in %s, found %d", resolved.path, matchErr.matches))
+		}
+		if errors.Is(lockErr, os.ErrNotExist) {
+			return d.failed(request, "", "NOT_FOUND", fmt.Sprintf("file not found: %s", resolved.path))
+		}
+		return d.failedFSMutation(request, lockErr)
+	}
+
+	result := map[string]interface{}{
+		"path":         resolved.path,
+		"applied":      applied,
+		"bytesWritten": bytesWritten,
+	}
+	if mtimeMs > 0 {
+		result["mtimeMs"] = mtimeMs
 	}
 	return result
 }

--- a/apps/sandbox/rpc/helpers.go
+++ b/apps/sandbox/rpc/helpers.go
@@ -7,11 +7,85 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"github.com/cohub/apps/sandbox/env"
 )
+
+// errPathConflict reports that the target file no longer matches the caller's
+// expected version (size/mtimeMs). The write is rejected instead of silently
+// overwriting a concurrent mutation (optimistic concurrency).
+var errPathConflict = errors.New("file changed since it was opened")
+
+// refCountedMutex serializes filesystem mutations for one resolved path.
+type refCountedMutex struct {
+	mu   sync.Mutex
+	refs int
+	gone bool
+}
+
+var pathLockTable sync.Map // canonical path -> *refCountedMutex
+
+// resolvePathLockKey canonicalizes the lock key through EvalSymlinks so
+// symlink aliases pointing at the same target share one lock (matching the
+// realpath semantics of the upstream mutation queue). When the full path does
+// not exist yet (e.g. a file about to be created), the longest existing
+// ancestor is resolved and the missing leaf components are re-appended, so
+// aliases under a symlinked parent directory still map to the same key.
+func resolvePathLockKey(path string) string {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved
+	}
+	probe := path
+	var trailing []string
+	for {
+		resolved, err := filepath.EvalSymlinks(probe)
+		if err == nil {
+			full := resolved
+			for i := len(trailing) - 1; i >= 0; i-- {
+				full = filepath.Join(full, trailing[i])
+			}
+			return full
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			// Reached the filesystem root without an existing ancestor.
+			return path
+		}
+		trailing = append(trailing, filepath.Base(probe))
+		probe = parent
+	}
+}
+
+// withPathLock runs fn while holding the per-path lock for key. Mutations to
+// the same path are serialized; distinct paths proceed in parallel. Entries are
+// garbage collected when the last waiter leaves so long-running sandboxes do
+// not accumulate locks. The gone flag makes LoadOrStore racing with a delete
+// retry instead of sharing a lock that is about to be removed.
+func withPathLock(key string, fn func() error) error {
+	key = resolvePathLockKey(key)
+	for {
+		value, _ := pathLockTable.LoadOrStore(key, &refCountedMutex{})
+		entry := value.(*refCountedMutex)
+		entry.mu.Lock()
+		if entry.gone {
+			entry.mu.Unlock()
+			continue
+		}
+		entry.refs++
+		err := fn()
+		entry.refs--
+		if entry.refs == 0 {
+			entry.gone = true
+			pathLockTable.Delete(key)
+		}
+		entry.mu.Unlock()
+		return err
+	}
+}
 
 func ensureParentDirs(root, path string) ([]string, error) {
 	return ensureDirs(root, filepath.Dir(path))
@@ -77,6 +151,16 @@ func writeAndClose(file *os.File, content []byte) error {
 		return err
 	}
 	return file.Close()
+}
+
+// statMtimeMs returns the file's modification time in epoch milliseconds, or
+// 0 when the file cannot be statted. Callers holding the per-path lock use it
+// to capture the response version so it always belongs to this mutation.
+func statMtimeMs(path string) int64 {
+	if info, err := os.Stat(path); err == nil {
+		return info.ModTime().UnixMilli()
+	}
+	return 0
 }
 
 // osWriteFileExclusive creates path atomically, failing with os.IsExist when it

--- a/apps/sandbox/rpc/tree_test.go
+++ b/apps/sandbox/rpc/tree_test.go
@@ -2,10 +2,13 @@ package rpc
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/cohub/apps/sandbox/env"
@@ -165,6 +168,180 @@ func writeRequest(t *testing.T, params fsWriteParams) protocol.RPCRequest {
 	}
 }
 
+func editRequest(t *testing.T, params fsEditParams) protocol.RPCRequest {
+	t.Helper()
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal edit params: %v", err)
+	}
+	return protocol.RPCRequest{
+		RequestScopedMessage: protocol.RequestScopedMessage{RequestID: "req-e"},
+		Method:               "fs.edit",
+		Params:               raw,
+	}
+}
+
+func TestFSEditApplies(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("alpha\nbeta\ngamma\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	res := d.handleFSEdit(editRequest(t, fsEditParams{
+		Path:  "a.txt",
+		Edits: []fsEditItem{{OldText: "beta", NewText: "BETA"}},
+	}))
+	result, ok := res.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected edit to succeed, got %T (%v)", res, res)
+	}
+	if applied, _ := result["applied"].(int); applied != 1 {
+		t.Fatalf("applied = %v, want 1", result["applied"])
+	}
+	content, err := os.ReadFile(filepath.Join(root, "a.txt"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(content) != "alpha\nBETA\ngamma\n" {
+		t.Fatalf("content = %q", string(content))
+	}
+}
+
+func TestFSEditMultipleEditsApplyIncrementally(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("alpha\nbeta\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	res := d.handleFSEdit(editRequest(t, fsEditParams{
+		Path: "a.txt",
+		Edits: []fsEditItem{
+			{OldText: "alpha", NewText: "ALPHA"},
+			{OldText: "beta", NewText: "BETA"},
+		},
+	}))
+	if _, ok := res.(map[string]interface{}); !ok {
+		t.Fatalf("expected edit to succeed, got %T (%v)", res, res)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "a.txt"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(content) != "ALPHA\nBETA\n" {
+		t.Fatalf("content = %q", string(content))
+	}
+}
+
+func TestFSEditMatchErrors(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("alpha\nalpha\nbeta\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	notFound := d.handleFSEdit(editRequest(t, fsEditParams{Path: "a.txt", Edits: []fsEditItem{{OldText: "missing", NewText: "x"}}}))
+	failed, ok := notFound.(protocol.RPCFailed)
+	if !ok {
+		t.Fatalf("expected EDIT_NOT_FOUND, got %T (%v)", notFound, notFound)
+	}
+	if failed.Error.Code != "EDIT_NOT_FOUND" {
+		t.Fatalf("error code = %q, want EDIT_NOT_FOUND", failed.Error.Code)
+	}
+
+	notUnique := d.handleFSEdit(editRequest(t, fsEditParams{Path: "a.txt", Edits: []fsEditItem{{OldText: "alpha", NewText: "x"}}}))
+	failed, ok = notUnique.(protocol.RPCFailed)
+	if !ok {
+		t.Fatalf("expected EDIT_NOT_UNIQUE, got %T (%v)", notUnique, notUnique)
+	}
+	if failed.Error.Code != "EDIT_NOT_UNIQUE" {
+		t.Fatalf("error code = %q, want EDIT_NOT_UNIQUE", failed.Error.Code)
+	}
+
+	// A failed edit must not modify the file.
+	content, err := os.ReadFile(filepath.Join(root, "a.txt"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(content) != "alpha\nalpha\nbeta\n" {
+		t.Fatalf("failed edit modified content: %q", string(content))
+	}
+}
+
+func TestFSEditMissingFile(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+
+	res := d.handleFSEdit(editRequest(t, fsEditParams{Path: "missing.txt", Edits: []fsEditItem{{OldText: "x", NewText: "y"}}}))
+	failed, ok := res.(protocol.RPCFailed)
+	if !ok {
+		t.Fatalf("expected failure for missing file, got %T (%v)", res, res)
+	}
+	if failed.Error.Code != "NOT_FOUND" {
+		t.Fatalf("error code = %q, want NOT_FOUND", failed.Error.Code)
+	}
+}
+
+func TestFSEditConcurrentDisjointRegions(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+	// A larger file widens the read-modify-write window so the race is
+	// observable without the per-path lock.
+	var seed strings.Builder
+	for i := 0; i < 20000; i++ {
+		fmt.Fprintf(&seed, "line-%05d\n", i)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte(seed.String()), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	// Concurrent edits to disjoint regions must all land: each edit reads the
+	// latest content inside the per-path lock, so no edit is based on stale
+	// content. Without the lock, the last writer would silently drop the
+	// earlier edits.
+	const rounds = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < rounds; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			var item fsEditItem
+			if i%2 == 0 {
+				item = fsEditItem{OldText: "line-00001", NewText: "ALPHA"}
+			} else {
+				item = fsEditItem{OldText: "line-19999", NewText: "GAMMA"}
+			}
+			raw, err := json.Marshal(fsEditParams{Path: "a.txt", Edits: []fsEditItem{item}})
+			if err != nil {
+				return
+			}
+			req := protocol.RPCRequest{
+				RequestScopedMessage: protocol.RequestScopedMessage{RequestID: fmt.Sprintf("req-%d", i)},
+				Method:               "fs.edit",
+				Params:               raw,
+			}
+			d.handleFSEdit(req)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	content, err := os.ReadFile(filepath.Join(root, "a.txt"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	text := string(content)
+	if strings.Contains(text, "line-00001") || strings.Contains(text, "line-19999") {
+		t.Fatalf("concurrent edits lost updates (line-00001 or line-19999 still present)")
+	}
+	if !strings.Contains(text, "ALPHA") || !strings.Contains(text, "GAMMA") {
+		t.Fatalf("concurrent edits did not both land: %q", text[:80])
+	}
+}
+
 func mkdirRequest(t *testing.T, params fsMkdirParams) protocol.RPCRequest {
 	t.Helper()
 	raw, err := json.Marshal(params)
@@ -265,6 +442,121 @@ func TestFSWriteExclusive(t *testing.T) {
 	}
 }
 
+func TestResolvePathLockKeySymlinkAliases(t *testing.T) {
+	root := setupTree(t)
+	target := filepath.Join(root, "target.txt")
+	if err := os.WriteFile(target, []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	for _, alias := range []string{"alias-a.txt", "alias-b.txt"} {
+		if err := os.Symlink(target, filepath.Join(root, alias)); err != nil {
+			t.Fatalf("create %s: %v", alias, err)
+		}
+	}
+
+	// Distinct symlink aliases must resolve to the same lock key so writes
+	// through either alias serialize against the same target file.
+	keyA := resolvePathLockKey(filepath.Join(root, "alias-a.txt"))
+	keyB := resolvePathLockKey(filepath.Join(root, "alias-b.txt"))
+	if keyA != keyB {
+		t.Fatalf("alias lock keys differ: %q vs %q", keyA, keyB)
+	}
+	if keyA != target {
+		t.Fatalf("alias lock key = %q, want target %q", keyA, target)
+	}
+
+	// A path that does not exist yet falls back to the lexical path: there is
+	// no symlink to resolve when the file is about to be created.
+	missing := filepath.Join(root, "missing.txt")
+	if key := resolvePathLockKey(missing); key != missing {
+		t.Fatalf("missing path lock key = %q, want lexical %q", key, missing)
+	}
+}
+
+func TestResolvePathLockKeySymlinkedParentMissingLeaf(t *testing.T) {
+	root := setupTree(t)
+	realDir := filepath.Join(root, "real")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatalf("mkdir real: %v", err)
+	}
+	if err := os.Symlink(realDir, filepath.Join(root, "alias")); err != nil {
+		t.Fatalf("create alias dir: %v", err)
+	}
+
+	// The leaf file does not exist yet, so EvalSymlinks on the full path
+	// fails; the longest existing ancestor (the symlinked parent) must still
+	// be resolved so both aliases share one lock for the about-to-be-created
+	// file.
+	keyReal := resolvePathLockKey(filepath.Join(realDir, "new.txt"))
+	keyAlias := resolvePathLockKey(filepath.Join(root, "alias", "new.txt"))
+	if keyReal != keyAlias {
+		t.Fatalf("symlinked-parent lock keys differ: %q vs %q", keyReal, keyAlias)
+	}
+	if keyReal != filepath.Join(realDir, "new.txt") {
+		t.Fatalf("lock key = %q, want %q", keyReal, filepath.Join(realDir, "new.txt"))
+	}
+}
+
+func TestFSWriteConcurrentSymlinkAliases(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+	target := filepath.Join(root, "target.txt")
+	if err := os.WriteFile(target, []byte(""), 0o644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "alias-a.txt")); err != nil {
+		t.Fatalf("create alias-a: %v", err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "alias-b.txt")); err != nil {
+		t.Fatalf("create alias-b: %v", err)
+	}
+
+	// Writes through distinct symlink aliases target the same file and must
+	// share one per-path lock, otherwise the shorter write can leave the
+	// longer content's tail behind (torn write).
+	contents := []string{
+		strings.Repeat("a", 4096),
+		strings.Repeat("b", 2048),
+	}
+	paths := []string{"alias-a.txt", "alias-b.txt"}
+	const rounds = 12
+	var wg sync.WaitGroup
+	for i := 0; i < rounds; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			raw, err := json.Marshal(fsWriteParams{Path: paths[i%2], Content: contents[i%2]})
+			if err != nil {
+				return
+			}
+			req := protocol.RPCRequest{
+				RequestScopedMessage: protocol.RequestScopedMessage{RequestID: fmt.Sprintf("req-%d", i)},
+				Method:               "fs.write",
+				Params:               raw,
+			}
+			d.handleFSWrite(req)
+		}(i)
+	}
+	wg.Wait()
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	wantLen := 4096
+	if got[0] == 'b' {
+		wantLen = 2048
+	}
+	if len(got) != wantLen {
+		t.Fatalf("torn write via symlink aliases: length = %d, want %d", len(got), wantLen)
+	}
+	for index, b := range got {
+		if b != got[0] {
+			t.Fatalf("torn write via symlink aliases: mixed content at byte %d", index)
+		}
+	}
+}
+
 func TestFSTreeRootUnreadable(t *testing.T) {
 	root := setupTree(t)
 	d := newTreeDispatcher(t, root)
@@ -272,5 +564,145 @@ func TestFSTreeRootUnreadable(t *testing.T) {
 	res := d.handleFSTree(treeRequest(t, fsTreeParams{Path: "does-not-exist", Depth: 1}))
 	if _, ok := res.(protocol.RPCFailed); !ok {
 		t.Fatalf("expected failure for missing root, got %T", res)
+	}
+}
+
+func writeResultVersion(t *testing.T, res interface{}) (size int64, mtimeMs int64) {
+	t.Helper()
+	result, ok := res.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected write to succeed, got %T (%v)", res, res)
+	}
+	written, ok := result["bytesWritten"].(int)
+	if !ok {
+		t.Fatalf("write result missing bytesWritten: %v", result)
+	}
+	size = int64(written)
+	mtimeMs, ok = result["mtimeMs"].(int64)
+	if !ok {
+		t.Fatalf("write result missing mtimeMs: %v", result)
+	}
+	return size, mtimeMs
+}
+
+func TestFSWriteExpectedVersionMatches(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+
+	size, mtimeMs := writeResultVersion(t, d.handleFSWrite(writeRequest(t, fsWriteParams{Path: "v.txt", Content: "one"})))
+
+	res := d.handleFSWrite(writeRequest(t, fsWriteParams{
+		Path:     "v.txt",
+		Content:  "two",
+		Expected: &fsWriteVersion{Size: size, MtimeMs: mtimeMs},
+	}))
+	if _, ok := res.(map[string]interface{}); !ok {
+		t.Fatalf("expected versioned write to succeed, got %T (%v)", res, res)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "v.txt"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(content) != "two" {
+		t.Fatalf("content = %q, want %q", string(content), "two")
+	}
+}
+
+func TestFSWriteExpectedVersionConflict(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+
+	size, mtimeMs := writeResultVersion(t, d.handleFSWrite(writeRequest(t, fsWriteParams{Path: "v.txt", Content: "one"})))
+	// Another writer modifies the file after the baseline was captured.
+	d.handleFSWrite(writeRequest(t, fsWriteParams{Path: "v.txt", Content: "changed by someone else"}))
+
+	res := d.handleFSWrite(writeRequest(t, fsWriteParams{
+		Path:     "v.txt",
+		Content:  "mine",
+		Expected: &fsWriteVersion{Size: size, MtimeMs: mtimeMs},
+	}))
+	failed, ok := res.(protocol.RPCFailed)
+	if !ok {
+		t.Fatalf("expected version conflict, got %T (%v)", res, res)
+	}
+	if failed.Error.Code != "CONFLICT" {
+		t.Fatalf("error code = %q, want CONFLICT", failed.Error.Code)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "v.txt"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(content) != "changed by someone else" {
+		t.Fatalf("conflicting write clobbered content: got %q", string(content))
+	}
+}
+
+func TestFSWriteExpectedVersionMissingFile(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+
+	res := d.handleFSWrite(writeRequest(t, fsWriteParams{
+		Path:     "missing.txt",
+		Content:  "x",
+		Expected: &fsWriteVersion{Size: 0, MtimeMs: 123},
+	}))
+	failed, ok := res.(protocol.RPCFailed)
+	if !ok {
+		t.Fatalf("expected version conflict for missing file, got %T (%v)", res, res)
+	}
+	if failed.Error.Code != "CONFLICT" {
+		t.Fatalf("error code = %q, want CONFLICT", failed.Error.Code)
+	}
+}
+
+func TestFSWriteConcurrentSamePath(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+	path := filepath.Join(root, "concurrent.txt")
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	// Unequal lengths are required to expose torn writes: a shorter write that
+	// lands after a longer one leaves the longer content's tail in the file.
+	contents := []string{
+		strings.Repeat("a", 4096),
+		strings.Repeat("b", 2048),
+	}
+	const rounds = 12
+	var wg sync.WaitGroup
+	for i := 0; i < rounds; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			raw, err := json.Marshal(fsWriteParams{Path: "concurrent.txt", Content: contents[i%2]})
+			if err != nil {
+				return
+			}
+			req := protocol.RPCRequest{
+				RequestScopedMessage: protocol.RequestScopedMessage{RequestID: fmt.Sprintf("req-%d", i)},
+				Method:               "fs.write",
+				Params:               raw,
+			}
+			d.handleFSWrite(req)
+		}(i)
+	}
+	wg.Wait()
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	wantLen := 4096
+	if got[0] == 'b' {
+		wantLen = 2048
+	}
+	if len(got) != wantLen {
+		t.Fatalf("torn write: length = %d, want %d", len(got), wantLen)
+	}
+	for index, b := range got {
+		if b != got[0] {
+			t.Fatalf("torn write: mixed content at byte %d", index)
+		}
 	}
 }

--- a/apps/sandbox/ws/session.go
+++ b/apps/sandbox/ws/session.go
@@ -208,6 +208,8 @@ func (s *Server) sendHeartbeat(session *connectionSession, includeSnapshot bool)
 			FSRead:             true,
 			FSWrite:            true,
 			FSWriteDisposition: true,
+			FSWriteExpected:    true,
+			FSEdit:             true,
 			FSMkdir:            true,
 			FSStat:             true,
 			FSLs:               true,

--- a/packages/protocol/src/fs/index.ts
+++ b/packages/protocol/src/fs/index.ts
@@ -105,6 +105,21 @@ export function matchesSpaceFsVersion(
     && Math.trunc(actual.mtimeMs) === Math.trunc(expected.mtimeMs);
 }
 
+/**
+ * Full preflight check used before a conditional write: the file must exist,
+ * must not be a directory, and must match the caller's expected version.
+ * Shared by the API and agent mutation paths so the conflict decision never
+ * diverges.
+ */
+export function spaceFsVersionMatches(
+  current: { exists?: boolean; isDirectory?: boolean; size?: number; mtimeMs?: number } | null | undefined,
+  expected: { size: number; mtimeMs: number },
+) {
+  return current?.exists === true
+    && current.isDirectory !== true
+    && matchesSpaceFsVersion(current, expected);
+}
+
 export type SpaceFsMoveInput = {
   fromPath: string;
   toPath: string;

--- a/packages/protocol/src/sandbox/index.ts
+++ b/packages/protocol/src/sandbox/index.ts
@@ -16,6 +16,7 @@ export type SandboxStatus = (typeof SANDBOX_STATUSES)[number];
 export const RPC_METHODS = [
   "fs.read",
   "fs.write",
+  "fs.edit",
   "fs.mkdir",
   "fs.stat",
   "fs.ls",
@@ -75,6 +76,9 @@ export const RPC_ERROR_CODES = [
   "INVALID_PATH",
   "ACCESS_DENIED",
   "READ_ONLY_FILESYSTEM",
+  "CONFLICT",
+  "EDIT_NOT_FOUND",
+  "EDIT_NOT_UNIQUE",
   "TIMEOUT",
   "PROCESS_SPAWN_FAILED",
   "PROCESS_ABORT_FAILED",
@@ -111,6 +115,10 @@ export type SandboxCapabilities = {
   fsWrite: boolean;
   /** fs.write reports atomic create/modify disposition and created parent directories. */
   fsWriteDisposition?: boolean;
+  /** fs.write honors the expected version baseline (atomic check-and-write). */
+  fsWriteExpected?: boolean;
+  /** Supports the atomic fs.edit read-apply-write method. */
+  fsEdit?: boolean;
   fsMkdir?: boolean;
   fsStat: boolean;
   fsLs: boolean;
@@ -201,6 +209,12 @@ export type FsWriteParams = {
   encoding?: "utf-8" | "base64";
   /** Fail with ALREADY_EXISTS instead of overwriting when the path exists (O_EXCL). */
   exclusive?: boolean;
+  /**
+   * Optimistic concurrency baseline: reject with CONFLICT when the file no
+   * longer matches this version (size + mtimeMs). Checked atomically with the
+   * write inside the sandbox. Only honored for non-exclusive writes.
+   */
+  expected?: { size: number; mtimeMs: number };
 };
 
 export type FsWriteResult = {
@@ -211,6 +225,25 @@ export type FsWriteResult = {
   /** Workspace-relative parent directories created by this write, outermost first. */
   createdDirs?: string[];
   /** File modification time in epoch milliseconds after the write. */
+  mtimeMs?: number;
+};
+
+export type FsEdit = {
+  oldText: string;
+  newText: string;
+};
+
+export type FsEditParams = {
+  path: string;
+  cwd?: string;
+  edits: FsEdit[];
+};
+
+export type FsEditResult = {
+  path: string;
+  /** Number of edits applied. */
+  applied: number;
+  bytesWritten: number;
   mtimeMs?: number;
 };
 
@@ -375,6 +408,10 @@ export type RpcRequestMap = {
   "fs.write": {
     params: FsWriteParams;
     result: FsWriteResult;
+  };
+  "fs.edit": {
+    params: FsEditParams;
+    result: FsEditResult;
   };
   "fs.mkdir": {
     params: FsMkdirParams;


### PR DESCRIPTION
## Summary

Concurrent writes to the same file (multiple agent sessions, web editor, API) can currently **tear file contents** (O_TRUNC + write is not atomic) and **silently lose updates** (last-write-wins on stale content). This PR fixes both at the sandbox layer.

## Changes

**Sandbox (Go)**
- `withPathLock`: per-canonical-path keyed mutex (refcounted, garbage-collected) serializes mutations to the same file; distinct paths run in parallel. Symlink aliases share one lock: the key resolves the longest existing ancestor via `EvalSymlinks` (matching the upstream mutation queue's `realpath` semantics), so even aliases under a symlinked parent dir with a not-yet-created leaf share one lock.
- `fs.write` gains an optional `expected: { size, mtimeMs }` baseline. The version check and the write run **atomically under the lock** (no TOCTOU window); stale writes are rejected with a new `CONFLICT` rpc error. `exclusive` (O_EXCL) stays orthogonal. The response version (mtimeMs) is captured under the lock so it always belongs to this write.
- New `fs.edit` RPC applies exact-text replacements atomically inside the same per-path lock (read-apply-write): edits always target the latest content, so concurrent edits to disjoint regions compose instead of losing updates — the sandbox-side equivalent of queueing the whole read-modify-write cycle. Match failures surface as `EDIT_NOT_FOUND` / `EDIT_NOT_UNIQUE` without modifying the file.

**Protocol**
- `RPC_METHODS` adds `fs.edit`; `RPC_ERROR_CODES` adds `CONFLICT`, `EDIT_NOT_FOUND`, `EDIT_NOT_UNIQUE`; `FsWriteParams` adds `expected`; `SandboxCapabilities` adds `fsEdit` and `fsWriteExpected`.

**API**
- The API forwards the client's `expected` to sandbox `fs.write` on the remote and agent-mutation paths **only when the sandbox advertises `fsWriteExpected`** (older sandboxes silently ignore unknown fields, which would downgrade a conditional write to an unconditional one; without the capability the API preflight stat remains the only check, matching pre-PR behavior). `mtimeMs` is truncated to whole ms to match the Go int64 field. The API stat check stays as a fast-fail; the sandbox check closes the TOCTOU window. Sandbox `CONFLICT` maps to 409 `file_conflict`, so the web editor's existing conflict-recovery path applies.

**Agent tools** (`apps/agent`)
- `edit` uses `fs.edit` (single atomic RPC, no version state). When the sandbox does not advertise `fsEdit` (older pinned local sandboxd), it degrades to the plain read-modify-write cycle instead of failing.
- `write` stays a plain write, matching upstream behavior. The web editor path remains the protected overwrite path.

## Guarantee scope

The per-path lock serializes **sandbox RPC mutations** (`fs.write`, `fs.edit`). Writers outside the RPC layer — shell commands / build tools / dev servers launched via `process.start`, or processes in the workspace — do not take the lock and can still race with an in-flight read-modify-write; this is a fundamental limit of user-space locking (the upstream mutation queue has the same gap) and is excluded from the guarantee. The `{size, mtimeMs}` version token can also collide for two same-size writes within one filesystem millisecond (the same racy-token class as git's stat cache), so the stale-write guarantee is best-effort, not cryptographic.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Concurrent RPC writes, same file | torn content possible | serialized, no tearing |
| Stale write (web editor, expected) | TOCTOU window | atomic check-and-write, `CONFLICT` → 409 |
| Two sessions edit disjoint regions | last-write-wins loses one side | lock-serialized, both edits compose |
| Single-session sequential edits | — | unaffected |

## Verification

- Go: `go build/vet/test ./... -race` all green; lock, symlink-resolution, and concurrent-edit tests verified to fail when disabled
- TS: protocol 53, api 168, agent 24 tests green; all workspace typechecks green (13 projects, incl. web)