### PR TITLE
fix(agent): compaction context duplication, turn placement and image accounting

### DIFF
--- a/apps/agent/src/runtime/compaction-plan.ts
+++ b/apps/agent/src/runtime/compaction-plan.ts
@@ -21,12 +21,21 @@ export function resolveCompactionScope(
     : { scope: "between_turns", ownerTurnId: null };
 }
 
+/**
+ * Reject compactions whose retained context is not meaningfully smaller than
+ * what would have been sent. Threshold-triggered compactions require at least
+ * a 20% reduction — image-dominated contexts that compaction cannot shrink
+ * would otherwise compact on every round without reducing the payload.
+ * Overflow-recovery (force) compactions only require any reduction.
+ */
 export function validateCompactionEffect(input: {
   estimatedTokensBefore: number;
   estimatedTokensAfter: number;
   inputBudget: number;
+  force?: boolean;
 }): "compaction_no_effect" | "compaction_still_over_budget" | null {
-  if (input.estimatedTokensAfter >= input.estimatedTokensBefore) {
+  const minimumReduction = input.force ? 0 : 0.2;
+  if (input.estimatedTokensAfter >= input.estimatedTokensBefore * (1 - minimumReduction)) {
     return "compaction_no_effect";
   }
   if (input.estimatedTokensAfter >= input.inputBudget) {

--- a/apps/agent/src/runtime/compaction-policy.ts
+++ b/apps/agent/src/runtime/compaction-policy.ts
@@ -12,13 +12,18 @@ const RESERVE_TOKENS_CAP = 32_768;
 const RESERVE_TOKENS_RATIO = 0.25;
 
 // Some provider proxies tokenize inline base64 image payloads as raw text
-// instead of charging vision tokens. Observed ratio on the cohub proxy is
-// ~1.97 chars/token, so one normalized image can bill ~100k tokens while pi's
-// heuristic estimates a flat 1.2k. Without this lower bound the accurate
-// provider usage stays far below the threshold and auto-compaction never runs
-// until the request hard-fails with a context-overflow error.
-const BASE64_CHARS_PER_TOKEN = 2;
+// instead of charging vision tokens (observed ratio on the cohub proxy is
+// ~1.97 chars/token). Accounting for compaction must not follow that billing
+// quirk: images are bounded at ingestion (see image-normalizer: <=1984px
+// webp), so a resized image costs a predictable amount under vision billing.
+// Count every image block as a flat token estimate instead of its raw base64
+// length — same approach as pi (1.2k tokens/image) and codex (~1.8k
+// tokens/image). 1984px is 16 vision tiles ≈ 2.8k tokens.
+export const FLAT_IMAGE_TOKEN_ESTIMATE = 2_800;
 const TEXT_CHARS_PER_TOKEN = 4;
+
+/** Placeholder text replacing image blocks omitted from request/estimate views. */
+export const OMITTED_IMAGE_TEXT = "Image omitted from this LLM request to stay under request size limit.";
 
 /** Resolve reserveTokens for a model context window. */
 export function resolveReserveTokens(contextWindow: number): number {
@@ -37,7 +42,7 @@ function safeBlockLength(block: Record<string, unknown>): number {
 /** Estimate context tokens the way a base64-counting proxy would bill them. */
 export function estimateProxyContextTokens(messages: AgentMessage[]): number {
   let textChars = 0;
-  let base64Chars = 0;
+  let imageTokens = 0;
 
   for (const message of messages) {
     const recordMessage = message as unknown as { content?: unknown; summary?: unknown };
@@ -54,7 +59,7 @@ export function estimateProxyContextTokens(messages: AgentMessage[]): number {
       const record = block as Record<string, unknown>;
       if (record.type === "image") {
         // Data-less image blocks carry no payload to bill.
-        if (typeof record.data === "string") base64Chars += record.data.length;
+        if (typeof record.data === "string") imageTokens += FLAT_IMAGE_TOKEN_ESTIMATE;
         continue;
       }
       if (typeof record.text === "string") {
@@ -69,5 +74,5 @@ export function estimateProxyContextTokens(messages: AgentMessage[]): number {
     }
   }
 
-  return Math.ceil(textChars / TEXT_CHARS_PER_TOKEN) + Math.ceil(base64Chars / BASE64_CHARS_PER_TOKEN);
+  return Math.ceil(textChars / TEXT_CHARS_PER_TOKEN) + imageTokens;
 }

--- a/apps/agent/src/runtime/compaction.ts
+++ b/apps/agent/src/runtime/compaction.ts
@@ -286,7 +286,21 @@ export async function maybeAutoCompact(
         return { compacted: false, reason: invalidEffect };
       }
 
-      // ── 2. Session file: append compaction entry, archive, rewrite ──
+      // ── 2. Resolve turn placement before mutating the session file ──
+      // Must run before archiveAndRewrite: for in-turn cuts the current turn's
+      // user message (the only branch entry carrying meta.turnId — assistant
+      // entries never do) sits before the cut and is removed by the rewrite.
+      // Resolving afterwards leaves no entry with a turnId to resolve from,
+      // silently degrading in-turn compactions to "between_turns" and
+      // appending the compact turn at the end of the timeline.
+      const firstKeptTurnStartEntryId = handle.sessionManager.findTurnStartEntryId(firstKeptEntryId);
+      const firstKeptTurnId =
+        (firstKeptTurnStartEntryId
+          ? handle.sessionManager.getEntryTurnId(firstKeptTurnStartEntryId)
+          : null) ?? handle.sessionManager.getFirstKeptTurnId(firstKeptEntryId);
+      const { scope, ownerTurnId } = resolveCompactionScope(preparation, firstKeptTurnId);
+
+      // ── 3. Session file: append compaction entry, archive, rewrite ──
       const compactionEntryId = handle.sessionManager.appendCompaction(
         result.summary,
         firstKeptEntryId,
@@ -312,21 +326,14 @@ export async function maybeAutoCompact(
       }
       archivePathForRecovery = archivePath;
 
-      // ── 3. Rebuild agent state ──
+      // ── 4. Rebuild agent state ──
       const sessionContext = handle.sessionManager.buildSessionContext();
       handle.session.agent.state.messages = sessionContext.messages;
       await refreshSessionHandleFileSignature(handle);
 
       span.setAttribute("agent.compaction.archive_path", archivePath);
 
-      // ── 4. Resolve whether the cut is between turns or inside its containing turn ──
-      const firstKeptTurnStartEntryId = handle.sessionManager.findTurnStartEntryId(firstKeptEntryId);
-      const firstKeptTurnId =
-        (firstKeptTurnStartEntryId
-          ? handle.sessionManager.getEntryTurnId(firstKeptTurnStartEntryId)
-          : null) ?? handle.sessionManager.getFirstKeptTurnId(firstKeptEntryId);
-      const { scope, ownerTurnId } = resolveCompactionScope(preparation, firstKeptTurnId);
-
+      // ── 5. Resolve DB sequence for the compact turn ──
       let insertBeforeTurnSequence: number | null = null;
       if (scope === "between_turns") {
         if (firstKeptTurnId) {
@@ -344,7 +351,7 @@ export async function maybeAutoCompact(
         }
       }
 
-      // ── 5. DB persistence ──
+      // ── 6. DB persistence ──
       const toolContext = getCurrentToolExecutionContext();
       const dbResult = await persistCompactionEvent({
         spaceId: handle.spaceId,

--- a/apps/agent/src/runtime/compaction.ts
+++ b/apps/agent/src/runtime/compaction.ts
@@ -277,6 +277,7 @@ export async function maybeAutoCompact(
         estimatedTokensBefore: Math.max(thresholdTokens, result.tokensBefore),
         estimatedTokensAfter,
         inputBudget: Math.max(1, contextWindow - settings.reserveTokens),
+        force,
       });
       if (invalidEffect) {
         span.setAttribute("agent.compaction.error", invalidEffect);

--- a/apps/agent/src/runtime/local-session-manager.ts
+++ b/apps/agent/src/runtime/local-session-manager.ts
@@ -479,9 +479,15 @@ export class SessionManager {
           if (foundFirstKept) appendMessage(entry);
         }
       }
-      for (let i = compactionIdx + 1; i < branch.length; i++) {
-        const entry = branch[i];
-        if (entry) appendMessage(entry);
+      if (compactionIdx > 0) {
+        // Post-compaction entries only in pre-rewrite layouts. When the
+        // compaction entry is the root, the post-rewrite loop above already
+        // appended every kept entry once — appending again would duplicate
+        // the entire context in every request.
+        for (let i = compactionIdx + 1; i < branch.length; i++) {
+          const entry = branch[i];
+          if (entry) appendMessage(entry);
+        }
       }
     } else {
       for (const entry of branch) appendMessage(entry);

--- a/apps/agent/src/runtime/session-runtime.ts
+++ b/apps/agent/src/runtime/session-runtime.ts
@@ -16,6 +16,7 @@ import { mergeHeaders } from "@cohub/infra/config-runtime/models";
 import type { ImageToTextConfig } from "@cohub/infra/config-runtime/image-to-text";
 import { ModelUnavailableError } from "@cohub/core/sessions";
 import { prepareAgentImagesForModel } from "./image-to-text.js";
+import { OMITTED_IMAGE_TEXT } from "./compaction-policy.js";
 import type { SpaceModListItem } from "@cohub/core/space-mods";
 
 export type CohubAgentSessionEvent = AgentEvent;
@@ -48,7 +49,6 @@ type ToolLike = AgentTool;
 const AGENT_RETRY_MAX_RETRIES = 2;
 const AGENT_RETRY_BASE_DELAY_MS = 1000;
 const LLM_REQUEST_MAX_BYTES = 30 * 1024 * 1024;
-const LLM_REQUEST_IMAGE_OMISSION_TEXT = "Image omitted from this LLM request to stay under request size limit.";
 
 const COMPACTION_SUMMARY_PREFIX = "The conversation history before this point was compacted into the following summary:\n\n<summary>\n";
 const COMPACTION_SUMMARY_SUFFIX = "\n</summary>";
@@ -317,7 +317,7 @@ function applyLlmRequestSizeGuard(messages: unknown[]) {
     omittedImages += 1;
     omittedBytes += image.bytes;
     image.block.type = "text" as never;
-    image.block.text = LLM_REQUEST_IMAGE_OMISSION_TEXT;
+    image.block.text = OMITTED_IMAGE_TEXT;
     delete (image.block as Partial<typeof image.block>).data;
     delete (image.block as Partial<typeof image.block>).mimeType;
     estimatedBytes = estimateLlmPayloadBytes(messages);

--- a/apps/agent/src/tests/compaction-plan.test.ts
+++ b/apps/agent/src/tests/compaction-plan.test.ts
@@ -72,14 +72,40 @@ test("compaction effect must reduce context and fit the next input budget", () =
     estimatedTokensAfter: 100,
     inputBudget: 90,
   }), "compaction_no_effect");
+  // Threshold compactions need a meaningful reduction (>=20%); marginal
+  // shrinks are rejected so image-dominated contexts don't re-compact on
+  // every round without reducing the actual payload.
   assert.equal(validateCompactionEffect({
     estimatedTokensBefore: 100,
     estimatedTokensAfter: 95,
     inputBudget: 90,
+  }), "compaction_no_effect");
+  assert.equal(validateCompactionEffect({
+    estimatedTokensBefore: 100,
+    estimatedTokensAfter: 81,
+    inputBudget: 90,
+  }), "compaction_no_effect");
+  assert.equal(validateCompactionEffect({
+    estimatedTokensBefore: 100,
+    estimatedTokensAfter: 70,
+    inputBudget: 90,
+  }), null);
+  assert.equal(validateCompactionEffect({
+    estimatedTokensBefore: 100,
+    estimatedTokensAfter: 70,
+    inputBudget: 60,
+  }), "compaction_still_over_budget");
+  // Overflow-recovery compactions only require any reduction at all.
+  assert.equal(validateCompactionEffect({
+    estimatedTokensBefore: 100,
+    estimatedTokensAfter: 95,
+    inputBudget: 90,
+    force: true,
   }), "compaction_still_over_budget");
   assert.equal(validateCompactionEffect({
     estimatedTokensBefore: 100,
-    estimatedTokensAfter: 60,
+    estimatedTokensAfter: 100,
     inputBudget: 90,
-  }), null);
+    force: true,
+  }), "compaction_no_effect");
 });

--- a/apps/agent/src/tests/compaction-policy.test.ts
+++ b/apps/agent/src/tests/compaction-policy.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { DEFAULT_COMPACTION_SETTINGS, shouldCompact } from "@earendil-works/pi-agent-core";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { estimateProxyContextTokens, resolveReserveTokens } from "../runtime/compaction-policy.js";
+import { estimateProxyContextTokens, FLAT_IMAGE_TOKEN_ESTIMATE, resolveReserveTokens } from "../runtime/compaction-policy.js";
 
 const asMessages = (messages: unknown[]) => messages as AgentMessage[];
 
@@ -15,13 +15,17 @@ const imageMessage = (base64Chars: number) => ({
 assert.equal(estimateProxyContextTokens(asMessages([textMessage("a".repeat(400))])), 100);
 assert.equal(estimateProxyContextTokens(asMessages([{ role: "user", content: "a".repeat(40) }])), 10);
 
-// ── Inline base64 images are charged at ~2 chars/token, not pi's flat 1.2k ──
-assert.equal(estimateProxyContextTokens(asMessages([imageMessage(200_000)])), 100_000);
+// ── Images count as a flat bounded estimate, not their raw base64 length ──
+// Ingestion normalizes images (<=1984px webp), so per-image vision cost is
+// predictable; base64 length is a text-billing proxy artifact that compaction
+// accounting deliberately ignores (same approach as pi/codex).
+assert.equal(estimateProxyContextTokens(asMessages([imageMessage(200_000)])), FLAT_IMAGE_TOKEN_ESTIMATE);
+assert.equal(estimateProxyContextTokens(asMessages([imageMessage(20)])), FLAT_IMAGE_TOKEN_ESTIMATE);
 
 // ── Mixed content sums both views ──
 assert.equal(
   estimateProxyContextTokens(asMessages([textMessage("a".repeat(400)), imageMessage(1_000)])),
-  100 + 500,
+  100 + FLAT_IMAGE_TOKEN_ESTIMATE,
 );
 
 // ── Thinking blocks and unknown block shapes still contribute ──
@@ -42,29 +46,22 @@ assert.equal(estimateProxyContextTokens(asMessages([])), 0);
 // ── Images without usable data are ignored rather than guessed at ──
 assert.equal(estimateProxyContextTokens(asMessages([{ role: "user", content: [{ type: "image", mimeType: "image/webp" }] }])), 0);
 
-// ── Regression: session f17dad70 sat below the threshold and never auto-compacted ──
-// 45 normalized images (~196k base64 chars each) plus ~324k chars of text. The
-// provider reported 4,564,921 tokens against a 1M window while pi's estimate
-// stayed at ~189k, so shouldCompact never fired.
+// ── Image-heavy sessions estimate at flat per-image cost regardless of payload ──
+// Session f17dad70: 45 normalized images plus ~324k chars of text. The proxy
+// billed ~4.56M tokens for the base64 payloads, but accounting follows the
+// bounded vision-cost model: text + 45 * flat image estimate.
 const contextWindow = 1_000_000;
 const settings = { ...DEFAULT_COMPACTION_SETTINGS, reserveTokens: resolveReserveTokens(contextWindow) };
-const stuckSession = asMessages([
+const imageHeavySession = asMessages([
   textMessage("a".repeat(324_000)),
   ...Array.from({ length: 45 }, () => imageMessage(196_074)),
 ]);
 
-const proxyTokens = estimateProxyContextTokens(stuckSession);
-assert.ok(
-  proxyTokens > 4_000_000 && proxyTokens < 5_000_000,
-  `expected proxy estimate near the reported 4.56M, got ${proxyTokens}`,
-);
+const proxyTokens = estimateProxyContextTokens(imageHeavySession);
+assert.equal(proxyTokens, 324_000 / 4 + 45 * FLAT_IMAGE_TOKEN_ESTIMATE);
+assert.equal(shouldCompact(Math.max(189_451, proxyTokens), contextWindow, settings), false);
 
-// pi's own view of the same context stays far below the threshold …
-assert.equal(shouldCompact(189_451, contextWindow, settings), false);
-// … while the base64-aware lower bound triggers compaction before the 413.
-assert.equal(shouldCompact(Math.max(189_451, proxyTokens), contextWindow, settings), true);
-
-// ── An image-free session is unaffected by the new lower bound ──
+// ── An image-free session is unaffected by flat image accounting ──
 const textOnlySession = asMessages([textMessage("a".repeat(400_000))]);
 assert.equal(estimateProxyContextTokens(textOnlySession), 100_000);
 assert.equal(shouldCompact(Math.max(100_000, estimateProxyContextTokens(textOnlySession)), contextWindow, settings), false);

--- a/apps/agent/src/tests/local-session-manager.test.ts
+++ b/apps/agent/src/tests/local-session-manager.test.ts
@@ -175,6 +175,103 @@ try {
     () => SessionManager.open(terminatedBadFile, sessionsDir, { recoverTrailingPartial: true }),
     /Invalid session JSONL/,
   );
+
+  // Regression: buildSessionContext must not duplicate kept messages when the
+  // compaction entry is the root (post-rewrite layout, normal state after the
+  // first compaction). A duplication here would double the whole request context.
+  const postRewriteFile = join(sessionsDir, "post-rewrite.jsonl");
+  const postRewriteEntry = (id: string, parentId: string | null, role: "user" | "assistant") => ({
+    type: "message",
+    id,
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: { role, content: [{ type: "text", text: id }], timestamp: Date.now() },
+  });
+  await writeFile(postRewriteFile, [
+    JSON.stringify({ type: "session", version: 3, id: "post-rewrite", timestamp: new Date().toISOString(), cwd: root }),
+    JSON.stringify({ type: "compaction", id: "c1", parentId: null, timestamp: new Date().toISOString(), summary: "s1", firstKeptEntryId: "k1", tokensBefore: 100 }),
+    JSON.stringify(postRewriteEntry("k1", "c1", "user")),
+    JSON.stringify(postRewriteEntry("k2", "k1", "assistant")),
+    JSON.stringify(postRewriteEntry("k3", "k2", "user")),
+    "",
+  ].join("\n"));
+  const postRewrite = await SessionManager.open(postRewriteFile, sessionsDir);
+  const postRewriteMessages = postRewrite.buildSessionContext().messages;
+  assert.equal(postRewriteMessages.length, 4, "post-rewrite layout must not duplicate kept messages");
+  assert.equal(postRewriteMessages[0]?.role, "compactionSummary");
+  assert.equal(postRewriteMessages[1]?.role, "user");
+  assert.equal(postRewriteMessages[2]?.role, "assistant");
+  assert.equal(postRewriteMessages[3]?.role, "user");
+
+  // Pre-rewrite layout (compaction at end): entries from firstKeptEntryId up to
+  // the compaction entry, plus entries appended after it.
+  const preRewriteFile = join(sessionsDir, "pre-rewrite.jsonl");
+  await writeFile(preRewriteFile, [
+    JSON.stringify({ type: "session", version: 3, id: "pre-rewrite", timestamp: new Date().toISOString(), cwd: root }),
+    JSON.stringify(postRewriteEntry("old1", null, "user")),
+    JSON.stringify(postRewriteEntry("old2", "old1", "assistant")),
+    JSON.stringify(postRewriteEntry("keep1", "old2", "user")),
+    JSON.stringify(postRewriteEntry("keep2", "keep1", "assistant")),
+    JSON.stringify({ type: "compaction", id: "c2", parentId: "keep2", timestamp: new Date().toISOString(), summary: "s2", firstKeptEntryId: "keep1", tokensBefore: 100 }),
+    JSON.stringify(postRewriteEntry("after1", "c2", "assistant")),
+    "",
+  ].join("\n"));
+  const preRewrite = await SessionManager.open(preRewriteFile, sessionsDir);
+  const preRewriteTexts = preRewrite.buildSessionContext().messages.map((message) => {
+    const record = message as { role?: string; content?: Array<{ text?: string }> };
+    return record.role === "compactionSummary" ? "summary" : record.content?.[0]?.text;
+  });
+  assert.deepEqual(preRewriteTexts, ["summary", "keep1", "keep2", "after1"]);
+
+  // Pre-rewrite layout with firstKeptEntryId missing: include all pre-compaction
+  // entries (fallback) plus post-compaction entries, without duplicates.
+  const preRewriteMissingFile = join(sessionsDir, "pre-rewrite-missing.jsonl");
+  await writeFile(preRewriteMissingFile, [
+    JSON.stringify({ type: "session", version: 3, id: "pre-rewrite-missing", timestamp: new Date().toISOString(), cwd: root }),
+    JSON.stringify(postRewriteEntry("old1", null, "user")),
+    JSON.stringify(postRewriteEntry("old2", "old1", "assistant")),
+    JSON.stringify({ type: "compaction", id: "c3", parentId: "old2", timestamp: new Date().toISOString(), summary: "s3", firstKeptEntryId: "missing", tokensBefore: 100 }),
+    JSON.stringify(postRewriteEntry("after1", "c3", "assistant")),
+    "",
+  ].join("\n"));
+  const preRewriteMissing = await SessionManager.open(preRewriteMissingFile, sessionsDir);
+  const preRewriteMissingTexts = preRewriteMissing.buildSessionContext().messages.map((message) => {
+    const record = message as { role?: string; content?: Array<{ text?: string }> };
+    return record.role === "compactionSummary" ? "summary" : record.content?.[0]?.text;
+  });
+  assert.deepEqual(preRewriteMissingTexts, ["summary", "old1", "old2", "after1"]);
+
+  // Regression: multiple consecutive compaction cycles through the real
+  // appendCompaction + archiveAndRewrite flow must never duplicate context.
+  const multiCompactFile = join(sessionsDir, "multi-compact.jsonl");
+  const multiCompact = SessionManager.create(root, sessionsDir);
+  multiCompact.newSession({ id: "multi-compact" });
+  multiCompact.setSessionFile(multiCompactFile);
+  const msg = (text: string, role: "user" | "assistant") =>
+    multiCompact.appendMessage({ role, content: [{ type: "text", text }], timestamp: Date.now() } as never);
+  msg("m1", "user");
+  msg("m2", "assistant");
+  const cm3 = msg("m3", "user");
+  msg("m4", "assistant");
+  const cm5 = msg("m5", "user");
+  msg("m6", "assistant");
+  const compactContextTexts = () => multiCompact.buildSessionContext().messages.map((message) => {
+    const record = message as { role?: string; content?: Array<{ text?: string }> };
+    return record.role === "compactionSummary" ? "summary" : record.content?.[0]?.text;
+  });
+  const c1 = multiCompact.appendCompaction("s1", cm3, 100);
+  await multiCompact.archiveAndRewrite(c1, cm3);
+  assert.deepEqual(compactContextTexts(), ["summary", "m3", "m4", "m5", "m6"]);
+  msg("m7", "user");
+  const cm8 = msg("m8", "assistant");
+  assert.deepEqual(compactContextTexts(), ["summary", "m3", "m4", "m5", "m6", "m7", "m8"]);
+  const c2 = multiCompact.appendCompaction("s2", cm5, 100);
+  await multiCompact.archiveAndRewrite(c2, cm5);
+  assert.deepEqual(compactContextTexts(), ["summary", "m5", "m6", "m7", "m8"]);
+  msg("m9", "user");
+  const c3 = multiCompact.appendCompaction("s3", cm8, 100);
+  await multiCompact.archiveAndRewrite(c3, cm8);
+  assert.deepEqual(compactContextTexts(), ["summary", "m8", "m9"]);
 } finally {
   await rm(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary

Fixes three compaction bugs behind the agent tool-call loops and misreported compactions (e.g. `76.8k → ~239.1k`).

## Root causes & fixes

### 1. Context history duplicated ×2 after compaction
`buildSessionContext()` in post-rewrite layout (compaction entry at root — the normal state after the first compaction) appended every kept entry once, then the unconditional post-compaction loop appended them all again. Every request after the first compaction carried the whole history twice — doubling input cost and feeding the model repeated patterns (verified via tcpdump of the real request body: identical reasoning ids at offset 550; 1102 items = 550×2 + developer + user).

Fix: only append post-compaction entries in pre-rewrite layouts (`compactionIdx > 0`).

### 2. Compact turns appended at the end of the timeline
Turn/scope resolution ran *after* `archiveAndRewrite`, but for in-turn cuts the current turn's user message — the only branch entry carrying `meta.turnId` (assistant entries never do) — sits before the cut and is removed by the rewrite. Resolution then failed, degraded in-turn compactions to `between_turns`, and the max+1 fallback appended the compact turn at the end (confirmed in prod DB: real turn seq=1, compact turns seq=2,3,4,5).

Fix: resolve `firstKeptTurnId`/`scope`/`ownerTurnId` before mutating the session file, so in-turn compactions land inside their owning turn.

### 3. Image accounting followed the proxy's text billing
Compaction accounting counted inline image base64 at ~2 chars/token (the proxy bills images as text), inflating context estimates by orders of magnitude and triggering compactions that cannot shrink the payload — e.g. 6 retained images (~442KB base64) reported `76.8k → ~239.1k` and caused repeated no-op compactions.

Fix (aligned with pi/codex): count each image block as a flat vision-cost estimate (2800 tokens for ≤1984px, 16 tiles), and require threshold-triggered compactions to reduce the estimated context by ≥20% (overflow-recovery still runs on any reduction). Age-based image omission was considered and deliberately not added.

## Verification

- 24 agent tests pass (new regression tests cover: post/pre-rewrite context layouts, 3 consecutive compaction cycles, flat image accounting, minimum-effect rule).
- typecheck + biome lint clean.
- Evidence gathered from prod logs, prod DB, and pod session files during investigation.

## Notes

- No migration needed; existing misplaced compact turns stay where they are.
- `FLAT_IMAGE_TOKEN_ESTIMATE` (2800) tracks the normalizer's 1984px max edge; tighten the normalizer to lower both estimate and real billed payload.
