### PR TITLE
[codex] feat(cli): support reference_audio generation inputs

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -261,6 +261,10 @@ cohub generate "keep the character identity from all reference images" \
   --image reference_image=https://example.com/reference-1.png \
   --image reference_image=https://example.com/reference-2.png
 
+cohub generate "follow the reference soundtrack" \
+  --model minimax-h3 \
+  --audio reference_audio=https://example.com/reference.mp3
+
 cohub generate "a calm lake" \
   --model <model> \
   --async
@@ -278,9 +282,10 @@ Supported inputs:
 --video <path-or-url>
 --video reference_video=<path-or-url>
 --audio <path-or-url>
+--audio reference_audio=<path-or-url>
 ```
 
-Role-qualified media values add `meta.role` to that content block. Repeat `--image reference_image=...` for multiple reference images. Seedance role-qualified media should use public URL inputs. Do not mix first/last frame roles with reference roles in one request.
+Role-qualified media values add `meta.role` to that content block. Repeat reference inputs for multiple images, videos, or audio files. Role-qualified media should use public URL inputs. Do not mix first/last frame roles with reference roles in one request.
 
 Pass generation parameters with `--param key=value` or `--parameters '<json>'`.
 

--- a/packages/cli/src/commands/generations.ts
+++ b/packages/cli/src/commands/generations.ts
@@ -15,15 +15,15 @@ type GenerationSource =
   | { type: "url"; url: string }
   | { type: "base64"; mediaType: string; data: string };
 
-type MediaInputType = "image" | "video" | "audio";
+export type MediaInputType = "image" | "video" | "audio";
 
 const frameMediaRoles = new Set(["first_frame", "last_frame"]);
-const referenceMediaRoles = new Set(["reference_image", "reference_video"]);
+const referenceMediaRoles = new Set(["reference_image", "reference_video", "reference_audio"]);
 
 const rolesByMediaType: Record<MediaInputType, ReadonlySet<string>> = {
   image: new Set([...frameMediaRoles, "reference_image"]),
   video: new Set(["reference_video"]),
-  audio: new Set(),
+  audio: new Set(["reference_audio"]),
 };
 
 const mediaRoles = new Set([...frameMediaRoles, ...referenceMediaRoles]);
@@ -87,7 +87,7 @@ async function parseMediaInput(type: MediaInputType, rawValue: string): Promise<
   return { value, role };
 }
 
-async function contentFromPathOrUrl(type: MediaInputType, rawValue: string): Promise<GenerationContentBlock> {
+export async function contentFromPathOrUrl(type: MediaInputType, rawValue: string): Promise<GenerationContentBlock> {
   const { value, role } = await parseMediaInput(type, rawValue);
   const meta = role ? { role } : undefined;
   if (/^https?:\/\//.test(value)) {
@@ -109,7 +109,7 @@ function validateMediaRoleModes(content: GenerationContentBlock[]): void {
   if (hasFrameRole && hasReferenceRole) {
     error(
       "Invalid media role mix",
-      "Use first_frame/last_frame or reference_image/reference_video, not both.",
+      "Use first_frame/last_frame or reference_image/reference_video/reference_audio, not both.",
     );
   }
 }
@@ -268,7 +268,12 @@ export function registerGenerations(program: Command): void {
       collect,
       [],
     )
-    .option("--audio <path-or-url>", "Audio input file path or URL; repeatable", collect, [])
+    .option(
+      "--audio <path-or-url>",
+      "Audio input file path or URL; prefix with reference_audio= when needed; repeatable",
+      collect,
+      [],
+    )
     .option("--param <key=value>", "Generation parameter; repeatable, values may be JSON/number/boolean", collect, [])
     .option("--parameters <json>", "Generation parameters as a JSON object")
     .option("--meta <json>", "Meta as a JSON object")
@@ -284,6 +289,7 @@ Examples:
   COHUB_SPACE_ID=<space-id> cohub generate "Restyle this image" -m <model> --image input.png
   cohub -s <space-id> generate "Smooth transition" -m seedance-2-0-fast --image first_frame=https://example.com/first.png --image last_frame=https://example.com/last.png
   cohub -s <space-id> generate "Use these references" -m seedance-2-0-fast --image reference_image=https://example.com/a.png --image reference_image=https://example.com/b.png
+  cohub -s <space-id> generate "Follow this soundtrack" -m minimax-h3 --audio reference_audio=https://example.com/reference.mp3
   cohub -s <space-id> generate "A calm lake" -m <model> --async
 `)
     .action(async (prompt: string, opts: {

--- a/packages/cli/tests/generations.test.ts
+++ b/packages/cli/tests/generations.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Command } from "commander";
+import { contentFromPathOrUrl, registerGenerations } from "../src/commands/generations.js";
+
+test("generation audio input supports the reference_audio role", async () => {
+  const input = await contentFromPathOrUrl(
+    "audio",
+    "reference_audio=https://example.com/reference.mp3?token=a=b",
+  );
+
+  assert.deepEqual(input, {
+    type: "audio",
+    source: {
+      type: "url",
+      url: "https://example.com/reference.mp3?token=a=b",
+    },
+    meta: { role: "reference_audio" },
+  });
+});
+
+test("generation help documents reference_audio", () => {
+  const program = new Command("cohub");
+  registerGenerations(program);
+
+  const generate = program.commands.find((command) => command.name() === "generate");
+  assert.ok(generate);
+  assert.match(generate.helpInformation(), /reference_audio=/);
+});


### PR DESCRIPTION
## What changed

- Add `reference_audio` as a valid role for `--audio` generation inputs.
- Preserve the complete URL after the first role separator, including query strings containing `=`.
- Document the role-qualified audio syntax and add a CLI example.
- Add focused tests for content parsing and generated help output.

## Why

MiniMax H3 requires audio references to carry the `reference_audio` role. Previously the CLI treated this value as an unqualified file path, so the provider rejected the request because the required audio role was missing.

## Validation

- `node --import tsx --test packages/cli/tests/generations.test.ts`
- CLI typecheck
- CLI build

The repository requires Node >=24; the local validation host uses Node 20 and reports only the existing engine warning.