### PR TITLE
ci: centralize and speed up verification

### DIFF
--- a/.github/workflows/agent-docker-build-push.yml
+++ b/.github/workflows/agent-docker-build-push.yml
@@ -1,14 +1,15 @@
 name: Agent Docker Build and Push
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*.*.*'
-    paths:
-      - 'apps/agent/**'
-      - 'packages/**'
+  workflow_call:
+    inputs:
+      source_sha:
+        required: false
+        type: string
+      skip_preflight:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       environment:
@@ -23,7 +24,6 @@ permissions:
   contents: read
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: git.talesofai.com
   NAMESPACE: ${{ secrets.GITEA_OWNER }}
   IMAGE_NAME: cohub-agent
@@ -39,7 +39,9 @@ jobs:
       image_version: ${{ steps.meta.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Validate service tag
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -52,15 +54,18 @@ jobs:
           fi
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        if: ${{ !inputs.skip_preflight }}
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        if: ${{ !inputs.skip_preflight }}
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'
 
       - name: Configure Talesofai npm auth
+        if: ${{ !inputs.skip_preflight }}
         run: |
           if [ -z "$GITEA_NPM_TOKEN" ]; then
             echo "GITEA_NPM_TOKEN not set; installing without private billing packages"
@@ -70,22 +75,26 @@ jobs:
           fi
 
       - name: Install dependencies
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm install --frozen-lockfile
 
       - name: Build dependency closure
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm --filter @cohub/agent... build
 
       - name: Lint
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm --filter @cohub/agent lint
 
       - name: Typecheck
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm --filter @cohub/agent typecheck
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GITEA_USERNAME }}
@@ -93,17 +102,17 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch,suffix=-{{sha}}
+            type=raw,value=main-{{sha}},enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,format=short
-            type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./apps/agent/Dockerfile
@@ -118,13 +127,13 @@ jobs:
 
   deploy-dev:
     needs: build-and-push
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.skip_preflight && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     env:
       IMAGE_TAG: ${{ needs.build-and-push.outputs.image_version }}
     steps:
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 
@@ -143,11 +152,11 @@ jobs:
 
   deploy-prod:
     needs: build-and-push
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ inputs.skip_preflight && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 
@@ -180,7 +189,7 @@ jobs:
       IMAGE_TAG: ${{ needs.build-and-push.outputs.image_version }}
     steps:
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 
@@ -205,7 +214,7 @@ jobs:
       IMAGE_TAG: ${{ needs.build-and-push.outputs.image_version }}
     steps:
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 

--- a/.github/workflows/api-docker-build-push.yml
+++ b/.github/workflows/api-docker-build-push.yml
@@ -1,19 +1,18 @@
 name: API Docker Build and Push
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*.*.*'
-    paths:
-      - 'apps/api/**'
-      - 'packages/**'
-      - '.npmrc'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - '.github/workflows/api-docker-build-push.yml'
+  workflow_call:
+    inputs:
+      source_sha:
+        required: false
+        type: string
+      base_sha:
+        required: false
+        type: string
+      skip_preflight:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       environment:
@@ -28,7 +27,6 @@ permissions:
   contents: read
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: git.talesofai.com
   NAMESPACE: ${{ secrets.GITEA_OWNER }}
   IMAGE_NAME: cohub-api
@@ -44,7 +42,9 @@ jobs:
       image_version: ${{ steps.meta.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Validate service tag
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -57,15 +57,18 @@ jobs:
           fi
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        if: ${{ !inputs.skip_preflight }}
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        if: ${{ !inputs.skip_preflight }}
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'
 
       - name: Configure Talesofai npm auth
+        if: ${{ !inputs.skip_preflight }}
         run: |
           if [ -z "$GITEA_NPM_TOKEN" ]; then
             echo "GITEA_NPM_TOKEN not set; installing without private billing packages"
@@ -75,22 +78,26 @@ jobs:
           fi
 
       - name: Install dependencies
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm install --frozen-lockfile
 
       - name: Build dependency closure
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm --filter @cohub/api... build
 
       - name: Lint
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm --filter @cohub/api lint
 
       - name: Typecheck
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm --filter @cohub/api typecheck
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GITEA_USERNAME }}
@@ -98,17 +105,17 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch,suffix=-{{sha}}
+            type=raw,value=main-{{sha}},enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,format=short
-            type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./apps/api/Dockerfile
@@ -123,18 +130,19 @@ jobs:
 
   deploy-dev:
     needs: build-and-push
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.skip_preflight && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     env:
       IMAGE_TAG: ${{ needs.build-and-push.outputs.image_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.source_sha || github.sha }}
           fetch-depth: 0
 
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 
@@ -145,8 +153,8 @@ jobs:
 
       - name: Run migration if needed
         run: |
-          BASE_SHA="${{ github.event.before }}"
-          HEAD_SHA="${{ github.sha }}"
+          BASE_SHA="${{ inputs.base_sha || github.event.before }}"
+          HEAD_SHA="${{ inputs.source_sha || github.sha }}"
 
           if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
             BASE_SHA="HEAD~1"
@@ -228,14 +236,14 @@ jobs:
 
   deploy-prod:
     needs: build-and-push
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ inputs.skip_preflight && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 
@@ -326,10 +334,10 @@ jobs:
       IMAGE_TAG: ${{ needs.build-and-push.outputs.image_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 
@@ -389,10 +397,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -17,14 +17,14 @@ jobs:
     env:
       GITEA_NPM_TOKEN: ${{ secrets.GITEA_NPM_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
-
-      - name: Install pnpm
-        run: npm i -g pnpm@10.32.1
+          cache: pnpm
 
       - name: Configure Talesofai npm auth
         run: |
@@ -40,12 +40,12 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v2
         with:
-          version: pnpm version-packages
-          publish: pnpm release
-          commit: "chore: update versions"
-          title: "Version Packages"
+          version-script: pnpm version-packages
+          publish-script: pnpm release
+          commit-message: "chore: update versions"
+          pr-title: "Version Packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -40,12 +40,14 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@v2
+        uses: changesets/action@v1
         with:
-          version-script: pnpm version-packages
-          publish-script: pnpm release
-          commit-message: "chore: update versions"
-          pr-title: "Version Packages"
+          version: pnpm version-packages
+          publish: pnpm release
+          commit: "chore: update versions"
+          title: "Version Packages"
+          createGithubReleases: true
+          commitMode: git-cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,94 +10,8 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
-  js-checks:
-    name: Lint, typecheck, test, build
-    runs-on: ubuntu-latest
-    env:
-      GITEA_NPM_TOKEN: ${{ secrets.GITEA_NPM_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-
-      # Optional: only used when available; installs fine without it
-      # because @talesofai-billing/sdk is an optional dependency.
-      - name: Configure Talesofai npm auth
-        run: |
-          if [ -z "$GITEA_NPM_TOKEN" ]; then
-            echo "GITEA_NPM_TOKEN not set; installing without private billing packages"
-          fi
-          if [ -n "$GITEA_NPM_TOKEN" ]; then
-            printf '\n//git.talesofai.com/api/packages/talesofai/npm/:_authToken=%s\n' "$GITEA_NPM_TOKEN" >> ~/.npmrc
-          fi
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Lint
-        run: pnpm lint
-
-      # Build first: workspace packages export types/runtime from dist/, so
-      # typecheck and tests need the build artifacts present (clean checkout
-      # has none). This mirrors the deploy workflows' build-before-check order.
-      # SvelteKit statically inlines $env/static/public at build time; a clean
-      # checkout has no .env, so named imports fail with MISSING_EXPORT.
-      # Use dev values, same as web-deploy-cloudflare.yml.
-      - name: Setup web environment
-        working-directory: apps/web
-        run: |
-          cat > .env <<EOF
-          PUBLIC_COHUB_ENV=dev
-          PUBLIC_API_ORIGIN=https://api-dev.cohub.live
-          PUBLIC_GATEWAY_ORIGIN=https://gateway-dev.cohub.live
-          PUBLIC_PREVIEW_ORIGIN=https://preview-dev.cohub.live
-          PUBLIC_LOGTO_ENDPOINT=https://dev-auth.neta.art/
-          PUBLIC_LOGTO_APP_ID=vpikk7sl9zwvefiptowtn
-          PUBLIC_LOGTO_API_RESOURCE=https://api.talesofai
-          EOF
-
-      - name: Build
-        run: pnpm build
-
-      - name: Typecheck
-        run: pnpm typecheck
-
-      - name: Test
-        run: pnpm test
-
-  go-checks:
-    name: Format, vet, test (sandbox)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.24'
-          cache-dependency-path: apps/sandbox/go.sum
-
-      - name: Check formatting
-        working-directory: apps/sandbox
-        run: test -z "$(gofmt -l .)"
-
-      - name: Vet
-        working-directory: apps/sandbox
-        run: go vet ./...
-
-      - name: Test
-        working-directory: apps/sandbox
-        run: go test ./...
+  verify:
+    name: Full verification
+    uses: ./.github/workflows/verify.yml
+    secrets: inherit

--- a/.github/workflows/configs-sync.yml
+++ b/.github/workflows/configs-sync.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 

--- a/.github/workflows/gateway-docker-build-push.yml
+++ b/.github/workflows/gateway-docker-build-push.yml
@@ -1,21 +1,21 @@
 name: Gateway Docker Build and Push
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*.*.*'
-    paths:
-      - 'apps/gateway/**'
-      - 'packages/**'
+  workflow_call:
+    inputs:
+      source_sha:
+        required: false
+        type: string
+      skip_preflight:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
 
 permissions:
   contents: read
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: git.talesofai.com
   NAMESPACE: ${{ secrets.GITEA_OWNER }}
   IMAGE_NAME: cohub-gateway
@@ -31,7 +31,9 @@ jobs:
       image_version: ${{ steps.meta.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Validate service tag
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -44,15 +46,18 @@ jobs:
           fi
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        if: ${{ !inputs.skip_preflight }}
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        if: ${{ !inputs.skip_preflight }}
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'
 
       - name: Configure Talesofai npm auth
+        if: ${{ !inputs.skip_preflight }}
         run: |
           if [ -z "$GITEA_NPM_TOKEN" ]; then
             echo "GITEA_NPM_TOKEN not set; installing without private billing packages"
@@ -62,22 +67,26 @@ jobs:
           fi
 
       - name: Install dependencies
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm install --frozen-lockfile
 
       - name: Build dependency closure
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm --filter @cohub/gateway... build
 
       - name: Lint
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm --filter @cohub/gateway lint
 
       - name: Typecheck
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm --filter @cohub/gateway typecheck
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GITEA_USERNAME }}
@@ -85,17 +94,17 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch,suffix=-{{sha}}
+            type=raw,value=main-{{sha}},enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,format=short
-            type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./apps/gateway/Dockerfile
@@ -110,13 +119,13 @@ jobs:
 
   deploy-dev:
     needs: build-and-push
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ (inputs.skip_preflight || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     env:
       IMAGE_TAG: ${{ needs.build-and-push.outputs.image_version }}
     steps:
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 
@@ -135,11 +144,11 @@ jobs:
 
   deploy-prod:
     needs: build-and-push
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ (inputs.skip_preflight || github.event_name == 'workflow_dispatch') && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -56,7 +56,12 @@ jobs:
             base="$(git rev-parse "$HEAD_SHA^")"
           fi
 
-          changed="$(git diff --name-only "$base" "$HEAD_SHA")"
+          if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            echo "Base commit $base is unavailable; using the full deploy scope."
+            changed="$(printf '%s\n' 'apps/agent/' 'apps/api/' 'apps/gateway/' 'apps/worker/' 'apps/web/' 'apps/sandbox/')"
+          else
+            changed="$(git diff --name-only "$base" "$HEAD_SHA")"
+          fi
           if [[ -n "$changed" ]]; then
             echo "Changed files:"
             echo "$changed"

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -1,0 +1,192 @@
+name: Main Deploy
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+concurrency:
+  group: main-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  changes:
+    name: Detect deploy scope
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      verify: ${{ steps.scope.outputs.verify }}
+      agent: ${{ steps.scope.outputs.agent }}
+      api: ${{ steps.scope.outputs.api }}
+      gateway: ${{ steps.scope.outputs.gateway }}
+      worker: ${{ steps.scope.outputs.worker }}
+      web: ${{ steps.scope.outputs.web }}
+      sandbox: ${{ steps.scope.outputs.sandbox }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Detect changed services
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$REF" == refs/tags/v* ]]; then
+            for service in verify agent api gateway worker web sandbox; do
+              echo "$service=true" >> "$GITHUB_OUTPUT"
+            done
+            exit 0
+          fi
+
+          base="$BASE_SHA"
+          if [[ -z "$base" || "$base" == 0000000000000000000000000000000000000000 ]]; then
+            base="$(git rev-parse "$HEAD_SHA^")"
+          fi
+
+          changed="$(git diff --name-only "$base" "$HEAD_SHA")"
+          if [[ -n "$changed" ]]; then
+            echo "Changed files:"
+            echo "$changed"
+          else
+            echo "No files changed"
+          fi
+
+          matches() {
+            printf '%s\n' "$changed" | grep -Eq "$1"
+          }
+
+          verify=false
+          if matches '^(apps/|packages/|deploy/|scripts/|\.github/workflows/|\.npmrc$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig\.base\.json$|biome\.json$|LICENSE$|NOTICE$|\.dockerignore$)'; then
+            verify=true
+          fi
+
+          node_shared=false
+          if matches '^(packages/|\.npmrc$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig\.base\.json$)'; then
+            node_shared=true
+          fi
+
+          container_shared=false
+          if matches '^(LICENSE$|NOTICE$|\.dockerignore$)'; then
+            container_shared=true
+          fi
+
+          agent=$node_shared
+          api=$node_shared
+          gateway=$node_shared
+          worker=$node_shared
+          web=$node_shared
+          sandbox=false
+
+          if [[ "$container_shared" == true ]]; then
+            agent=true
+            api=true
+            gateway=true
+            worker=true
+          fi
+
+          matches '^apps/agent/|^deploy/agent/|^\.github/workflows/agent-docker-build-push\.yml$' && agent=true || true
+          matches '^apps/api/|^deploy/api/|^\.github/workflows/api-docker-build-push\.yml$' && api=true || true
+          matches '^apps/gateway/|^deploy/gateway/|^\.github/workflows/gateway-docker-build-push\.yml$' && gateway=true || true
+          matches '^apps/worker/|^deploy/worker/|^\.github/workflows/worker-docker-build-push\.yml$' && worker=true || true
+          matches '^apps/web/|^\.github/workflows/web-deploy-cloudflare\.yml$' && web=true || true
+          matches '^apps/sandbox/|^\.github/workflows/sandbox-docker-build-push\.yml$' && sandbox=true || true
+
+          echo "verify=$verify" >> "$GITHUB_OUTPUT"
+          echo "agent=$agent" >> "$GITHUB_OUTPUT"
+          echo "api=$api" >> "$GITHUB_OUTPUT"
+          echo "gateway=$gateway" >> "$GITHUB_OUTPUT"
+          echo "worker=$worker" >> "$GITHUB_OUTPUT"
+          echo "web=$web" >> "$GITHUB_OUTPUT"
+          echo "sandbox=$sandbox" >> "$GITHUB_OUTPUT"
+
+  verify:
+    name: Full verification
+    needs: changes
+    if: ${{ needs.changes.outputs.verify == 'true' }}
+    uses: ./.github/workflows/verify.yml
+    secrets: inherit
+
+  deploy-agent:
+    name: Agent
+    needs: [changes, verify]
+    if: ${{ needs.changes.outputs.agent == 'true' && needs.verify.result == 'success' }}
+    uses: ./.github/workflows/agent-docker-build-push.yml
+    with:
+      source_sha: ${{ github.sha }}
+      skip_preflight: true
+    secrets: inherit
+
+  deploy-api:
+    name: API
+    needs: [changes, verify]
+    if: ${{ needs.changes.outputs.api == 'true' && needs.verify.result == 'success' }}
+    uses: ./.github/workflows/api-docker-build-push.yml
+    with:
+      source_sha: ${{ github.sha }}
+      base_sha: ${{ github.event.before }}
+      skip_preflight: true
+    secrets: inherit
+
+  deploy-gateway:
+    name: Gateway
+    needs: [changes, verify]
+    if: ${{ needs.changes.outputs.gateway == 'true' && needs.verify.result == 'success' }}
+    uses: ./.github/workflows/gateway-docker-build-push.yml
+    with:
+      source_sha: ${{ github.sha }}
+      skip_preflight: true
+    secrets: inherit
+
+  deploy-worker:
+    name: Worker
+    needs: [changes, verify]
+    if: ${{ needs.changes.outputs.worker == 'true' && needs.verify.result == 'success' }}
+    uses: ./.github/workflows/worker-docker-build-push.yml
+    with:
+      source_sha: ${{ github.sha }}
+      skip_preflight: true
+    secrets: inherit
+
+  deploy-web:
+    name: Web
+    needs: [changes, verify]
+    if: ${{ needs.changes.outputs.web == 'true' && needs.verify.result == 'success' }}
+    uses: ./.github/workflows/web-deploy-cloudflare.yml
+    with:
+      source_sha: ${{ github.sha }}
+      skip_preflight: true
+    secrets: inherit
+
+  deploy-sandbox:
+    name: Sandbox
+    needs: [changes, verify]
+    if: ${{ needs.changes.outputs.sandbox == 'true' && needs.verify.result == 'success' }}
+    uses: ./.github/workflows/sandbox-docker-build-push.yml
+    with:
+      source_sha: ${{ github.sha }}
+      skip_preflight: true
+    secrets: inherit
+
+  release-sandbox-binaries:
+    name: Sandbox binaries
+    needs: verify
+    permissions:
+      contents: write
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && needs.verify.result == 'success' }}
+    uses: ./.github/workflows/sandbox-binaries-build.yml
+    with:
+      source_sha: ${{ github.sha }}
+    secrets: inherit

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -34,7 +34,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -37,7 +37,6 @@ env:
   # 运行时判断 Logto 端点（dev-auth vs auth），preview 必须落入 dev 分支
   WEB_HOSTNAME: dev-${{ github.event.pull_request.number }}-preview.cohub.live
   WEB_WORKER_NAME: cohub-web-pr-${{ github.event.pull_request.number }}
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build-images:
@@ -53,11 +52,11 @@ jobs:
       GITEA_NPM_TOKEN: ${{ secrets.GITEA_NPM_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Detect changed apps
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             api:
@@ -78,10 +77,10 @@ jobs:
               - 'tsconfig.base.json'
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GITEA_USERNAME }}
@@ -93,7 +92,7 @@ jobs:
           contains(fromJSON('["labeled", "reopened"]'), github.event.action) ||
           (matrix.app == 'api' && steps.changes.outputs.api == 'true') ||
           (matrix.app == 'gateway' && steps.changes.outputs.gateway == 'true')
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./apps/${{ matrix.app }}/Dockerfile
@@ -116,13 +115,13 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -141,7 +140,7 @@ jobs:
 
       - name: Detect changed apps
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             web:
@@ -210,12 +209,12 @@ jobs:
     steps:
       # 部署脚本/模板必须来自 main（可信）；PR 的代码只以镜像 tag 形式进入
       - name: Checkout (main)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 
@@ -226,7 +225,7 @@ jobs:
 
       - name: Detect changed apps
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             api:
@@ -439,7 +438,7 @@ jobs:
           done
 
       - name: Post preview comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           WEB_URL: ${{ env.WEB_URL }}
           API_HOSTNAME: ${{ env.API_HOSTNAME }}

--- a/.github/workflows/sandbox-binaries-build.yml
+++ b/.github/workflows/sandbox-binaries-build.yml
@@ -6,12 +6,11 @@ name: Sandbox Binaries Build and Release
 # are attached to a GitHub Release; on other runs they are uploaded as artifacts.
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
-    paths:
-      - 'apps/sandbox/**'
-      - '.github/workflows/sandbox-binaries-build.yml'
+  workflow_call:
+    inputs:
+      source_sha:
+        required: false
+        type: string
   pull_request:
     paths:
       - 'apps/sandbox/**'
@@ -41,10 +40,12 @@ jobs:
             goarch: arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: '1.24'
           cache-dependency-path: apps/sandbox/go.sum
@@ -91,7 +92,7 @@ jobs:
           sha256sum "${BASE}.tar.gz" > "${BASE}.tar.gz.sha256"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BINARY_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }}
           path: |
@@ -108,7 +109,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -122,7 +123,7 @@ jobs:
           ls -la release
 
       - name: Publish to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             release/*.tar.gz
@@ -142,7 +143,7 @@ jobs:
       OSS_REGION: us-west-1
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/.github/workflows/sandbox-docker-build-push.yml
+++ b/.github/workflows/sandbox-docker-build-push.yml
@@ -1,20 +1,21 @@
 name: Sandbox Docker Build and Push
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*.*.*'
-    paths:
-      - 'apps/sandbox/**'
+  workflow_call:
+    inputs:
+      source_sha:
+        required: false
+        type: string
+      skip_preflight:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
 
 permissions:
   contents: read
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: git.talesofai.com
   NAMESPACE: ${{ secrets.GITEA_OWNER }}
   IMAGE_NAME: cohub-sandbox
@@ -27,8 +28,9 @@ jobs:
       sandbox_release_changed: ${{ steps.release-scope.outputs.changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.source_sha || github.sha }}
           fetch-depth: 0
 
       - name: Validate service tag
@@ -75,37 +77,37 @@ jobs:
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
-        if: ${{ steps.release-scope.outputs.changed == 'true' }}
-        uses: actions/setup-go@v5
+        if: ${{ steps.release-scope.outputs.changed == 'true' && !inputs.skip_preflight }}
+        uses: actions/setup-go@v7
         with:
           go-version: '1.24'
           cache-dependency-path: apps/sandbox/go.sum
 
       - name: Go fmt check
-        if: ${{ steps.release-scope.outputs.changed == 'true' }}
+        if: ${{ steps.release-scope.outputs.changed == 'true' && !inputs.skip_preflight }}
         run: |
           cd apps/sandbox
           test -z "$(gofmt -l .)"
 
       - name: Go vet
-        if: ${{ steps.release-scope.outputs.changed == 'true' }}
+        if: ${{ steps.release-scope.outputs.changed == 'true' && !inputs.skip_preflight }}
         run: |
           cd apps/sandbox
           go vet ./...
 
       - name: Go test
-        if: ${{ steps.release-scope.outputs.changed == 'true' }}
+        if: ${{ steps.release-scope.outputs.changed == 'true' && !inputs.skip_preflight }}
         run: |
           cd apps/sandbox
           go test ./...
 
       - name: Set up Docker Buildx
         if: ${{ steps.release-scope.outputs.changed == 'true' }}
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Registry
         if: ${{ steps.release-scope.outputs.changed == 'true' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GITEA_USERNAME }}
@@ -114,18 +116,18 @@ jobs:
       - name: Extract metadata
         if: ${{ steps.release-scope.outputs.changed == 'true' }}
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch,suffix=-{{sha}}
+            type=raw,value=main-{{sha}},enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,format=short
-            type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
         if: ${{ steps.release-scope.outputs.changed == 'true' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./apps/sandbox
           file: ./apps/sandbox/Dockerfile
@@ -138,16 +140,17 @@ jobs:
 
   deploy-dev:
     needs: build-and-push
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ (inputs.skip_preflight || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.source_sha || github.sha }}
           fetch-depth: 1
 
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 
@@ -174,11 +177,11 @@ jobs:
 
   deploy-prod:
     needs: build-and-push
-    if: ${{ startsWith(github.ref, 'refs/tags/v') && needs.build-and-push.outputs.sandbox_release_changed == 'true' }}
+    if: ${{ (inputs.skip_preflight || github.event_name == 'workflow_dispatch') && startsWith(github.ref, 'refs/tags/v') && needs.build-and-push.outputs.sandbox_release_changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,100 @@
+name: Verify
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  js-checks:
+    name: Lint, typecheck, test, build
+    runs-on: ubuntu-latest
+    env:
+      GITEA_NPM_TOKEN: ${{ secrets.GITEA_NPM_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Configure Talesofai npm auth
+        run: |
+          if [ -z "$GITEA_NPM_TOKEN" ]; then
+            echo "GITEA_NPM_TOKEN not set; installing without private billing packages"
+          fi
+          if [ -n "$GITEA_NPM_TOKEN" ]; then
+            printf '\n//git.talesofai.com/api/packages/talesofai/npm/:_authToken=%s\n' "$GITEA_NPM_TOKEN" >> ~/.npmrc
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      # Workspace packages export types/runtime from dist/, so typecheck and
+      # tests need the build artifacts present on a clean checkout.
+      - name: Setup web environment
+        working-directory: apps/web
+        run: |
+          cat > .env <<EOF
+          PUBLIC_COHUB_ENV=dev
+          PUBLIC_API_ORIGIN=https://api-dev.cohub.live
+          PUBLIC_GATEWAY_ORIGIN=https://gateway-dev.cohub.live
+          PUBLIC_PREVIEW_ORIGIN=https://preview-dev.cohub.live
+          PUBLIC_LOGTO_ENDPOINT=https://dev-auth.neta.art/
+          PUBLIC_LOGTO_APP_ID=vpikk7sl9zwvefiptowtn
+          PUBLIC_LOGTO_API_RESOURCE=https://api.talesofai
+          EOF
+
+      - name: Build
+        run: pnpm build
+
+      - name: Restore typecheck cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            node_modules/.cache/tsbuildinfo
+            apps/web/.svelte-kit/.svelte-check
+          key: typecheck-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.base.json', 'apps/**/tsconfig*.json', 'packages/**/tsconfig*.json', 'apps/web/svelte.config.js', 'scripts/typecheck-web.mjs') }}-${{ github.sha }}
+          restore-keys: |
+            typecheck-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.base.json', 'apps/**/tsconfig*.json', 'packages/**/tsconfig*.json', 'apps/web/svelte.config.js', 'scripts/typecheck-web.mjs') }}-
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+  go-checks:
+    name: Format, vet, test (sandbox)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: '1.24'
+          cache-dependency-path: apps/sandbox/go.sum
+
+      - name: Check formatting
+        working-directory: apps/sandbox
+        run: test -z "$(gofmt -l .)"
+
+      - name: Vet
+        working-directory: apps/sandbox
+        run: go vet ./...
+
+      - name: Test
+        working-directory: apps/sandbox
+        run: go test ./...

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -59,7 +59,7 @@ jobs:
         run: pnpm build
 
       - name: Restore typecheck cache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: |
             node_modules/.cache/tsbuildinfo
@@ -73,6 +73,15 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Save typecheck cache
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            node_modules/.cache/tsbuildinfo
+            apps/web/.svelte-kit/.svelte-check
+          key: typecheck-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.base.json', 'apps/**/tsconfig*.json', 'packages/**/tsconfig*.json', 'apps/web/svelte.config.js', 'scripts/typecheck-web.mjs') }}-${{ github.sha }}
 
   go-checks:
     name: Format, vet, test (sandbox)

--- a/.github/workflows/web-deploy-cloudflare.yml
+++ b/.github/workflows/web-deploy-cloudflare.yml
@@ -1,14 +1,15 @@
 name: Web Deploy to Cloudflare Workers
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*.*.*'
-    paths:
-      - 'apps/web/**'
-      - 'packages/**'
+  workflow_call:
+    inputs:
+      source_sha:
+        required: false
+        type: string
+      skip_preflight:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       environment:
@@ -23,9 +24,6 @@ on:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   deploy:
     if: ${{ !startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/tags/v') }}
@@ -34,13 +32,15 @@ jobs:
       GITEA_NPM_TOKEN: ${{ secrets.GITEA_NPM_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -101,10 +101,12 @@ jobs:
           fi
 
       - name: Lint
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm lint
         working-directory: apps/web
 
       - name: Typecheck
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm typecheck
         working-directory: apps/web
 

--- a/.github/workflows/worker-docker-build-push.yml
+++ b/.github/workflows/worker-docker-build-push.yml
@@ -1,15 +1,15 @@
 name: Worker Docker Build and Push
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*.*.*'
-    paths:
-      - 'apps/worker/**'
-      - 'deploy/worker/**'
-      - 'packages/**'
+  workflow_call:
+    inputs:
+      source_sha:
+        required: false
+        type: string
+      skip_preflight:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       environment:
@@ -24,7 +24,6 @@ permissions:
   contents: read
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: git.talesofai.com
   NAMESPACE: ${{ secrets.GITEA_OWNER }}
   IMAGE_NAME: cohub-worker
@@ -40,7 +39,9 @@ jobs:
       image_version: ${{ steps.meta.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Validate service tag
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -53,15 +54,18 @@ jobs:
           fi
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        if: ${{ !inputs.skip_preflight }}
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        if: ${{ !inputs.skip_preflight }}
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'
 
       - name: Configure Talesofai npm auth
+        if: ${{ !inputs.skip_preflight }}
         run: |
           if [ -z "$GITEA_NPM_TOKEN" ]; then
             echo "GITEA_NPM_TOKEN not set; installing without private billing packages"
@@ -71,22 +75,26 @@ jobs:
           fi
 
       - name: Install dependencies
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm install --frozen-lockfile
 
       - name: Build dependency closure
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm --filter @cohub/worker... build
 
       - name: Lint
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm --filter @cohub/worker lint
 
       - name: Typecheck
+        if: ${{ !inputs.skip_preflight }}
         run: pnpm --filter @cohub/worker typecheck
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GITEA_USERNAME }}
@@ -94,17 +102,17 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch,suffix=-{{sha}}
+            type=raw,value=main-{{sha}},enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,format=short
-            type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./apps/worker/Dockerfile
@@ -119,13 +127,13 @@ jobs:
 
   deploy-dev:
     needs: build-and-push
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ inputs.skip_preflight && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     env:
       IMAGE_TAG: ${{ needs.build-and-push.outputs.image_version }}
     steps:
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 
@@ -156,11 +164,11 @@ jobs:
 
   deploy-prod:
     needs: build-and-push
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ inputs.skip_preflight && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 
@@ -205,7 +213,7 @@ jobs:
       IMAGE_TAG: ${{ needs.build-and-push.outputs.image_version }}
     steps:
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 
@@ -242,7 +250,7 @@ jobs:
       IMAGE_TAG: ${{ needs.build-and-push.outputs.image_version }}
     steps:
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.30.0'
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
 		"build": "vite build",
 		"lint": "biome lint .",
 		"lint:fix": "biome lint --write .",
-		"test": "node ../../scripts/test/run.mjs --native-types --import ./scripts/register-alias.mjs 'src/tests/**/*.test.ts'",
+		"test": "node ../../scripts/test/run.mjs --native-types --test-isolation=none --import ./scripts/register-alias.mjs 'src/tests/**/*.test.ts'",
 		"typecheck": "node ../../scripts/typecheck-web.mjs",
 		"preview": "pnpm build && wrangler dev",
 		"preview:prod": "pnpm build && wrangler dev --config wrangler.prod.toml",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -113,7 +113,7 @@
     "build": "tsdown",
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",
-    "test": "node ../../scripts/test/run.mjs 'src/**/*.test.ts' 'tests/**/*.test.ts'",
+    "test": "node ../../scripts/test/run.mjs --test-concurrency=2 'src/**/*.test.ts' 'tests/**/*.test.ts'",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- add a reusable `Verify` workflow and a path-aware `Main Deploy` orchestrator for `main` and stable version tags
- convert service deploy workflows to reusable/manual entry points, gate deploys on one full verification run, and skip duplicate host preflight work
- gate sandbox image and binary releases, preserve manual dev/prod behavior, and serialize newer main deploys with concurrency
- upgrade referenced GitHub Actions to native Node 24 releases while keeping `changesets/action@v1` for the repository's Changesets CLI v2 compatibility
- cache TypeScript/Svelte incremental typecheck state and reduce test runtime with Web single-process execution plus bounded SDK concurrency
- handle unavailable push base commits by falling back to a full verification/deploy scope, and only save typecheck caches from `main`

## Behavior

- pull requests run `CI`, which calls `Verify`
- `main` pushes run `Main Deploy` plus `Changesets`; docs-only changes stop after scope detection
- runtime changes run one full verification, then fan out only to affected service deploys
- `v*.*.*` tags run one full verification before production services and sandbox artifacts are released
- service workflows remain available through `workflow_dispatch`

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (1516 tests across 12 workspaces on the original PR base; 1516+ tests pass on the current main base)
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- force-push scope fallback simulation

Local optimized test runs completed in about 16-23 seconds versus the previous 31-34 second baseline. Warm typecheck completed in about 12 seconds versus the 22 second CI baseline; the first main run seeds the new incremental cache.

## Notes

- no changeset: this only changes internal CI/deployment behavior and test execution settings
- PR check names now include the reusable `Full verification` job; required status-check rules should use the new names if branch protection is enabled later
- Docker pushes and external deployments were not executed locally
