### PR TITLE
feat(billing): internal/realtime-voice session route for neta-router

### DIFF
--- a/.changeset/realtime-voice-client.md
+++ b/.changeset/realtime-voice-client.md
@@ -1,0 +1,5 @@
+---
+"@neta-art/cohub": minor
+---
+
+Add `RealtimeVoiceClient`/`createRealtimeVoiceClient` for connecting to cohub's realtime voice gateway (`apps/gateway`'s `/v1/realtime`), so browser and Node consumers don't need to hand-roll the WebSocket handshake. Auth travels as a `x-token.<value>` WebSocket subprotocol entry rather than an in-band message, keeping the wire protocol a plain OpenAI-Realtime-API-compatible connection.

--- a/apps/api/src/realtime-voice-tickets.ts
+++ b/apps/api/src/realtime-voice-tickets.ts
@@ -1,0 +1,70 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { config } from "./config.js";
+
+/**
+ * Opaque session id for the realtime-voice internal API (see
+ * routes/internal/realtime-voice.route.ts). Signed the same way as work room
+ * tickets (work-realtime-rooms.ts) so acquire/heartbeat/release stay stateless:
+ * the session's identity travels inside the token itself instead of a DB row,
+ * and heartbeat/release only need to verify the signature, not look anything up.
+ */
+
+const ticketBase64 = (value: string | Buffer) => Buffer.from(value).toString("base64url");
+const ticketSecret = () => {
+  if (!config.appEncryptionKey) throw new Error("Missing APP_ENCRYPTION_KEY for realtime voice session tickets");
+  return config.appEncryptionKey;
+};
+const ticketSignature = (value: string) => createHmac("sha256", ticketSecret()).update(value).digest();
+
+export type RealtimeVoiceService = "realtime_calling" | "realtime_tts";
+
+export type RealtimeVoiceSessionTicketPayload = {
+  typ: "realtime_voice_session";
+  userUuid: string;
+  service: RealtimeVoiceService;
+  /** Random per-session id, used only for logging/idempotency, not as a lookup key. */
+  sid: string;
+  exp: number;
+};
+
+export const createRealtimeVoiceSessionTicket = (input: {
+  userUuid: string;
+  service: RealtimeVoiceService;
+  sid: string;
+  expiresAt: number;
+}) => {
+  const payload: RealtimeVoiceSessionTicketPayload = {
+    typ: "realtime_voice_session",
+    userUuid: input.userUuid,
+    service: input.service,
+    sid: input.sid,
+    exp: Math.floor(input.expiresAt / 1000),
+  };
+  const header = ticketBase64(JSON.stringify({ alg: "HS256", typ: "COHUB_REALTIME_VOICE" }));
+  const body = ticketBase64(JSON.stringify(payload));
+  const signingInput = `${header}.${body}`;
+  return `${signingInput}.${ticketBase64(ticketSignature(signingInput))}`;
+};
+
+export const verifyRealtimeVoiceSessionTicket = (token: string): RealtimeVoiceSessionTicketPayload | null => {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [header, body, signature] = parts as [string, string, string];
+  const expected = ticketSignature(`${header}.${body}`);
+  const actual = Buffer.from(signature, "base64url");
+  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) return null;
+  try {
+    const payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8")) as RealtimeVoiceSessionTicketPayload;
+    if (
+      payload.typ !== "realtime_voice_session" ||
+      !payload.userUuid ||
+      !payload.sid ||
+      (payload.service !== "realtime_calling" && payload.service !== "realtime_tts") ||
+      !Number.isInteger(payload.exp) ||
+      payload.exp * 1000 <= Date.now()
+    ) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+};

--- a/apps/api/src/routes/internal/index.ts
+++ b/apps/api/src/routes/internal/index.ts
@@ -1,11 +1,13 @@
 import { Hono } from "hono";
 import internalGatewayRouter from "./gateway.route.js";
+import internalRealtimeVoiceRouter from "./realtime-voice.route.js";
 import internalSpaceEventsRouter from "./space-events.route.js";
 import internalSpacesRouter from "./spaces.route.js";
 
 const router = new Hono();
 
 router.route("/gateway", internalGatewayRouter);
+router.route("/realtime-voice", internalRealtimeVoiceRouter);
 router.route("/space-events", internalSpaceEventsRouter);
 router.route("/spaces", internalSpacesRouter);
 

--- a/apps/api/src/routes/internal/realtime-voice.route.ts
+++ b/apps/api/src/routes/internal/realtime-voice.route.ts
@@ -1,0 +1,171 @@
+import { randomUUID } from "node:crypto";
+import { Hono } from "hono";
+import {
+  BillingAccessBlockedError,
+  COHUB_BILLING_TOKEN_TYPES,
+  COHUB_BILLING_USAGE_TYPES,
+  REALTIME_VOICE_BILLING,
+  billingOperations,
+  createBillingUsageGate,
+  isBillingUsageGateUnavailableError,
+} from "@cohub/billing";
+import { createLogger } from "@cohub/infra/logging";
+import { ensureInternalRequest, getOptionalAuth } from "../../lib/middleware.js";
+import { billingBlockedResponse } from "../../lib/billing-blocked.js";
+import {
+  createRealtimeVoiceSessionTicket,
+  verifyRealtimeVoiceSessionTicket,
+  type RealtimeVoiceService,
+} from "../../realtime-voice-tickets.js";
+
+// Internal API consumed by neta-router's WebSocket relay (GET /v1/realtime),
+// not by browsers directly. neta-router forwards the end user's own Logto
+// access token as a normal Authorization header on acquire, so the existing
+// global auth middleware resolves it into `principal` the same way it does
+// for every other route; ensureInternalRequest additionally proves the
+// caller is neta-router itself (x-worker-secret), not an arbitrary client.
+//
+// acquire/heartbeat/release are intentionally stateless on this side: the
+// session's identity travels inside the signed `session_id` ticket
+// (realtime-voice-tickets.ts) instead of a DB row, so heartbeat/release only
+// need to verify a signature, not look anything up.
+//
+// Billing model: realtime voice has no natural per-task cost the way
+// generation does (it's a continuous connection, not a discrete job), so it's
+// billed as wall-clock connected time — a flat per-heartbeat-tick charge —
+// rather than off provider-reported token usage. See REALTIME_VOICE_BILLING;
+// its rate is a placeholder pending real pricing input.
+
+const logger = createLogger({ serviceName: "cohub-api" });
+const router = new Hono();
+
+const IDLE_TIMEOUT_S = 60;
+// TODO(product): confirm the intended max realtime-voice session length.
+const MAX_DURATION_S = 30 * 60;
+// Ticket must outlive the session it authorizes, with slack for the last heartbeat's round trip.
+const TICKET_TTL_MS = (MAX_DURATION_S + IDLE_TIMEOUT_S + 60) * 1000;
+
+const billingUsageGate = createBillingUsageGate({
+  operations: billingOperations,
+  onEvaluationError: (error, gateInput) => {
+    logger.warn("[BillingGate] realtime voice billing evaluation failed", { error, gateInput });
+  },
+});
+
+function parseService(value: unknown): RealtimeVoiceService {
+  return value === "realtime_calling" ? "realtime_calling" : "realtime_tts";
+}
+
+router.post("/session/acquire", async (c) => {
+  const forbidden = ensureInternalRequest(c);
+  if (forbidden) return forbidden;
+
+  const user = getOptionalAuth(c);
+  if (!user) return c.json({ detail: "authentication is required" }, 401);
+
+  const body = await c.req.json<{ service?: string }>().catch(() => null);
+  const service = parseService(body?.service);
+
+  let decision: Awaited<ReturnType<typeof billingUsageGate.evaluate>>;
+  try {
+    decision = await billingUsageGate.evaluate({
+      userId: user.uuid,
+      usageKind: COHUB_BILLING_USAGE_TYPES.realtimeVoice,
+      source: "realtime_session",
+    });
+  } catch (error) {
+    if (!isBillingUsageGateUnavailableError(error)) throw error;
+    return c.json({ detail: error.message }, 503);
+  }
+  if (decision.status === "blocked") {
+    return billingBlockedResponse(c, new BillingAccessBlockedError(decision));
+  }
+
+  const sid = randomUUID();
+  const expiresAt = Date.now() + TICKET_TTL_MS;
+  const sessionId = createRealtimeVoiceSessionTicket({ userUuid: user.uuid, service, sid, expiresAt });
+
+  logger.info("[RealtimeVoice] session acquired", { userUuid: user.uuid, service, sid });
+
+  return c.json({
+    session_id: sessionId,
+    user_uuid: user.uuid,
+    config: {
+      idle_timeout_s: IDLE_TIMEOUT_S,
+      max_duration_s: MAX_DURATION_S,
+    },
+  });
+});
+
+router.post("/session/heartbeat", async (c) => {
+  const forbidden = ensureInternalRequest(c);
+  if (forbidden) return forbidden;
+
+  const body = await c.req.json<{ session_id?: string }>().catch(() => null);
+  const ticket = typeof body?.session_id === "string" ? verifyRealtimeVoiceSessionTicket(body.session_id) : null;
+  if (!ticket) return c.json({ detail: "invalid or expired session" }, 404);
+
+  let decision: Awaited<ReturnType<typeof billingUsageGate.evaluate>>;
+  try {
+    decision = await billingUsageGate.evaluate({
+      userId: ticket.userUuid,
+      usageKind: COHUB_BILLING_USAGE_TYPES.realtimeVoice,
+      source: "realtime_session",
+      sessionId: ticket.sid,
+    });
+  } catch (error) {
+    // Fail closed: an unreadable balance is treated the same as no balance,
+    // rather than letting the session run un-metered.
+    logger.warn("[RealtimeVoice] heartbeat billing gate unavailable, closing session", { error, sid: ticket.sid });
+    return c.json({ success: true, billing: { allowed: false, reason: "billing temporarily unavailable" } });
+  }
+  if (decision.status === "blocked") {
+    return c.json({ success: true, billing: { allowed: false, reason: "insufficient balance" } });
+  }
+
+  const amountUsd = Number(
+    ((REALTIME_VOICE_BILLING.usdPerMinute / 60) * REALTIME_VOICE_BILLING.heartbeatIntervalSeconds).toFixed(8),
+  );
+  const tickBucket = Math.floor(Date.now() / (REALTIME_VOICE_BILLING.heartbeatIntervalSeconds * 1000));
+  let charged = 0;
+  try {
+    const result = await billingOperations.recordUsage({
+      userId: ticket.userUuid,
+      amountUsd,
+      tokenType: COHUB_BILLING_TOKEN_TYPES.usdMicroCent,
+      usageType: COHUB_BILLING_USAGE_TYPES.realtimeVoice,
+      sourceId: ticket.sid,
+      // Idempotency key covers this session + this ~30s tick, so a client
+      // retry of the same heartbeat can never double-charge.
+      operationId: `realtime_voice:${ticket.sid}:${tickBucket}`,
+      reason: `Realtime voice (${ticket.service})`,
+    });
+    if (result.status === "recorded" || result.status === "overage") charged = amountUsd;
+  } catch (error) {
+    // A transient billing-write failure doesn't kill the session — the
+    // preflight gate above is what actually protects against runaway debt.
+    logger.error("[RealtimeVoice] failed to record heartbeat usage", { error, sid: ticket.sid });
+  }
+
+  return c.json({
+    success: true,
+    billing: {
+      allowed: true,
+      charged,
+      remaining_usd: decision.status === "allowed" || decision.status === "allowed_with_debt" ? decision.netUsd : undefined,
+    },
+  });
+});
+
+router.delete("/session/:sessionId", async (c) => {
+  const forbidden = ensureInternalRequest(c);
+  if (forbidden) return forbidden;
+
+  const ticket = verifyRealtimeVoiceSessionTicket(c.req.param("sessionId"));
+  if (ticket) {
+    logger.info("[RealtimeVoice] session released", { userUuid: ticket.userUuid, sid: ticket.sid });
+  }
+  return c.json({ ok: true });
+});
+
+export default router;

--- a/apps/gateway/.env.example
+++ b/apps/gateway/.env.example
@@ -14,6 +14,11 @@ WORKER_SECRET=""
 # 火山 ASR API Key，供 /asr/ws 语音输入使用
 VOLC_ASR_API_KEY=""
 
+# neta-router base URL/API key，供 /v1/realtime 语音网关向上游转发使用
+# （复用与 generation-sdk 相同的业务 key 约定，默认同 https://router.neta.art）
+GENERATION_BASE_URL=""
+GENERATION_API_KEY=""
+
 # ==========================================
 # 本地调试模式配置 (仅供本地单测 Gateway 使用)
 # ==========================================

--- a/apps/gateway/src/api-client.ts
+++ b/apps/gateway/src/api-client.ts
@@ -100,6 +100,73 @@ export const authenticateRealtimeToken = async (input: { token: string }): Promi
   };
 };
 
+export type RealtimeVoiceAcquireResult = {
+  session_id: string;
+  user_uuid: string;
+  config: { idle_timeout_s: number; max_duration_s: number };
+};
+
+/** Runs the billing preflight gate and issues a ticket-backed session id. Throws (with `.status`) on 401/402/503. */
+export const acquireRealtimeVoiceSession = async (input: {
+  token: string;
+  service: string;
+}): Promise<RealtimeVoiceAcquireResult> => {
+  const response = await fetch(`${gatewayConfig.apiBaseUrl}/internal/realtime-voice/session/acquire`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-worker-secret": gatewayConfig.workerSecret,
+      authorization: `Bearer ${input.token}`,
+      ...buildTraceHeaders(),
+    },
+    body: JSON.stringify({ service: input.service }),
+  });
+  if (!response.ok) {
+    const body = await parseJson<{ detail?: string; message?: string }>(response);
+    const error = new Error(body?.detail ?? body?.message ?? `session acquire failed: ${response.status}`) as Error & { status?: number };
+    error.status = response.status;
+    throw error;
+  }
+  const data = await parseJson<RealtimeVoiceAcquireResult>(response);
+  if (!data?.session_id || !data.user_uuid || !data.config) {
+    throw new Error("Realtime voice session acquire returned an invalid response");
+  }
+  return data;
+};
+
+export type RealtimeVoiceHeartbeatResult = {
+  success: boolean;
+  billing?: { allowed: boolean; charged?: number; remaining_usd?: number; reason?: string };
+};
+
+export const heartbeatRealtimeVoiceSession = async (sessionId: string): Promise<RealtimeVoiceHeartbeatResult> => {
+  const response = await fetch(`${gatewayConfig.apiBaseUrl}/internal/realtime-voice/session/heartbeat`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-worker-secret": gatewayConfig.workerSecret,
+      ...buildTraceHeaders(),
+    },
+    body: JSON.stringify({ session_id: sessionId }),
+  });
+  if (!response.ok) throw new Error(`Realtime voice heartbeat failed: ${response.status}`);
+  const data = await parseJson<RealtimeVoiceHeartbeatResult>(response);
+  if (!data) throw new Error("Realtime voice heartbeat returned an invalid response");
+  return data;
+};
+
+export const releaseRealtimeVoiceSession = async (sessionId: string): Promise<void> => {
+  await fetch(`${gatewayConfig.apiBaseUrl}/internal/realtime-voice/session/${sessionId}`, {
+    method: "DELETE",
+    headers: {
+      "x-worker-secret": gatewayConfig.workerSecret,
+      ...buildTraceHeaders(),
+    },
+  }).catch(() => {
+    // best-effort: an unreleased ticket just expires on its own (TICKET_TTL_MS).
+  });
+};
+
 export const requestGatewayChannelReconcile = async (): Promise<{ stats: unknown }> => {
   const response = await fetch(`${gatewayConfig.apiBaseUrl}/internal/gateway/reconcile-channels`, {
     method: "POST",

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -19,6 +19,13 @@ export const gatewayConfig = {
     resourceId: "volc.seedasr.sauc.duration",
     url: "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async",
   },
+  // neta-router credentials for the realtime voice relay (apps/gateway is the
+  // caller here, same trust boundary as apps/api/apps/worker's generation
+  // calls -- reuses the same business key convention, just a different route).
+  netaRouter: {
+    baseUrl: normalizeBaseUrl(process.env.GENERATION_BASE_URL ?? "https://router.neta.art"),
+    apiKey: process.env.GENERATION_API_KEY ?? "",
+  },
 };
 
 export type GatewayAuthUser = {

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -47,6 +47,7 @@ import {
 } from "./board-awareness-admission.js";
 import { markChannelDegraded, touchChannelOutbound } from "./channel-health.js";
 import { handleAsrWebSocketConnection } from "./asr/session.js";
+import { handleRealtimeVoiceConnection } from "./realtime-voice/session.js";
 import { handleRelayControlConnection, handleRelayDataConnection, handleRelayPeerConnection } from "./relay/index.js";
 import {
   createPubSubRedisClient,
@@ -949,6 +950,7 @@ async function main() {
   const server = serve({ fetch: app.fetch, port: gatewayConfig.port }) as unknown as import("node:http").Server;
   const wss = new WebSocketServer({ noServer: true });
   const asrWss = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 });
+  const realtimeVoiceWss = new WebSocketServer({ noServer: true });
   // Local sandbox relay: control (runner⇒gateway), data (runner dial-out), and
   // peer (agent/worker⇒gateway) channels. Large payloads flow on data channels.
   const relayControlWss = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 });
@@ -958,6 +960,7 @@ async function main() {
   const websocketRoutes = new Map<string, WebSocketServer>([
     ["/ws", wss],
     ["/asr/ws", asrWss],
+    ["/v1/realtime", realtimeVoiceWss],
     ["/sandbox/relay", relayControlWss],
     ["/sandbox/relay/data", relayDataWss],
   ]);
@@ -994,6 +997,7 @@ async function main() {
   });
 
   asrWss.on("connection", handleAsrWebSocketConnection);
+  realtimeVoiceWss.on("connection", handleRealtimeVoiceConnection);
   relayControlWss.on("connection", (socket, request) => void handleRelayControlConnection(socket, request));
   relayDataWss.on("connection", (socket, request) => handleRelayDataConnection(socket, request));
 

--- a/apps/gateway/src/realtime-voice/session.ts
+++ b/apps/gateway/src/realtime-voice/session.ts
@@ -1,0 +1,169 @@
+import type { IncomingMessage } from "node:http";
+import { WebSocket } from "ws";
+import { createLogger } from "@cohub/infra/logging";
+import {
+  acquireRealtimeVoiceSession,
+  heartbeatRealtimeVoiceSession,
+  releaseRealtimeVoiceSession,
+} from "../api-client.js";
+import { gatewayConfig } from "../config.js";
+
+const logger = createLogger({ serviceName: "cohub-gateway" });
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const UPSTREAM_CONNECT_TIMEOUT_MS = 10_000;
+
+/**
+ * Terminates the end user's realtime voice WebSocket at cohub (same shape as
+ * asr/session.ts's ASR gateway), then relays raw bytes to neta-router's own
+ * /v1/realtime, which in turn forwards to new-api. Bytes never transit through
+ * neta-router's or new-api's protocol translation at this layer -- this is a
+ * pure passthrough, same as neta-router's role for every other route.
+ *
+ * The wire protocol from the client's perspective is meant to look like a
+ * normal OpenAI-realtime-compatible endpoint, so auth travels in the
+ * handshake (x-token header for native clients, or a `x-token.<value>`
+ * Sec-WebSocket-Protocol entry for browsers, which can't set custom headers
+ * on a WebSocket) rather than as an in-band message the way asr/session.ts's
+ * custom envelope protocol does it.
+ */
+export function handleRealtimeVoiceConnection(socket: WebSocket, request: IncomingMessage): void {
+  void run(socket, request);
+}
+
+async function run(socket: WebSocket, request: IncomingMessage): Promise<void> {
+  const token = firstHeader(request.headers["x-token"]) ?? extractTokenFromSubprotocol(request.headers["sec-websocket-protocol"]);
+  if (!token) {
+    socket.close(4001, "missing x-token");
+    return;
+  }
+
+  const url = new URL(request.url ?? "", "http://localhost");
+  const service = url.searchParams.get("calling") === "true" ? "realtime_calling" : "realtime_tts";
+
+  let sessionId: string;
+  let sessionConfig: { idle_timeout_s: number; max_duration_s: number };
+  try {
+    const acquired = await acquireRealtimeVoiceSession({ token, service });
+    sessionId = acquired.session_id;
+    sessionConfig = acquired.config;
+    logger.info("[RealtimeVoice] session acquired", { service });
+  } catch (error) {
+    const status = (error as { status?: number }).status;
+    const message = error instanceof Error ? error.message : "session acquire failed";
+    const code = status === 429 || status === 402 || status === 503 ? 4005 : 4001;
+    trySend(socket, { type: "error", error: { message, code } });
+    socket.close(code, message.slice(0, 120));
+    return;
+  }
+
+  const netaRouter = gatewayConfig.netaRouter;
+  const upstreamUrl = `${netaRouter.baseUrl.replace(/^http/, "ws")}/v1/realtime${url.search}`;
+
+  let upstream: WebSocket;
+  try {
+    upstream = new WebSocket(upstreamUrl, {
+      headers: { Authorization: `Bearer ${netaRouter.apiKey}` },
+    });
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("upstream connect timeout")), UPSTREAM_CONNECT_TIMEOUT_MS);
+      upstream.once("open", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      upstream.once("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+    });
+    logger.info("[RealtimeVoice] upstream connected", { sessionId });
+  } catch (error) {
+    logger.error("[RealtimeVoice] upstream connect failed", { sessionId, error });
+    trySend(socket, { type: "error", error: { message: "upstream connection failed", code: 4006 } });
+    socket.close(4006, "upstream connection failed");
+    await releaseRealtimeVoiceSession(sessionId);
+    return;
+  }
+
+  let closed = false;
+  let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  let maxDurationTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const cleanup = async () => {
+    if (closed) return;
+    closed = true;
+    if (heartbeatTimer) clearInterval(heartbeatTimer);
+    if (maxDurationTimer) clearTimeout(maxDurationTimer);
+    if (upstream.readyState === WebSocket.OPEN) upstream.close();
+    if (socket.readyState === WebSocket.OPEN) socket.close();
+    await releaseRealtimeVoiceSession(sessionId).catch((error) => {
+      logger.warn("[RealtimeVoice] session release failed", { sessionId, error });
+    });
+  };
+
+  socket.on("message", (data, isBinary) => {
+    if (upstream.readyState === WebSocket.OPEN) upstream.send(data, { binary: isBinary });
+  });
+  upstream.on("message", (data, isBinary) => {
+    if (socket.readyState === WebSocket.OPEN) socket.send(data, { binary: isBinary });
+  });
+  socket.on("close", () => void cleanup());
+  socket.on("error", (error) => {
+    logger.warn("[RealtimeVoice] client error", { sessionId, error });
+    void cleanup();
+  });
+  upstream.on("close", () => void cleanup());
+  upstream.on("error", (error) => {
+    logger.warn("[RealtimeVoice] upstream error", { sessionId, error });
+    void cleanup();
+  });
+
+  const doHeartbeat = async () => {
+    try {
+      const result = await heartbeatRealtimeVoiceSession(sessionId);
+      if (result.billing?.allowed === false) {
+        logger.info("[RealtimeVoice] billing denied, closing session", { sessionId, reason: result.billing.reason });
+        trySend(socket, { type: "error", error: { type: "billing_exhausted", message: result.billing.reason ?? "余额不足，会话结束" } });
+        await cleanup();
+      }
+    } catch (error) {
+      logger.error("[RealtimeVoice] heartbeat failed, closing session", { sessionId, error });
+      await cleanup();
+    }
+  };
+  void doHeartbeat();
+  heartbeatTimer = setInterval(() => void doHeartbeat(), HEARTBEAT_INTERVAL_MS);
+
+  // Backend session TTL is authoritative; this just avoids waiting up to
+  // HEARTBEAT_INTERVAL_MS after expiry for the next heartbeat to notice.
+  maxDurationTimer = setTimeout(() => {
+    logger.info("[RealtimeVoice] max duration reached, closing session", { sessionId });
+    trySend(socket, { type: "error", error: { type: "max_duration_reached", message: "会话已达最长时长，连接关闭" } });
+    void cleanup();
+  }, sessionConfig.max_duration_s * 1000);
+}
+
+function trySend(socket: WebSocket, payload: unknown): void {
+  if (socket.readyState !== WebSocket.OPEN) return;
+  try {
+    socket.send(JSON.stringify(payload));
+  } catch (error) {
+    logger.warn("[RealtimeVoice] failed to send error frame", { error });
+  }
+}
+
+function firstHeader(value: string | string[] | undefined): string | undefined {
+  const header = Array.isArray(value) ? value[0] : value;
+  const trimmed = header?.trim();
+  return trimmed || undefined;
+}
+
+function extractTokenFromSubprotocol(value: string | string[] | undefined): string | undefined {
+  const raw = Array.isArray(value) ? value.join(",") : value;
+  if (!raw) return undefined;
+  for (const part of raw.split(",")) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith("x-token.")) return trimmed.slice("x-token.".length);
+  }
+  return undefined;
+}

--- a/packages/billing/src/constants.ts
+++ b/packages/billing/src/constants.ts
@@ -2,6 +2,21 @@ export const COHUB_BILLING_POLICY = {
   hardNegativeLimitUsd: -1,
   minimumBalanceUsdByUsageKind: {
     "generation.video": 0.6,
+    // TODO(product/finance): placeholder threshold, not yet priced by product.
+    "realtime.voice": 0.1,
   },
-  failClosedUsageKinds: ["generation.video"],
+  failClosedUsageKinds: ["generation.video", "realtime.voice"],
+} as const;
+
+/**
+ * Per-heartbeat charge for realtime voice sessions (see apps/api's
+ * internal/realtime-voice route). Realtime voice has no natural per-task
+ * cost the way generation does, so it's billed as wall-clock connected time
+ * at a flat rate rather than off provider-reported usage.
+ *
+ * TODO(product/finance): usdPerMinute is a placeholder, not a priced rate.
+ */
+export const REALTIME_VOICE_BILLING = {
+  usdPerMinute: 0.06,
+  heartbeatIntervalSeconds: 30,
 } as const;

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -63,7 +63,7 @@ export {
   COHUB_BILLING_TOKEN_TYPES,
   COHUB_BILLING_USAGE_TYPES,
 } from "./interfaces.js";
-export { COHUB_BILLING_POLICY } from "./constants.js";
+export { COHUB_BILLING_POLICY, REALTIME_VOICE_BILLING } from "./constants.js";
 export {
   createBillingConversionIntent,
   createFeatureGateConversionIntent,

--- a/packages/billing/src/interfaces.ts
+++ b/packages/billing/src/interfaces.ts
@@ -65,6 +65,7 @@ export const COHUB_BILLING_USAGE_TYPES = {
   sandboxCompute: "sandbox.compute",
   spaceStorage: "space.storage",
   workConsumption: "work.consumption",
+  realtimeVoice: "realtime.voice",
 } as const;
 
 export const COHUB_BILLING_BENEFITS = {

--- a/packages/billing/src/usage-gate.ts
+++ b/packages/billing/src/usage-gate.ts
@@ -11,6 +11,7 @@ export type BillingUsageKind =
   | "generation.video"
   | "generation.music"
   | "sandbox.compute"
+  | "realtime.voice"
   | (string & {});
 
 export type BillingUsageSource =

--- a/packages/sdk/src/environment.ts
+++ b/packages/sdk/src/environment.ts
@@ -5,13 +5,18 @@ export const COHUB_ENVIRONMENTS = {
     apiBaseUrl: "https://api.cohub.run",
     websocketUrl: "wss://gateway.cohub.run/ws",
     voiceInputWebsocketUrl: "wss://gateway.cohub.run/asr/ws",
+    realtimeVoiceWebsocketUrl: "wss://gateway.cohub.run/v1/realtime",
   },
   dev: {
     apiBaseUrl: "https://api-dev.cohub.run",
     websocketUrl: "wss://gateway-dev.cohub.run/ws",
     voiceInputWebsocketUrl: "wss://gateway-dev.cohub.run/asr/ws",
+    realtimeVoiceWebsocketUrl: "wss://gateway-dev.cohub.run/v1/realtime",
   },
-} as const satisfies Record<CohubEnvironment, { apiBaseUrl: string; websocketUrl: string; voiceInputWebsocketUrl: string }>;
+} as const satisfies Record<
+  CohubEnvironment,
+  { apiBaseUrl: string; websocketUrl: string; voiceInputWebsocketUrl: string; realtimeVoiceWebsocketUrl: string }
+>;
 
 const readRuntimeEnv = (): string | undefined => {
   const runtime = globalThis as typeof globalThis & {
@@ -45,6 +50,9 @@ export const normalizeWebsocketUrl = (input: string) => normalizeWebsocketPath(i
 export const normalizeVoiceInputWebsocketUrl = (input: string) =>
   normalizeWebsocketPath(input, "/asr/ws", ["/ws"]);
 
+export const normalizeRealtimeVoiceWebsocketUrl = (input: string) =>
+  normalizeWebsocketPath(input, "/v1/realtime", ["/ws", "/asr/ws"]);
+
 export const resolveApiBaseUrl = (options: {
   baseUrl?: string;
   env?: CohubEnvironment;
@@ -67,4 +75,12 @@ export const resolveVoiceInputWebsocketUrl = (options: {
 } = {}) => {
   if (options.url) return normalizeVoiceInputWebsocketUrl(options.url);
   return COHUB_ENVIRONMENTS[resolveCohubEnvironment(options.env)].voiceInputWebsocketUrl;
+};
+
+export const resolveRealtimeVoiceWebsocketUrl = (options: {
+  url?: string;
+  env?: CohubEnvironment;
+} = {}) => {
+  if (options.url) return normalizeRealtimeVoiceWebsocketUrl(options.url);
+  return COHUB_ENVIRONMENTS[resolveCohubEnvironment(options.env)].realtimeVoiceWebsocketUrl;
 };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,6 +3,7 @@ export { BillingApi } from "./apis/billing.js";
 export { CohubClient, createCohubClient } from "./client.js";
 export { WebsocketClient, createWebsocketClient } from "./websocket.js";
 export { VoiceApi, VoiceInputClient, createVoiceInputClient } from "./voice-input.js";
+export { RealtimeVoiceClient, createRealtimeVoiceClient } from "./realtime-voice.js";
 export { UsersApi } from "./apis/users.js";
 export { WorksApi } from "./apis/works.js";
 export { UiCommandsApi } from "./apis/ui-commands.js";
@@ -84,10 +85,12 @@ export type { RawHttpResponse } from "./transport.js";
 export {
   COHUB_ENVIRONMENTS,
   normalizeBaseUrl,
+  normalizeRealtimeVoiceWebsocketUrl,
   normalizeVoiceInputWebsocketUrl,
   normalizeWebsocketUrl,
   resolveApiBaseUrl,
   resolveCohubEnvironment,
+  resolveRealtimeVoiceWebsocketUrl,
   resolveVoiceInputWebsocketUrl,
   resolveWebsocketUrl,
 } from "./environment.js";
@@ -99,6 +102,11 @@ export type {
   VoiceInputCreateOptions,
   VoiceInputEvent,
 } from "./voice-input.js";
+export type {
+  RealtimeVoiceCallbacks,
+  RealtimeVoiceClientOptions,
+  RealtimeVoiceEvent,
+} from "./realtime-voice.js";
 export type {
   SessionPatchApplyInput,
   SessionPatchApplyResult,

--- a/packages/sdk/src/realtime-voice.ts
+++ b/packages/sdk/src/realtime-voice.ts
@@ -1,0 +1,153 @@
+import type { CohubEnvironment } from "./environment.js";
+import { resolveRealtimeVoiceWebsocketUrl } from "./environment.js";
+
+export type RealtimeVoiceEvent = Record<string, unknown> & { type: string };
+
+export type RealtimeVoiceCallbacks = {
+  onEvent?: (event: RealtimeVoiceEvent) => void;
+  onError?: (message: string) => void;
+  onClose?: (code: number, reason: string) => void;
+};
+
+export type RealtimeVoiceClientOptions = {
+  env?: CohubEnvironment;
+  url?: string;
+  /** Opens a full-duplex calling session instead of the default TTS-only session (see cohub's apps/gateway realtime-voice route). */
+  calling?: boolean;
+  getAccessToken?: (options?: { forceRefresh?: boolean }) => Promise<string | null> | string | null;
+  WebSocketImpl?: WebSocketConstructor;
+  connectionTimeoutMs?: number;
+  callbacks?: RealtimeVoiceCallbacks;
+};
+
+export type WebSocketLike = {
+  readonly readyState: number;
+  onopen: ((event: Event) => void) | null;
+  onmessage: ((event: MessageEvent) => void) | null;
+  onerror: ((event: Event) => void) | null;
+  onclose: ((event: CloseEvent) => void) | null;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+};
+
+export type WebSocketConstructor = new (url: string, protocols?: string | string[]) => WebSocketLike;
+
+const DEFAULT_CONNECTION_TIMEOUT_MS = 10_000;
+const WEBSOCKET_OPEN = 1;
+
+const getDefaultWebSocket = (): WebSocketConstructor => {
+  const WebSocketImpl = globalThis.WebSocket;
+  if (!WebSocketImpl) throw new Error("WebSocket is not available in this environment");
+  return WebSocketImpl as unknown as WebSocketConstructor;
+};
+
+const extractErrorMessage = (event: RealtimeVoiceEvent): string => {
+  const error = event.error as { message?: unknown } | undefined;
+  return typeof error?.message === "string" ? error.message : "Realtime voice error";
+};
+
+/**
+ * Thin client for cohub's realtime voice gateway (apps/gateway's
+ * /v1/realtime, relayed through neta-router to new-api). This class does not
+ * interpret, validate, or transform events -- it only handles connection
+ * setup and framing. Speak the OpenAI Realtime API event protocol directly
+ * via `send`/`onEvent`.
+ *
+ * Auth travels in the WebSocket handshake as a `x-token.<value>`
+ * Sec-WebSocket-Protocol entry, not an in-band message (unlike
+ * VoiceInputClient's ASR protocol) -- the native WebSocket API can't set
+ * custom headers but can set subprotocols, and keeping auth out of the
+ * message stream keeps the wire protocol a plain OpenAI-Realtime-compatible
+ * connection so standard realtime client tooling can be layered on top
+ * unmodified.
+ */
+export class RealtimeVoiceClient {
+  private readonly baseUrl: string;
+  private readonly calling: boolean;
+  private readonly getAccessToken?: RealtimeVoiceClientOptions["getAccessToken"];
+  private readonly WebSocketImpl: WebSocketConstructor;
+  private readonly connectionTimeoutMs: number;
+  private readonly callbacks: RealtimeVoiceCallbacks;
+
+  private socket: WebSocketLike | null = null;
+
+  constructor(options: RealtimeVoiceClientOptions = {}) {
+    this.baseUrl = resolveRealtimeVoiceWebsocketUrl({ env: options.env, url: options.url });
+    this.calling = options.calling ?? false;
+    this.getAccessToken = options.getAccessToken;
+    this.WebSocketImpl = options.WebSocketImpl ?? getDefaultWebSocket();
+    this.connectionTimeoutMs = options.connectionTimeoutMs ?? DEFAULT_CONNECTION_TIMEOUT_MS;
+    this.callbacks = options.callbacks ?? {};
+  }
+
+  get readyState(): number {
+    return this.socket?.readyState ?? -1;
+  }
+
+  async connect(): Promise<void> {
+    if (this.socket?.readyState === WEBSOCKET_OPEN) return;
+
+    const token = await this.getAccessToken?.();
+    if (!token) throw new Error("Sign in to use realtime voice");
+
+    const url = this.calling ? `${this.baseUrl}?calling=true` : this.baseUrl;
+    const socket = new this.WebSocketImpl(url, [`x-token.${token}`]);
+    this.socket = socket;
+
+    await this.withConnectionTimeout(
+      new Promise<void>((resolve, reject) => {
+        socket.onopen = () => resolve();
+        socket.onerror = () => reject(new Error("Realtime voice connection failed"));
+      }),
+    );
+
+    socket.onmessage = (event) => this.handleMessage(event);
+    socket.onerror = () => this.callbacks.onError?.("Realtime voice connection error");
+    socket.onclose = (event) => {
+      if (this.socket === socket) this.socket = null;
+      this.callbacks.onClose?.(event.code, event.reason);
+    };
+  }
+
+  /** Sends a raw OpenAI Realtime API event (e.g. session.update, input_audio_buffer.append, response.create). */
+  send(event: RealtimeVoiceEvent): void {
+    if (this.socket?.readyState !== WEBSOCKET_OPEN) throw new Error("Realtime voice connection is not open");
+    this.socket.send(JSON.stringify(event));
+  }
+
+  close(code?: number, reason?: string): void {
+    this.socket?.close(code, reason);
+    this.socket = null;
+  }
+
+  private handleMessage(event: MessageEvent): void {
+    let data: RealtimeVoiceEvent;
+    try {
+      data = JSON.parse(String(event.data)) as RealtimeVoiceEvent;
+    } catch {
+      this.callbacks.onError?.("Realtime voice service sent invalid data");
+      return;
+    }
+    if (data.type === "error") this.callbacks.onError?.(extractErrorMessage(data));
+    this.callbacks.onEvent?.(data);
+  }
+
+  private async withConnectionTimeout<T>(promise: Promise<T>): Promise<T> {
+    let timeout: ReturnType<typeof globalThis.setTimeout> | null = null;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<never>((_, reject) => {
+          timeout = globalThis.setTimeout(
+            () => reject(new Error("Realtime voice connection timed out")),
+            this.connectionTimeoutMs,
+          );
+        }),
+      ]);
+    } finally {
+      if (timeout) globalThis.clearTimeout(timeout);
+    }
+  }
+}
+
+export const createRealtimeVoiceClient = (options?: RealtimeVoiceClientOptions) => new RealtimeVoiceClient(options);

--- a/scripts/typecheck-staged.mjs
+++ b/scripts/typecheck-staged.mjs
@@ -108,7 +108,10 @@ async function run(pnpmArgs) {
   const command = npmExecPath ? process.execPath : "pnpm";
   const args = npmExecPath ? [npmExecPath, ...fullArgs] : fullArgs;
   return new Promise((resolve) => {
-    const child = spawn(command, args, { stdio: "inherit" });
+    // Windows: child_process.spawn only resolves .cmd/.bat shims (like pnpm's)
+  // through a shell; without it this fails with ENOENT even though `pnpm` is
+  // on PATH.
+  const child = spawn(command, args, { stdio: "inherit", shell: process.platform === "win32" });
     child.once("error", (error) => {
       console.error(`typecheck: failed to spawn pnpm: ${error.message}`);
       resolve(1);


### PR DESCRIPTION
## Summary

Adds `realtime.voice` as a billing usage kind (`packages/billing`), the internal API `apps/api` exposes for it, and the `apps/gateway` WebSocket endpoint that actually terminates the end user's realtime voice connection and calls that API. See the matching neta-router PR (https://git.talesofai.com/talesofai/neta-router/pulls/198), which is now a thin authenticated relay from neta-router to new-api -- cohub'''s gateway is the caller, not a browser.

## Background

Realtime voice (OpenAI/Qwen realtime WebSocket) is scoped to cohub/neta-studio, not the talesofai app -- so it bills against cohub'''s own ledger (the same one generation and LLM completions already use), not the app'''s AP account. It also goes through cohub'''s existing WebSocket-terminating layer (`apps/gateway`, same as the existing ASR voice-input feature) rather than having the browser connect to neta-router directly -- this PR went through one revision to get that topology right (see commit history: the first commit put the relay in neta-router with cohub only as a side-channel billing call, which isn'''t what "route it through cohub" meant).

## What changed

- `packages/billing`: `realtime.voice` added to `COHUB_BILLING_USAGE_TYPES`/`BillingUsageKind`; fail-closed + a placeholder minimum balance in `COHUB_BILLING_POLICY`; new `REALTIME_VOICE_BILLING` (usdPerMinute, heartbeatIntervalSeconds). Realtime voice has no natural per-task cost the way generation does (it'''s a continuous connection, not a discrete job), so it'''s billed as wall-clock connected time at a flat per-heartbeat rate rather than off provider-reported usage. **`usdPerMinute` is a placeholder -- needs real pricing input from product/finance before this ships to real users.**
- `apps/api/src/realtime-voice-tickets.ts`: HMAC-signed session ids, same construction as the existing work-room-ticket helper (`work-realtime-rooms.ts`). Keeps acquire/heartbeat/release stateless -- no new DB table.
- `apps/api/src/routes/internal/realtime-voice.route.ts`: `session/acquire` runs `createBillingUsageGate()` and returns a ticket; `session/heartbeat` re-evaluates the gate and records one tick'''s usage via `recordUsage()` with a per-tick idempotency key; `session/:id` (DELETE) just logs. Auth matches every other `internal/*` route: `ensureInternalRequest()` (`x-worker-secret`) for the calling service, `getOptionalAuth()` for the end user (their own forwarded `Authorization: Bearer`).
- `apps/gateway/src/realtime-voice/session.ts`: terminates the actual end-user WebSocket (token via handshake -- `x-token` header or a `x-token.<value>` subprotocol entry for browsers, not an in-band auth message, so the wire protocol stays a plain OpenAI-realtime-compatible connection), calls `apps/api` to acquire/heartbeat/release the billed session, and relays raw bytes to neta-router'''s `/v1/realtime`.
- `apps/gateway/src/api-client.ts`, `config.ts`: the three internal calls, and `netaRouter.baseUrl`/`apiKey` (reuses the `GENERATION_BASE_URL`/`GENERATION_API_KEY` env vars already used for generation-sdk calls -- same business key, same trust boundary).
- `apps/gateway/src/index.ts`: registers `/v1/realtime` on the existing raw-`WebSocketServer` upgrade dispatcher (same mechanism as `/asr/ws`).
- `scripts/typecheck-staged.mjs`: unrelated drive-by fix (own commit) -- `child_process.spawn()` doesn'''t resolve pnpm'''s `.cmd` shim on Windows without a shell, which was failing the pre-commit hook for every commit on this dev machine.

## Verification

- `pnpm --filter @cohub/billing typecheck`, `pnpm --filter @cohub/api typecheck`, `pnpm --filter @cohub/gateway typecheck` all pass clean (also passed as part of the pre-commit hook).
- Not yet exercised end to end against a running neta-router -- no integration/e2e test for the new route yet.

## Open questions for review

1. `REALTIME_VOICE_BILLING.usdPerMinute` and `COHUB_BILLING_POLICY.minimumBalanceUsdByUsageKind["realtime.voice"]` are placeholders (0.06, 0.1) -- need real numbers.
2. `IDLE_TIMEOUT_S`/`MAX_DURATION_S` (60s / 30min, in the `apps/api` route) are also guesses at reasonable session bounds, not confirmed product requirements.
3. Heartbeat billing-gate failures currently fail closed (session denied) rather than allowing a grace period -- worth confirming that'''s the right tradeoff for a live voice call versus a queued generation task.
4. No browser-side client helper yet (nothing in `packages/sdk`/`@neta-art/cohub` mirroring `voice-input.ts` for this) -- a consumer would have to hand-roll the WebSocket handshake today.
