### PR TITLE
[codex] Schedule recurring Space commands

### DIFF
--- a/.changeset/fresh-commands-repeat.md
+++ b/.changeset/fresh-commands-repeat.md
@@ -1,0 +1,6 @@
+---
+"@neta-art/cohub": minor
+"@neta-art/cohub-cli": minor
+---
+
+Allow Space commands to run on a recurring cron schedule through the SDK and CLI.

--- a/apps/api/src/lib/repeat-schedule.test.ts
+++ b/apps/api/src/lib/repeat-schedule.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { validateRepeatSchedule } from "./repeat-schedule.js";
+
+test("repeat schedules normalize whitespace and return the next run", () => {
+  const result = validateRepeatSchedule({
+    cronExpression: "  */5  * * * *  ",
+    timezone: "UTC",
+  });
+  assert.equal(result.cronExpression, "*/5 * * * *");
+  assert.equal(result.timezone, "UTC");
+  assert.ok(result.nextRun instanceof Date);
+});
+
+test("repeat schedules accept the minimum one-minute interval", () => {
+  assert.doesNotThrow(() =>
+    validateRepeatSchedule({
+      cronExpression: "* * * * *",
+      timezone: "UTC",
+    }),
+  );
+});
+
+test("repeat schedules reject invalid timezones", () => {
+  assert.throws(
+    () =>
+      validateRepeatSchedule({
+        cronExpression: "0 * * * *",
+        timezone: "Mars/Olympus",
+      }),
+    /IANA timezone/,
+  );
+});

--- a/apps/api/src/lib/repeat-schedule.ts
+++ b/apps/api/src/lib/repeat-schedule.ts
@@ -1,0 +1,29 @@
+import * as cronParser from "cron-parser";
+
+const { CronExpressionParser } = cronParser;
+
+export function validateRepeatSchedule(input: {
+  cronExpression: string;
+  timezone: string;
+}): { cronExpression: string; timezone: string; nextRun: Date } {
+  const fields = input.cronExpression.trim().split(/\s+/);
+  const cronExpression = fields.join(" ");
+  const timezone = input.timezone.trim();
+  if (fields.length !== 5) {
+    throw new Error("cronExpression must have 5 fields, e.g. 0 9 * * *");
+  }
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(new Date());
+  } catch {
+    throw new Error(
+      "timezone must be an IANA timezone, e.g. Asia/Shanghai or UTC",
+    );
+  }
+  const interval = CronExpressionParser.parse(cronExpression, { tz: timezone });
+  const nextRun = interval.next().toDate();
+  const secondRun = interval.next().toDate();
+  if (secondRun.getTime() - nextRun.getTime() < 60_000) {
+    throw new Error("cron interval must be at least 1 minute");
+  }
+  return { cronExpression, timezone, nextRun };
+}

--- a/apps/api/src/lib/space-command-request.test.ts
+++ b/apps/api/src/lib/space-command-request.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  MAX_SPACE_COMMAND_LENGTH,
+  parseSpaceCommandRequest,
+} from "./space-command-request.js";
+
+test("space command requests default to immediate execution", () => {
+  assert.deepEqual(parseSpaceCommandRequest({ command: "  git status  " }), {
+    mode: "immediate",
+    command: "git status",
+  });
+});
+
+test("space command requests parse recurring execution", () => {
+  const request = parseSpaceCommandRequest({
+    command: "./reconcile.sh",
+    title: "  bot-agent reconcile  ",
+    schedule: {
+      mode: "repeat",
+      cronExpression: "  */5 * * * * ",
+      timezone: "UTC",
+    },
+  });
+
+  assert.equal(request.mode, "repeat");
+  if (request.mode !== "repeat") assert.fail("expected repeat request");
+  assert.equal(request.title, "bot-agent reconcile");
+  assert.equal(request.cronExpression, "*/5 * * * *");
+  assert.ok(request.nextRun instanceof Date);
+});
+
+test("space command requests reject malformed schedules and oversized commands", () => {
+  assert.throws(
+    () => parseSpaceCommandRequest({ command: "pwd", schedule: "repeat" }),
+    /schedule must be an object/,
+  );
+  assert.throws(
+    () =>
+      parseSpaceCommandRequest({
+        command: "pwd",
+        schedule: { mode: "repeat", cronExpression: 5, timezone: "UTC" },
+      }),
+    /cronExpression is required/,
+  );
+  assert.throws(
+    () => parseSpaceCommandRequest({ command: "x".repeat(MAX_SPACE_COMMAND_LENGTH + 1) }),
+    /command is too long/,
+  );
+});

--- a/apps/api/src/lib/space-command-request.ts
+++ b/apps/api/src/lib/space-command-request.ts
@@ -1,0 +1,68 @@
+import { validateRepeatSchedule } from "./repeat-schedule.js";
+
+export const MAX_SPACE_COMMAND_LENGTH = 16 * 1024;
+
+export type ParsedSpaceCommandRequest =
+  | {
+      mode: "immediate";
+      command: string;
+    }
+  | {
+      mode: "repeat";
+      command: string;
+      title: string;
+      cronExpression: string;
+      timezone: string;
+      nextRun: Date;
+    };
+
+export function parseSpaceCommandRequest(
+  input: unknown,
+): ParsedSpaceCommandRequest {
+  if (!isRecord(input)) throw new Error("invalid json body");
+
+  const command = typeof input.command === "string" ? input.command.trim() : "";
+  if (!command) throw new Error("command is required");
+  if (command.length > MAX_SPACE_COMMAND_LENGTH) {
+    throw new Error(
+      `command is too long; max ${MAX_SPACE_COMMAND_LENGTH} characters`,
+    );
+  }
+
+  if (input.schedule === undefined) return { mode: "immediate", command };
+  if (!isRecord(input.schedule)) throw new Error("schedule must be an object");
+
+  const mode = input.schedule.mode ?? "immediate";
+  if (mode === "immediate") return { mode, command };
+  if (mode !== "repeat") {
+    throw new Error("schedule.mode must be one of: immediate, repeat");
+  }
+
+  const cronExpression = input.schedule.cronExpression;
+  const timezone = input.schedule.timezone;
+  if (typeof cronExpression !== "string" || !cronExpression.trim()) {
+    throw new Error("cronExpression is required, e.g. */5 * * * *");
+  }
+  if (typeof timezone !== "string" || !timezone.trim()) {
+    throw new Error("timezone is required, e.g. Asia/Shanghai");
+  }
+
+  const title = input.title === undefined
+    ? "scheduled command"
+    : requireTitle(input.title);
+  const schedule = validateRepeatSchedule({ cronExpression, timezone });
+  return { mode, command, title, ...schedule };
+}
+
+function requireTitle(value: unknown): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error("title must be a non-empty string");
+  }
+  const title = value.trim();
+  if (title.length > 255) throw new Error("title must be at most 255 characters");
+  return title;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}

--- a/apps/api/src/routes/cron-jobs.route.ts
+++ b/apps/api/src/routes/cron-jobs.route.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono";
-import * as cronParser from "cron-parser";
 import { db } from "../db/index.js";
 import { cronJobs, taskRuns } from "@cohub/db";
 import { eq, and, isNull, desc, lt, or } from "drizzle-orm";
@@ -9,9 +8,9 @@ import { hasPermission } from "../permissions.js";
 import { disableCronJob, enableCronJob, removeCronJob, updateCronJob } from "../tasks.js";
 import { fallbackPublicUserProfile, getProfilesByUuids } from "../user-profiles.js";
 import { sanitizeTaskRunPricingForViewer } from "../task-run-privacy.js";
+import { validateRepeatSchedule } from "../lib/repeat-schedule.js";
 
 const router = new Hono();
-const { CronExpressionParser } = cronParser;
 
 const MAX_RUNS_LIMIT = 100;
 
@@ -28,31 +27,6 @@ async function hydrateCronJobUserProfiles<T extends { userUuid: string }>(jobs: 
     ...job,
     userProfile: profiles.get(job.userUuid) ?? fallbackPublicUserProfile(job.userUuid),
   }));
-}
-
-function validateTimezone(timezone: string) {
-  try {
-    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(new Date());
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function validateCronSchedule(input: { cronExpression: string; timezone: string }) {
-  const cronExpression = input.cronExpression.trim();
-  const timezone = input.timezone.trim();
-  if (cronExpression.split(/\s+/).length !== 5) {
-    throw new Error("cronExpression must have 5 fields, e.g. 0 9 * * *");
-  }
-  if (!validateTimezone(timezone)) throw new Error("timezone must be an IANA timezone, e.g. Asia/Shanghai or UTC");
-  const interval = CronExpressionParser.parse(cronExpression, { tz: timezone });
-  const nextRun = interval.next().toDate();
-  const secondRun = interval.next().toDate();
-  if (secondRun.getTime() - nextRun.getTime() < 60_000) {
-    throw new Error("cron interval must be at least 1 minute");
-  }
-  return { cronExpression, timezone };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -259,7 +233,7 @@ router.patch("/:id", async (c) => {
     if (nextCronExpression !== undefined && typeof nextCronExpression !== "string") return c.json({ message: "cronExpression must be a string" }, 400);
     if (nextTimezone !== undefined && typeof nextTimezone !== "string") return c.json({ message: "timezone must be a string" }, 400);
     try {
-      const schedule = validateCronSchedule({
+      const schedule = validateRepeatSchedule({
         cronExpression: nextCronExpression === undefined ? job.cronExpression : nextCronExpression,
         timezone: nextTimezone === undefined ? job.timezone : nextTimezone,
       });

--- a/apps/api/src/routes/spaces/spaces.route.ts
+++ b/apps/api/src/routes/spaces/spaces.route.ts
@@ -9,7 +9,6 @@ import {
   validatePublicIdentifierAssignment,
 } from "@cohub/protocol/public-identifiers";
 import { normalizeGenerationPolicy } from "@cohub/protocol/generation";
-import * as cronParser from "cron-parser";
 import { db } from "../../db/index.js";
 import { getPostgresErrorConstraint, isPostgresUniqueViolation } from "../../db/postgres-error.js";
 import {
@@ -88,6 +87,8 @@ import { parseChannelConfigPatch, mergeChannelConfig, validateChannelModelConfig
 import { redisCommandClient } from "../../redis.js";
 import { featureGateResponse } from "../../lib/feature-gate.js";
 import { billingBlockedResponse } from "../../lib/billing-blocked.js";
+import { validateRepeatSchedule } from "../../lib/repeat-schedule.js";
+import { parseSpaceCommandRequest } from "../../lib/space-command-request.js";
 import { applyRequestSourceToMeta, getRequestSource, resolveSessionSourceFromRequest } from "../../lib/request-source.js";
 import { validatePromptModel } from "../../llm/models.js";
 
@@ -96,7 +97,6 @@ const logger = createLogger({ serviceName: "cohub-api" });
 const getSpaceSaveCheckpointLockKey = (spaceId: string) => `cohub:space:${spaceId}:save-checkpoint`;
 
 const router = new Hono();
-const { CronExpressionParser } = cronParser;
 
 type SpaceRouteSessionRecord = NonNullable<Awaited<ReturnType<typeof getSpaceSessionById>>>;
 
@@ -502,15 +502,6 @@ function promptInputError(error: unknown): string | null {
 
 const isPositiveSafeInteger = (value: number) => Number.isSafeInteger(value) && value > 0;
 
-const validateTimezone = (timezone: string) => {
-  try {
-    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(new Date());
-    return true;
-  } catch {
-    return false;
-  }
-};
-
 const parseScheduledAt = (sendAt: string) => {
   const trimmed = sendAt.trim();
   if (!hasExplicitTimezone(trimmed)) {
@@ -522,22 +513,6 @@ const parseScheduledAt = (sendAt: string) => {
   }
   if (scheduledAt.getTime() <= Date.now()) throw new Error("sendAt must be in the future");
   return scheduledAt;
-};
-
-const validateRepeatSchedule = (input: { cronExpression: string; timezone: string }) => {
-  const cronExpression = input.cronExpression.trim();
-  const timezone = input.timezone.trim();
-  if (cronExpression.split(/\s+/).length !== 5) {
-    throw new Error("cronExpression must have 5 fields, e.g. 0 9 * * *");
-  }
-  if (!validateTimezone(timezone)) throw new Error("timezone must be an IANA timezone, e.g. Asia/Shanghai or UTC");
-  const interval = CronExpressionParser.parse(cronExpression, { tz: timezone });
-  const nextRun = interval.next().toDate();
-  const secondRun = interval.next().toDate();
-  if (secondRun.getTime() - nextRun.getTime() < 60_000) {
-    throw new Error("cron interval must be at least 1 minute");
-  }
-  return { cronExpression, timezone, nextRun };
 };
 
 // ── Provisioning params builder ──────────────────────────────────────────────
@@ -1760,8 +1735,6 @@ router.post("/:id/sandbox/recreate", async (c) => {
   return c.json(result);
 });
 
-const MAX_COMMAND_LENGTH = 16 * 1024;
-
 router.post("/:id/commands", async (c) => {
   const user = useAuth(c);
   if (user instanceof Response) return user;
@@ -1769,26 +1742,56 @@ router.post("/:id/commands", async (c) => {
   if (!requireValidId(spaceId)) return c.json({ message: "space not found" }, 404);
   if (!(await hasPermission(user, "command.execute", { spaceId }))) return authzDenied(c);
 
-  const body = await c.req.json<{ command?: string }>().catch(() => null);
-  const command = body?.command?.trim();
-  if (!command) return c.json({ message: "command is required" }, 400);
-  if (command.length > MAX_COMMAND_LENGTH) return c.json({ message: `command is too long; max ${MAX_COMMAND_LENGTH} characters` }, 400);
+  const body = await c.req.json<unknown>().catch(() => null);
+  let request: ReturnType<typeof parseSpaceCommandRequest>;
+  try {
+    request = parseSpaceCommandRequest(body);
+  } catch (error) {
+    return c.json({
+      message: error instanceof Error ? error.message : "invalid command request",
+    }, 400);
+  }
   const cwd = "/workspace";
   const sourceClientId = getRequestSource(c)?.clientId;
+  const taskData = {
+    command: request.command,
+    cwd,
+    source: request.mode === "repeat" ? "scheduled_command" : "command_palette",
+    ...(sourceClientId ? { sourceClientId } : {}),
+  };
+
+  if (request.mode === "repeat") {
+    if (!(await hasPermission(user, "cronjob.manage", { spaceId }))) {
+      return authzDenied(c);
+    }
+    const cronJob = await createCronJob({
+      userId: user.uuid,
+      title: request.title,
+      taskType: RUN_COMMAND_TASK_TYPE,
+      payload: taskData,
+      schedule: {
+        pattern: request.cronExpression,
+        timezone: request.timezone,
+      },
+      spaceId,
+    });
+
+    return c.json({
+      mode: "repeat",
+      cronJobId: cronJob.id,
+      nextRunAt: request.nextRun.toISOString(),
+      timezone: request.timezone,
+    });
+  }
 
   const { taskRunId } = await enqueueTask({
     type: RUN_COMMAND_TASK_TYPE,
     spaceId,
     userId: user.uuid,
-    data: {
-      command,
-      cwd,
-      source: "command_palette",
-      ...(sourceClientId ? { sourceClientId } : {}),
-    },
+    data: taskData,
   });
 
-  return c.json({ taskRunId });
+  return c.json({ mode: "immediate", taskRunId });
 });
 
 // ── Sessions ─────────────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,4 +1,7 @@
-import type { TaskRunDetailResponse } from "@neta-art/cohub";
+import type {
+  SpaceRunCommandResponse,
+  TaskRunDetailResponse,
+} from "@neta-art/cohub";
 import { createClient } from "../client.js";
 import { error, handleHttp, json as outJson, spinner } from "../output.js";
 
@@ -7,6 +10,8 @@ type RunCliOptions = {
   json: boolean;
   async: boolean;
   command: string;
+  cron: string | null;
+  timezone: string | null;
 };
 
 type RunCommandResult = {
@@ -63,7 +68,7 @@ function parseSpaceId(tokens: string[]): string | undefined {
   return undefined;
 }
 
-function parseRunCliOptions(argv: string[]): RunCliOptions {
+export function parseRunCliOptions(argv: string[]): RunCliOptions {
   const runIndex = topLevelRunIndex(argv);
   if (runIndex < 0) return error("Invalid invocation", "Use `cohub run [options] <command>`");
 
@@ -73,6 +78,8 @@ function parseRunCliOptions(argv: string[]): RunCliOptions {
   let spaceId = parseSpaceId(beforeRun) ?? process.env.COHUB_SPACE_ID?.trim() ?? "";
   let json = beforeRun.includes("--json");
   let async = false;
+  let cron: string | null = null;
+  let timezone: string | null = null;
   let commandOption: string | null = null;
   let positionalTokens: string[] = [];
 
@@ -91,6 +98,27 @@ function parseRunCliOptions(argv: string[]): RunCliOptions {
 
     if (token === "--json") {
       json = true;
+      continue;
+    }
+
+    if (token === "--cron" || token === "--timezone") {
+      const value = afterRun[index + 1]?.trim();
+      if (!value) return error("Missing schedule value", `${token} requires a value`);
+      if (token === "--cron") cron = value;
+      else timezone = value;
+      index += 1;
+      continue;
+    }
+
+    if (token.startsWith("--cron=")) {
+      cron = token.slice("--cron=".length).trim();
+      if (!cron) return error("Missing schedule value", "--cron requires a value");
+      continue;
+    }
+
+    if (token.startsWith("--timezone=")) {
+      timezone = token.slice("--timezone=".length).trim();
+      if (!timezone) return error("Missing schedule value", "--timezone requires a value");
       continue;
     }
 
@@ -137,8 +165,17 @@ function parseRunCliOptions(argv: string[]): RunCliOptions {
   if (!spaceId) {
     return error("Missing required space", "Add -s, --space <id> before `run` or set COHUB_SPACE_ID.");
   }
+  if (cron && !timezone) {
+    return error("Missing timezone", "--timezone is required with --cron");
+  }
+  if (!cron && timezone) {
+    return error("Missing cron expression", "--cron is required with --timezone");
+  }
+  if (cron && async) {
+    return error("Conflicting options", "Scheduled commands are already asynchronous; remove --async.");
+  }
 
-  return { spaceId, json, async, command };
+  return { spaceId, json, async, command, cron, timezone };
 }
 
 function printRunHelp(): void {
@@ -150,12 +187,15 @@ Usage:
 Options:
   -c, --command <command>  Shell command to execute in the space workspace
       --async              Queue the command and return immediately
+      --cron <expression>  Run the command on a recurring 5-field cron schedule
+      --timezone <tz>      IANA timezone required by --cron
       --json               Output as JSON
   -h, --help               Show this help
 
 Examples:
   cohub -s <spaceId> run --command "git status"
   cohub -s <spaceId> run --async --command "pnpm test"
+  cohub -s <spaceId> run --cron "*/5 * * * *" --timezone UTC --command "./reconcile.sh"
   cohub -s <spaceId> run -- git status -sb
 
 Notes:
@@ -237,7 +277,32 @@ async function handleRunCli(argv: string[]): Promise<void> {
   const client = createClient();
 
   try {
-    const { taskRunId } = await client.space(opts.spaceId).runCommand({ command: opts.command });
+    let response: SpaceRunCommandResponse;
+    if (opts.cron && opts.timezone) {
+      response = await client.space(opts.spaceId).runCommand({
+        command: opts.command,
+        title: `scheduled command: ${opts.command.slice(0, 80)}`,
+        schedule: {
+          mode: "repeat",
+          cronExpression: opts.cron,
+          timezone: opts.timezone,
+        },
+      });
+    } else {
+      response = await client.space(opts.spaceId).runCommand({
+        command: opts.command,
+      });
+    }
+
+    if (response.mode === "repeat") {
+      if (opts.json) return outJson(response);
+      process.stderr.write(
+        `  Command scheduled — cronJobId: ${response.cronJobId}, nextRunAt: ${response.nextRunAt}, timezone: ${response.timezone}\n`,
+      );
+      return;
+    }
+
+    const { taskRunId } = response;
 
     if (opts.async) {
       if (opts.json) return outJson({ taskRunId });

--- a/packages/cli/tests/run.test.ts
+++ b/packages/cli/tests/run.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseRunCliOptions } from "../src/commands/run.js";
+
+test("run parses recurring command options", () => {
+  assert.deepEqual(
+    parseRunCliOptions([
+      "-s",
+      "deployment-space",
+      "run",
+      "--cron",
+      "*/5 * * * *",
+      "--timezone",
+      "UTC",
+      "--command",
+      "./reconcile.sh",
+    ]),
+    {
+      spaceId: "deployment-space",
+      json: false,
+      async: false,
+      command: "./reconcile.sh",
+      cron: "*/5 * * * *",
+      timezone: "UTC",
+    },
+  );
+});

--- a/packages/sdk/src/apis/spaces.ts
+++ b/packages/sdk/src/apis/spaces.ts
@@ -1238,7 +1238,40 @@ export class SpaceSandboxApi {
   }
 }
 
-export type SpaceRunCommandResponse = { taskRunId: string };
+export type SpaceRunCommandImmediateInput = {
+  command: string;
+  schedule?: { mode?: "immediate" };
+};
+
+export type SpaceRunCommandRepeatInput = {
+  command: string;
+  title?: string;
+  schedule: {
+    mode: "repeat";
+    cronExpression: string;
+    timezone: string;
+  };
+};
+
+export type SpaceRunCommandInput =
+  | SpaceRunCommandImmediateInput
+  | SpaceRunCommandRepeatInput;
+
+export type SpaceRunCommandImmediateResponse = {
+  mode: "immediate";
+  taskRunId: string;
+};
+
+export type SpaceRunCommandRepeatResponse = {
+  mode: "repeat";
+  cronJobId: string;
+  nextRunAt: string;
+  timezone: string;
+};
+
+export type SpaceRunCommandResponse =
+  | SpaceRunCommandImmediateResponse
+  | SpaceRunCommandRepeatResponse;
 
 export class SpaceLabelsApi {
   constructor(
@@ -2243,7 +2276,14 @@ export class SpaceClient {
     );
   }
 
-  runCommand(input: { command: string }) {
+  runCommand(
+    input: SpaceRunCommandRepeatInput,
+  ): Promise<SpaceRunCommandRepeatResponse>;
+  runCommand(
+    input: SpaceRunCommandImmediateInput,
+  ): Promise<SpaceRunCommandImmediateResponse>;
+  runCommand(input: SpaceRunCommandInput): Promise<SpaceRunCommandResponse>;
+  runCommand(input: SpaceRunCommandInput): Promise<SpaceRunCommandResponse> {
     return this.transport.request<SpaceRunCommandResponse>(
       `/api/spaces/${this.id}/commands`,
       {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -144,6 +144,12 @@ export type {
   SpaceChannelBindingRecord,
   SpaceEventName,
   SpaceTurnListOptions,
+  SpaceRunCommandImmediateInput,
+  SpaceRunCommandImmediateResponse,
+  SpaceRunCommandInput,
+  SpaceRunCommandRepeatInput,
+  SpaceRunCommandRepeatResponse,
+  SpaceRunCommandResponse,
   WebSocketConnectionState,
 } from "./apis/spaces.js";
 export type {

--- a/packages/sdk/tests/space-run-command.test.ts
+++ b/packages/sdk/tests/space-run-command.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { CohubHttpClient } from "../src/http.js";
+import type { Fetch } from "../src/transport.js";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+test("space.runCommand sends immediate commands", async () => {
+  const requests: Array<{ url: string; init?: RequestInit }> = [];
+  const fetch: Fetch = async (input, init) => {
+    requests.push({ url: String(input), init });
+    return jsonResponse({ mode: "immediate", taskRunId: "task-1" });
+  };
+  const space = new CohubHttpClient({
+    baseUrl: "https://api.example.test",
+    fetch,
+  }).space("space-1");
+
+  const response = await space.runCommand({ command: "git status" });
+
+  assert.deepEqual(response, { mode: "immediate", taskRunId: "task-1" });
+  assert.equal(requests[0]?.url, "https://api.example.test/api/spaces/space-1/commands");
+  assert.equal(requests[0]?.init?.method, "POST");
+  assert.deepEqual(JSON.parse(String(requests[0]?.init?.body)), {
+    command: "git status",
+  });
+});
+
+test("space.runCommand sends recurring command schedules", async () => {
+  const requests: Array<{ url: string; init?: RequestInit }> = [];
+  const fetch: Fetch = async (input, init) => {
+    requests.push({ url: String(input), init });
+    return jsonResponse({
+      mode: "repeat",
+      cronJobId: "cron-1",
+      nextRunAt: "2026-08-14T00:05:00.000Z",
+      timezone: "UTC",
+    });
+  };
+  const space = new CohubHttpClient({
+    baseUrl: "https://api.example.test",
+    fetch,
+  }).space("space-1");
+
+  const response = await space.runCommand({
+    command: "./reconcile.sh",
+    title: "bot-agent service reconcile",
+    schedule: {
+      mode: "repeat",
+      cronExpression: "*/5 * * * *",
+      timezone: "UTC",
+    },
+  });
+
+  assert.equal(response.mode, "repeat");
+  assert.deepEqual(JSON.parse(String(requests[0]?.init?.body)), {
+    command: "./reconcile.sh",
+    title: "bot-agent service reconcile",
+    schedule: {
+      mode: "repeat",
+      cronExpression: "*/5 * * * *",
+      timezone: "UTC",
+    },
+  });
+});


### PR DESCRIPTION
## What changed

- extend `POST /api/spaces/:id/commands` with validated recurring cron schedules
- expose discriminated immediate/repeat command types and overloads in the SDK
- add `cohub run --cron ... --timezone ...` for recurring Space commands
- share cron/timezone validation between command scheduling and Cron Job updates
- require both command execution and Cron Job management permissions for recurring commands

## Why

Long-running services in a Space need a Cohub-native reconciliation loop. A recurring `run_command` removes the need for an external Kubernetes CronJob or an unmanaged process supervisor.

## Impact

Existing immediate command calls remain source-compatible and keep their precise SDK return type. Recurring calls return a Cron Job ID and next-run timestamp and can be managed through the existing Cron Job APIs.

## Validation

- `pnpm test`: 1382 tests across 12 workspaces passed
- `pnpm lint`
- `pnpm typecheck` with the documented web public env values
- `pnpm build` with the documented web public env values
