### PR TITLE
feat(spaces): add personal Space groups in the Mine picker

### DIFF
--- a/apps/api/src/routes/me-labels.route.ts
+++ b/apps/api/src/routes/me-labels.route.ts
@@ -1,9 +1,14 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { db } from "../db/index.js";
 import { useAuth, requireValidId } from "../lib/middleware.js";
 import {
+  createUserLabel,
+  deleteUserLabel,
   getUserResourceLabelAssignments,
+  listUserLabels,
+  listUserSpaceGroups,
   patchUserResourceLabels,
+  UserLabelError,
 } from "@cohub/core/labels";
 import type { LabelResourceType } from "@cohub/core/labels";
 import { hasPermission } from "../permissions.js";
@@ -17,6 +22,14 @@ const MAX_LABEL_REFS = 20;
 
 function parseResourceType(value: string): LabelResourceType | null {
   return RESOURCE_TYPES.has(value as LabelResourceType) ? value as LabelResourceType : null;
+}
+
+function userLabelHttpError(c: Context, error: unknown) {
+  if (error instanceof UserLabelError) {
+    if (error.kind === "not_found") return c.json({ message: error.message }, 404);
+    return c.json({ message: error.message }, 409);
+  }
+  return c.json({ message: error instanceof Error ? error.message : String(error) }, 400);
 }
 
 function parseLabelRefs(value: unknown): string[] | null {
@@ -79,6 +92,69 @@ router.patch("/resources/:resourceType/labels", async (c) => {
   );
   await dispatchUserLabelAssignmentsUpdated(user.uuid, resourceType, resourceRef, assignments.map((a) => a.labelId));
   return c.json({ assignments });
+});
+
+/**
+ * GET /api/me/labels
+ * List the viewer's private user-scope labels, including the built-in Pinned label when present.
+ * Auth-only: this is private viewer data, never another user's labels.
+ */
+router.get("/labels", async (c) => {
+  const user = useAuth(c);
+  if (user instanceof Response) return user;
+  const labels = await listUserLabels(db, user.uuid);
+  return c.json({ labels });
+});
+
+/**
+ * POST /api/me/labels
+ * Create a custom user-scope label (empty group). Body: { name }
+ * Refuses reserved Pinned; idempotent if the name already exists.
+ */
+router.post("/labels", async (c) => {
+  const user = useAuth(c);
+  if (user instanceof Response) return user;
+  const body = await c.req.json().catch(() => null);
+  if (!body || typeof body !== "object") return c.json({ message: "invalid json body" }, 400);
+  const name = (body as { name?: unknown }).name;
+  if (typeof name !== "string") return c.json({ message: "name is required" }, 400);
+  try {
+    const label = await db.transaction((tx) => createUserLabel(tx, user.uuid, name));
+    await dispatchUserLabelAssignmentsUpdated(user.uuid, "space", "", [label.id]);
+    return c.json({ label }, 201);
+  } catch (error) {
+    return userLabelHttpError(c, error);
+  }
+});
+
+/**
+ * DELETE /api/me/labels?name=
+ * Delete a custom user-scope label and its assignments. Refuses Pinned.
+ */
+router.delete("/labels", async (c) => {
+  const user = useAuth(c);
+  if (user instanceof Response) return user;
+  const name = c.req.query("name")?.trim() ?? "";
+  if (!name) return c.json({ message: "name is required" }, 400);
+  try {
+    const label = await db.transaction((tx) => deleteUserLabel(tx, user.uuid, name));
+    await dispatchUserLabelAssignmentsUpdated(user.uuid, "space", "", [label.id]);
+    return c.json({ ok: true });
+  } catch (error) {
+    return userLabelHttpError(c, error);
+  }
+});
+
+/**
+ * GET /api/me/space-groups
+ * Snapshot of the viewer's user labels with ordered space assignment ids.
+ * Includes Pinned when it exists; Mine UI hides systemKey === 'user:pinned'.
+ */
+router.get("/space-groups", async (c) => {
+  const user = useAuth(c);
+  if (user instanceof Response) return user;
+  const groups = await listUserSpaceGroups(db, user.uuid);
+  return c.json({ groups });
 });
 
 /**

--- a/apps/web/src/lib/command-palette/space-groups.ts
+++ b/apps/web/src/lib/command-palette/space-groups.ts
@@ -1,0 +1,103 @@
+import type { UserSpaceGroup } from "@neta-art/cohub";
+import type { CommandPaletteItem } from "./types";
+
+export const PINNED_USER_SYSTEM_KEY = "user:pinned";
+export const SPACE_ID_MIME = "text/cohub-space-id";
+
+export type IndexedPaletteItem = {
+	item: CommandPaletteItem;
+	index: number;
+};
+
+export type MineSpaceSection = {
+	id: string;
+	name: string;
+	items: IndexedPaletteItem[];
+};
+
+export type MineSpaceView = {
+	commands: IndexedPaletteItem[];
+	sections: MineSpaceSection[];
+	ungrouped: IndexedPaletteItem[];
+	rows: CommandPaletteItem[];
+};
+
+export function visibleUserSpaceGroups(groups: UserSpaceGroup[]) {
+	return groups.filter((group) => group.systemKey !== PINNED_USER_SYSTEM_KEY);
+}
+
+export function matchesSpaceQuery(item: CommandPaletteItem, query: string) {
+	const needle = query.trim().toLowerCase();
+	if (!needle) return true;
+	return [item.title, item.spaceName, item.excerpt].some((value) =>
+		(value ?? "").toLowerCase().includes(needle),
+	);
+}
+
+export function sectionMineSpaceItems(input: {
+	items: CommandPaletteItem[];
+	groups: UserSpaceGroup[];
+	ownerUuid?: string | null;
+	query?: string;
+	collapsedGroupIds?: Set<string>;
+}): MineSpaceView {
+	const query = input.query ?? "";
+	const hasQuery = query.trim().length > 0;
+	const collapsedGroupIds = input.collapsedGroupIds ?? new Set<string>();
+	const owned = input.items.filter((item) => {
+		if (item.type === "command") return true;
+		if (item.type !== "space") return false;
+		if (
+			input.ownerUuid &&
+			item.ownerProfile?.userUuid &&
+			item.ownerProfile.userUuid !== input.ownerUuid
+		) {
+			return false;
+		}
+		return matchesSpaceQuery(item, query);
+	});
+
+	const commands = owned.filter((item) => item.type === "command");
+	const spaces = owned.filter((item) => item.type === "space");
+	const spacesById = new Map(spaces.map((item) => [item.spaceId, item]));
+	const visibleGroups = visibleUserSpaceGroups(input.groups);
+	const assignedIds = new Set<string>();
+	const sections: MineSpaceSection[] = [];
+	let index = 0;
+
+	const commandRows = commands.map((item) => ({ item, index: index++ }));
+
+	for (const group of visibleGroups) {
+		const items = group.spaceIds
+			.map((spaceId) => spacesById.get(spaceId))
+			.filter((item): item is CommandPaletteItem => Boolean(item));
+		for (const item of items) assignedIds.add(item.spaceId);
+		if (hasQuery && items.length === 0) continue;
+		const collapsed = collapsedGroupIds.has(group.id);
+		sections.push({
+			id: group.id,
+			name: group.name,
+			items: items.map((item) => ({
+				item,
+				index: collapsed ? -1 : index++,
+			})),
+		});
+	}
+
+	const ungrouped = spaces
+		.filter((item) => !assignedIds.has(item.spaceId))
+		.map((item) => ({ item, index: index++ }));
+
+	return {
+		commands: commandRows,
+		sections,
+		ungrouped,
+		rows: [
+			...commandRows,
+			...sections.flatMap((section) =>
+				collapsedGroupIds.has(section.id) ? [] : section.items,
+			),
+			...ungrouped,
+		].map((row) => row.item),
+	};
+}

--- a/apps/web/src/lib/components/CommandPalette.svelte
+++ b/apps/web/src/lib/components/CommandPalette.svelte
@@ -10,6 +10,7 @@ import {
 	Search,
 	Tag,
 	TerminalSquare,
+	X,
 } from "lucide-svelte";
 import { onMount, tick } from "svelte";
 import { goto } from "$app/navigation";
@@ -32,14 +33,33 @@ import {
 	getRemoteResourceTypes,
 	typeLabelFor,
 } from "$lib/command-palette/scope";
+import {
+	type IndexedPaletteItem,
+	SPACE_ID_MIME,
+	sectionMineSpaceItems,
+} from "$lib/command-palette/space-groups";
 import type { CommandPaletteItem } from "$lib/command-palette/types";
 import SpaceAvatar from "$lib/components/SpaceAvatar.svelte";
+import SpacePickerMineGroups from "$lib/components/SpacePickerMineGroups.svelte";
 import ToolCallList from "$lib/components/ToolCallList.svelte";
 import UserAvatar from "$lib/components/UserAvatar.svelte";
 import { isComposingKeyboardEvent } from "$lib/keyboard";
 import { sdk } from "$lib/sdk";
 import { buildUserNewSessionRoute } from "$lib/space-routes";
 import { authStore } from "$lib/stores/auth.svelte";
+import {
+	getCollapsedSpaceGroupIds,
+	setCollapsedSpaceGroupIds,
+} from "$lib/stores/space-group-collapse";
+import {
+	addSpaceToGroup,
+	createSpaceGroup,
+	deleteSpaceGroup,
+	fetchSpaceGroupsWithCache,
+	getCachedSpaceGroups,
+	onSpaceGroupsCacheUpdated,
+	removeSpaceFromGroup,
+} from "$lib/stores/space-groups.svelte";
 import {
 	fetchSpaceListWithCache,
 	getCachedSpaceListMeta,
@@ -125,6 +145,12 @@ let runPollTimer: number | null = null;
 // in space-selection mode (query starts with `a:` or intent is new-chat).
 type SpaceFilter = SpaceFilterPref;
 let spaceFilter = $state<SpaceFilter>("all");
+let spaceGroups = $state(getCachedSpaceGroups() ?? []);
+let collapsedGroupIds = $state(getCollapsedSpaceGroupIds());
+let dropTargetGroupId = $state<string | null>(null);
+let creatingGroup = $state(false);
+let createGroupName = $state("");
+let createGroupError = $state<string | null>(null);
 
 // Pagination for Space Picker mode: load larger page sizes (e.g. 50 items per page)
 // and dynamically render more as user scrolls.
@@ -230,9 +256,21 @@ const mergedItems = $derived.by(() => {
 	return mergedItemsRaw;
 });
 const isSearching = $derived(!localDone || !remoteDone || !defaultDone);
-const renderedItems = $derived(
+const baseRenderedItems = $derived(
 	mergedItems.length > 0 || !isSearching ? mergedItems : settledItems,
 );
+const mineView = $derived.by(() => {
+	if (!isSpacePickerMode || spaceFilter !== "mine" || runMode) return null;
+	return sectionMineSpaceItems({
+		items: baseRenderedItems,
+		groups: spaceGroups,
+		ownerUuid: myUserUuid,
+		query: trimmedQuery.length >= MIN_QUERY_LENGTH ? trimmedQuery : "",
+		collapsedGroupIds,
+	});
+});
+const renderedItems = $derived(mineView?.rows ?? baseRenderedItems);
+const showingMineGroups = $derived(Boolean(mineView));
 const showingSettledItems = $derived(
 	isSearching && mergedItems.length === 0 && settledItems.length > 0,
 );
@@ -264,6 +302,81 @@ function profileFor(item: CommandPaletteItem) {
 	return item.ownerProfile?.userUuid && item.ownerProfile.displayName
 		? item.ownerProfile
 		: null;
+}
+
+function resetGroupEditor() {
+	creatingGroup = false;
+	createGroupName = "";
+	createGroupError = null;
+	dropTargetGroupId = null;
+}
+
+function toggleGroupCollapsed(groupId: string) {
+	const next = new Set(collapsedGroupIds);
+	if (next.has(groupId)) next.delete(groupId);
+	else next.add(groupId);
+	collapsedGroupIds = next;
+	setCollapsedSpaceGroupIds(next);
+}
+
+async function handleCreateGroup() {
+	const name = createGroupName.trim();
+	if (!name) return;
+	createGroupError = null;
+	try {
+		await createSpaceGroup(name);
+		spaceGroups = getCachedSpaceGroups() ?? spaceGroups;
+		resetGroupEditor();
+	} catch (error) {
+		const body =
+			error && typeof error === "object" && "body" in error
+				? (error as { body?: { message?: unknown } }).body
+				: null;
+		createGroupError =
+			typeof body?.message === "string"
+				? body.message
+				: error instanceof Error
+					? error.message
+					: "Could not create group";
+	}
+}
+
+async function handleDeleteGroup(name: string) {
+	try {
+		await deleteSpaceGroup(name);
+		spaceGroups = getCachedSpaceGroups() ?? spaceGroups;
+	} catch (error) {
+		console.warn("[palette] delete group failed", error);
+	}
+}
+
+async function handleDropSpaceOnGroup(groupId: string, spaceId: string) {
+	const group = spaceGroups.find((item) => item.id === groupId);
+	if (!group || group.spaceIds.includes(spaceId)) return;
+	try {
+		await addSpaceToGroup(spaceId, group.name);
+		spaceGroups = getCachedSpaceGroups() ?? spaceGroups;
+	} catch (error) {
+		console.warn("[palette] add to group failed", error);
+	}
+}
+
+async function handleRemoveSpaceFromGroup(spaceId: string, groupId: string) {
+	const group = spaceGroups.find((item) => item.id === groupId);
+	if (!group) return;
+	try {
+		await removeSpaceFromGroup(spaceId, group.name);
+		spaceGroups = getCachedSpaceGroups() ?? spaceGroups;
+	} catch (error) {
+		console.warn("[palette] remove from group failed", error);
+	}
+}
+
+function handleSpaceDragStart(event: DragEvent, spaceId: string) {
+	if (!event.dataTransfer) return;
+	event.dataTransfer.setData(SPACE_ID_MIME, spaceId);
+	event.dataTransfer.setData("text/plain", spaceId);
+	event.dataTransfer.effectAllowed = "copy";
 }
 
 function armPointerHover() {
@@ -367,6 +480,9 @@ function openPalette(detail?: OpenCommandPaletteDetail) {
 	query = detail?.query ?? "";
 	openIntent = detail?.intent ?? "navigate";
 	spaceFilter = getCachedSpaceFilterPref();
+	spaceGroups = getCachedSpaceGroups() ?? spaceGroups;
+	collapsedGroupIds = getCollapsedSpaceGroupIds();
+	resetGroupEditor();
 	forceSpaceRefreshForNextSearch = Boolean(detail?.refreshSpaces);
 	activeIndex = 0;
 	armPointerHover();
@@ -382,6 +498,7 @@ function closePalette() {
 	placeholder = DEFAULT_PLACEHOLDER;
 	openIntent = "navigate";
 	spaceFilter = getCachedSpaceFilterPref();
+	resetGroupEditor();
 	activeIndex = 0;
 	settledItems = [];
 	refreshingSpaces = false;
@@ -724,6 +841,19 @@ $effect(() => {
 });
 
 $effect(() => {
+	if (!open || !isSpacePickerMode || runMode) return;
+	const cached = getCachedSpaceGroups();
+	if (cached) spaceGroups = cached;
+	void fetchSpaceGroupsWithCache()
+		.then((groups) => {
+			spaceGroups = groups;
+		})
+		.catch((error) => {
+			console.warn("[command-palette] space groups refresh failed", error);
+		});
+});
+
+$effect(() => {
 	if (mergedItems.length > 0 || !isSearching) settledItems = mergedItems;
 });
 
@@ -746,6 +876,9 @@ onMount(() => {
 	const offSpaceListCache = onSpaceListCacheUpdated(() => {
 		if (open && !runMode) spaceListRefreshToken += 1;
 	});
+	const offSpaceGroupsCache = onSpaceGroupsCacheUpdated(({ groups }) => {
+		spaceGroups = groups;
+	});
 	return () => {
 		window.removeEventListener("keydown", handleGlobalKeydown, {
 			capture: true,
@@ -755,6 +888,7 @@ onMount(() => {
 			handleOpenPaletteEvent,
 		);
 		offSpaceListCache();
+		offSpaceGroupsCache();
 		localController?.abort();
 		remoteController?.abort();
 		if (debounceTimer != null) window.clearTimeout(debounceTimer);
@@ -835,7 +969,100 @@ onMount(() => {
 				</div>
 			{:else}
 				<div bind:this={resultsEl} class:searching={showingSettledItems} class="command-results" role="listbox" aria-label="Search results" onscroll={handleResultsScroll}>
-					{#if renderedItems.length === 0}
+					{#snippet paletteRow(item: CommandPaletteItem, index: number, groupId: string | null)}
+						{@const meta = typeMeta(item.type)}
+						{@const Icon = meta.icon}
+						{@const profile = profileFor(item)}
+						{@const timestamp = itemTimestamp(item)}
+						<div
+							class:active={index === activeIndex}
+							class="command-result"
+							onpointermove={() => handleResultPointerMove(index)}
+							role="option"
+							aria-selected={index === activeIndex}
+							tabindex="-1"
+						>
+							<button
+								type="button"
+								class="command-result-main"
+								draggable={showingMineGroups && item.type === "space"}
+								onclick={() => void activate(item)}
+								ondragstart={(event) => {
+									if (item.type !== "space") return;
+									handleSpaceDragStart(event, item.spaceId);
+								}}
+							>
+								{#if item.type === "space"}
+									<SpaceAvatar name={item.title || item.spaceName || item.spaceId} profile={item.spaceProfile} size="sm" />
+								{:else}
+									<div class={`command-type-mark ${meta.className}`} aria-label={item.type}>
+										<Icon class="h-3.5 w-3.5" />
+									</div>
+								{/if}
+								<div class="min-w-0 flex-1 text-left">
+									<div class="flex min-w-0 items-center gap-2">
+										<span class="truncate text-[13px] font-medium text-text-primary">{item.title}</span>
+									</div>
+									<div class="command-context-row">
+										{#if profile}
+											<span class="command-profile" title={profile.displayName}>
+												<UserAvatar name={profile.displayName} avatarUrl={profile.avatarUrl} size="xxs" class="border-0 bg-bg-primary text-[8px]" />
+												<span class="truncate">{profile.displayName}</span>
+											</span>
+											<span class="command-context-separator">·</span>
+										{/if}
+										<span class="command-context" title={contextFor(item)}>{contextFor(item)}</span>
+										{#if timestamp}
+											<span class="command-context-separator">·</span>
+											<time class="command-time" datetime={item.updatedAt ?? undefined} title={timestamp.title}>{timestamp.label}</time>
+										{/if}
+									</div>
+								</div>
+								<div class="command-enter">↵</div>
+							</button>
+							{#if showingMineGroups && groupId && item.type === "space"}
+								<button
+									type="button"
+									class="command-pin-btn command-ungroup-btn"
+									title={`Remove from group`}
+									aria-label={`Remove ${item.title} from group`}
+									onclick={(event) => {
+										event.stopPropagation();
+										void handleRemoveSpaceFromGroup(item.spaceId, groupId);
+									}}
+								>
+									<X class="h-3.5 w-3.5" />
+								</button>
+							{/if}
+							{#if isSpacePickerMode && item.type === "space"}
+								<button
+									type="button"
+									class="command-pin-btn"
+									class:pinned={item.isPinned}
+									title={item.isPinned ? "Unpin" : "Pin"}
+									aria-label={item.isPinned ? `Unpin ${item.title}` : `Pin ${item.title}`}
+									onclick={(e) => {
+								e.stopPropagation();
+								const wasPinned = item.isPinned ?? false;
+								syncPinStateInItems(item.spaceId, !wasPinned);
+								void toggleSpacePin(item.spaceId).catch((err) => {
+									console.warn("[palette] pin toggle failed", err);
+									syncPinStateInItems(item.spaceId, wasPinned);
+								});
+							}}
+								>
+									<Pin class="h-3.5 w-3.5" />
+								</button>
+							{/if}
+						</div>
+					{/snippet}
+					{#snippet mineCommandRow(row: IndexedPaletteItem)}
+						{@render paletteRow(row.item, row.index, null)}
+					{/snippet}
+					{#snippet mineSpaceRow(row: IndexedPaletteItem, groupId: string | null)}
+						{@render paletteRow(row.item, row.index, groupId)}
+					{/snippet}
+					{#if renderedItems.length === 0 && !mineView?.sections.length}
 						<div class="command-empty">
 							<div class="command-empty-mark"><CornerDownRight class="h-4 w-4" /></div>
 							<div>
@@ -853,6 +1080,8 @@ onMount(() => {
 								<div class="mt-1 text-[12px] text-text-tertiary">
 									{#if isSpacePickerMode && spaceFilter === "pinned"}
 										Pin a space to bookmark it here.
+									{:else if isSpacePickerMode && spaceFilter === "mine"}
+										Create a group to organize the Spaces you own.
 									{:else if trimmedQuery.length < MIN_QUERY_LENGTH && !hasLabelScope}
 										Try label:bug for labels, a: for spaces, or t: for turns.
 									{:else}
@@ -861,74 +1090,57 @@ onMount(() => {
 								</div>
 							</div>
 						</div>
+						{#if showingMineGroups}
+							<SpacePickerMineGroups
+								commands={[]}
+								sections={[]}
+								ungrouped={[]}
+								{collapsedGroupIds}
+								dropTargetId={dropTargetGroupId}
+								creating={creatingGroup}
+								createName={createGroupName}
+								createError={createGroupError}
+								commandRow={mineCommandRow}
+								spaceRow={mineSpaceRow}
+								onToggleCollapsed={toggleGroupCollapsed}
+								onDeleteGroup={(name) => void handleDeleteGroup(name)}
+								onDropSpace={(groupId, spaceId) => void handleDropSpaceOnGroup(groupId, spaceId)}
+								onDragOverGroup={(groupId) => { dropTargetGroupId = groupId; }}
+								onStartCreate={() => { creatingGroup = true; createGroupError = null; }}
+								onCancelCreate={resetGroupEditor}
+								onCreateNameInput={(value) => { createGroupName = value; }}
+								onSubmitCreate={() => void handleCreateGroup()}
+							/>
+						{/if}
+					{:else if showingMineGroups && mineView}
+						<SpacePickerMineGroups
+							commands={mineView.commands}
+							sections={mineView.sections}
+							ungrouped={mineView.ungrouped}
+							{collapsedGroupIds}
+							dropTargetId={dropTargetGroupId}
+							creating={creatingGroup}
+							createName={createGroupName}
+							createError={createGroupError}
+							commandRow={mineCommandRow}
+							spaceRow={mineSpaceRow}
+							onToggleCollapsed={toggleGroupCollapsed}
+							onDeleteGroup={(name) => void handleDeleteGroup(name)}
+							onDropSpace={(groupId, spaceId) => void handleDropSpaceOnGroup(groupId, spaceId)}
+							onDragOverGroup={(groupId) => { dropTargetGroupId = groupId; }}
+							onStartCreate={() => { creatingGroup = true; createGroupError = null; }}
+							onCancelCreate={resetGroupEditor}
+							onCreateNameInput={(value) => { createGroupName = value; }}
+							onSubmitCreate={() => void handleCreateGroup()}
+						/>
+						{#if isSpacePickerMode && mergedItemsRaw.length > spaceDisplayLimit}
+							<div class="flex items-center justify-center py-2 text-[11px] text-text-tertiary">
+								<span>Showing {spaceDisplayLimit} of {mergedItemsRaw.length} spaces · scroll for more</span>
+							</div>
+						{/if}
 					{:else}
 						{#each renderedItems as item, index (`${item.type}:${item.id || item.turnId || item.sessionId || item.spaceId}`)}
-							{@const meta = typeMeta(item.type)}
-							{@const Icon = meta.icon}
-							{@const profile = profileFor(item)}
-							{@const timestamp = itemTimestamp(item)}
-							<div
-								class:active={index === activeIndex}
-								class="command-result"
-								onpointermove={() => handleResultPointerMove(index)}
-								role="option"
-								aria-selected={index === activeIndex}
-								tabindex="-1"
-							>
-								<button
-									type="button"
-									class="command-result-main"
-									onclick={() => void activate(item)}
-								>
-									{#if item.type === "space"}
-										<SpaceAvatar name={item.title || item.spaceName || item.spaceId} profile={item.spaceProfile} size="sm" />
-									{:else}
-										<div class={`command-type-mark ${meta.className}`} aria-label={item.type}>
-											<Icon class="h-3.5 w-3.5" />
-										</div>
-									{/if}
-									<div class="min-w-0 flex-1 text-left">
-										<div class="flex min-w-0 items-center gap-2">
-											<span class="truncate text-[13px] font-medium text-text-primary">{item.title}</span>
-										</div>
-										<div class="command-context-row">
-											{#if profile}
-												<span class="command-profile" title={profile.displayName}>
-													<UserAvatar name={profile.displayName} avatarUrl={profile.avatarUrl} size="xxs" class="border-0 bg-bg-primary text-[8px]" />
-													<span class="truncate">{profile.displayName}</span>
-												</span>
-												<span class="command-context-separator">·</span>
-											{/if}
-											<span class="command-context" title={contextFor(item)}>{contextFor(item)}</span>
-											{#if timestamp}
-												<span class="command-context-separator">·</span>
-												<time class="command-time" datetime={item.updatedAt ?? undefined} title={timestamp.title}>{timestamp.label}</time>
-											{/if}
-										</div>
-									</div>
-									<div class="command-enter">↵</div>
-								</button>
-								{#if isSpacePickerMode && item.type === "space"}
-									<button
-										type="button"
-										class="command-pin-btn"
-										class:pinned={item.isPinned}
-										title={item.isPinned ? "Unpin" : "Pin"}
-										aria-label={item.isPinned ? `Unpin ${item.title}` : `Pin ${item.title}`}
-										onclick={(e) => {
-									e.stopPropagation();
-									const wasPinned = item.isPinned ?? false;
-									syncPinStateInItems(item.spaceId, !wasPinned);
-									void toggleSpacePin(item.spaceId).catch((err) => {
-										console.warn("[palette] pin toggle failed", err);
-										syncPinStateInItems(item.spaceId, wasPinned);
-									});
-								}}
-									>
-										<Pin class="h-3.5 w-3.5" />
-									</button>
-								{/if}
-							</div>
+							{@render paletteRow(item, index, null)}
 						{/each}
 						{#if isSpacePickerMode && mergedItemsRaw.length > spaceDisplayLimit}
 							<div class="flex items-center justify-center py-2 text-[11px] text-text-tertiary">
@@ -1084,6 +1296,10 @@ onMount(() => {
 	.command-pin-btn.pinned {
 		opacity: 1;
 		color: var(--brand);
+	}
+
+	.command-ungroup-btn:hover {
+		color: var(--error-700);
 	}
 
 	.command-pin-btn:hover {
@@ -1339,6 +1555,10 @@ onMount(() => {
 		.command-pin-btn:not(.pinned) {
 			width: 44px;
 			height: 44px;
+			opacity: 1;
+		}
+
+		.command-ungroup-btn {
 			opacity: 1;
 		}
 

--- a/apps/web/src/lib/components/SpacePickerMineGroups.svelte
+++ b/apps/web/src/lib/components/SpacePickerMineGroups.svelte
@@ -1,0 +1,366 @@
+<script lang="ts">
+import { ChevronDown, Folder, Plus, Trash2 } from "lucide-svelte";
+import { type Snippet, tick } from "svelte";
+import {
+	type IndexedPaletteItem,
+	type MineSpaceSection,
+	SPACE_ID_MIME,
+} from "$lib/command-palette/space-groups";
+
+type Props = {
+	commands: IndexedPaletteItem[];
+	sections: MineSpaceSection[];
+	ungrouped: IndexedPaletteItem[];
+	collapsedGroupIds: Set<string>;
+	dropTargetId: string | null;
+	creating: boolean;
+	createName: string;
+	createError: string | null;
+	commandRow: Snippet<[IndexedPaletteItem]>;
+	spaceRow: Snippet<[IndexedPaletteItem, string | null]>;
+	onToggleCollapsed: (id: string) => void;
+	onDeleteGroup: (name: string) => void;
+	onDropSpace: (groupId: string, spaceId: string) => void;
+	onDragOverGroup: (groupId: string | null) => void;
+	onStartCreate: () => void;
+	onCancelCreate: () => void;
+	onCreateNameInput: (value: string) => void;
+	onSubmitCreate: () => void;
+};
+
+let {
+	commands,
+	sections,
+	ungrouped,
+	collapsedGroupIds,
+	dropTargetId,
+	creating,
+	createName,
+	createError,
+	commandRow,
+	spaceRow,
+	onToggleCollapsed,
+	onDeleteGroup,
+	onDropSpace,
+	onDragOverGroup,
+	onStartCreate,
+	onCancelCreate,
+	onCreateNameInput,
+	onSubmitCreate,
+}: Props = $props();
+
+let createInputEl = $state<HTMLInputElement | null>(null);
+
+$effect(() => {
+	if (!creating) return;
+	void tick().then(() => createInputEl?.focus());
+});
+
+function readSpaceId(dataTransfer: DataTransfer | null) {
+	if (!dataTransfer) return "";
+	return (
+		dataTransfer.getData(SPACE_ID_MIME) || dataTransfer.getData("text/plain")
+	).trim();
+}
+
+function handleDragOver(event: DragEvent, groupId: string) {
+	if (!event.dataTransfer) return;
+	const types = Array.from(event.dataTransfer.types);
+	if (!types.includes(SPACE_ID_MIME) && !types.includes("text/plain")) return;
+	event.preventDefault();
+	event.dataTransfer.dropEffect = "copy";
+	onDragOverGroup(groupId);
+}
+
+function handleDrop(event: DragEvent, groupId: string) {
+	event.preventDefault();
+	const spaceId = readSpaceId(event.dataTransfer);
+	onDragOverGroup(null);
+	if (spaceId) onDropSpace(groupId, spaceId);
+}
+
+function handleCreateKeydown(event: KeyboardEvent) {
+	if (event.key === "Enter") {
+		event.preventDefault();
+		event.stopPropagation();
+		onSubmitCreate();
+		return;
+	}
+	if (event.key === "Escape") {
+		event.preventDefault();
+		event.stopPropagation();
+		onCancelCreate();
+	}
+}
+</script>
+
+<div class="mine-groups">
+	{#each commands as command (command.item.id)}
+		{@render commandRow(command)}
+	{/each}
+
+	{#each sections as section (section.id)}
+		{@const collapsed = collapsedGroupIds.has(section.id)}
+		<div
+			class="mine-group"
+			class:drop-target={dropTargetId === section.id}
+			ondragenter={(event) => handleDragOver(event, section.id)}
+			ondragover={(event) => handleDragOver(event, section.id)}
+			ondragleave={(event) => {
+				if (!(event.currentTarget as HTMLElement).contains(event.relatedTarget as Node)) {
+					onDragOverGroup(null);
+				}
+			}}
+			ondrop={(event) => handleDrop(event, section.id)}
+			role="presentation"
+		>
+			<div class="mine-group-header">
+				<button
+					type="button"
+					class="mine-group-toggle"
+					aria-expanded={!collapsed}
+					onclick={() => onToggleCollapsed(section.id)}
+				>
+					<span class="mine-chevron" class:collapsed>
+						<ChevronDown class="h-3.5 w-3.5" />
+					</span>
+					<Folder class="h-3.5 w-3.5" />
+					<span class="mine-group-name">{section.name}</span>
+					<span class="mine-group-count">{section.items.length}</span>
+				</button>
+				<button
+					type="button"
+					class="mine-group-delete"
+					title={`Delete ${section.name}`}
+					aria-label={`Delete group ${section.name}`}
+					onclick={() => onDeleteGroup(section.name)}
+				>
+					<Trash2 class="h-3.5 w-3.5" />
+				</button>
+			</div>
+			{#if !collapsed}
+				{#if section.items.length === 0}
+					<div class="mine-group-empty">Drop a Space here</div>
+				{:else}
+					{#each section.items as row (`${section.id}:${row.item.spaceId}`)}
+						{@render spaceRow(row, section.id)}
+					{/each}
+				{/if}
+			{/if}
+		</div>
+	{/each}
+
+	{#if sections.length > 0 && ungrouped.length > 0}
+		<div class="mine-ungrouped-label">Ungrouped</div>
+	{/if}
+	{#each ungrouped as row (`ungrouped:${row.item.spaceId}`)}
+		{@render spaceRow(row, null)}
+	{/each}
+
+	<div class="mine-create">
+		{#if creating}
+			<input
+				bind:this={createInputEl}
+				class="mine-create-input"
+				value={createName}
+				placeholder="Group name"
+				autocomplete="off"
+				spellcheck="false"
+				oninput={(event) => onCreateNameInput((event.currentTarget as HTMLInputElement).value)}
+				onkeydown={handleCreateKeydown}
+			/>
+			<button type="button" class="mine-create-submit" onclick={onSubmitCreate}>Create</button>
+			<button type="button" class="mine-create-cancel" onclick={onCancelCreate}>Cancel</button>
+		{:else}
+			<button type="button" class="mine-create-btn" onclick={onStartCreate}>
+				<Plus class="h-3.5 w-3.5" />
+				New group
+			</button>
+		{/if}
+		{#if createError}
+			<div class="mine-create-error">{createError}</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.mine-groups {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.mine-group {
+		border-radius: 9px;
+		padding: 2px 0;
+	}
+
+	.mine-group.drop-target {
+		background: color-mix(in oklch, var(--brand-bg) 42%, transparent);
+		box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brand) 28%, transparent);
+	}
+
+	.mine-group-header {
+		display: flex;
+		align-items: center;
+		gap: 2px;
+		padding: 0 4px;
+	}
+
+	.mine-group-toggle {
+		display: flex;
+		min-width: 0;
+		flex: 1;
+		align-items: center;
+		gap: 8px;
+		border: 0;
+		background: transparent;
+		padding: 6px 8px;
+		border-radius: 7px;
+		color: var(--text-secondary);
+		font-size: 12px;
+		font-weight: 500;
+		cursor: pointer;
+	}
+
+	.mine-group-toggle:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.mine-group-toggle:focus-visible,
+	.mine-group-delete:focus-visible,
+	.mine-create-btn:focus-visible,
+	.mine-create-submit:focus-visible,
+	.mine-create-cancel:focus-visible,
+	.mine-create-input:focus-visible {
+		outline: 2px solid color-mix(in oklch, var(--brand) 42%, transparent);
+		outline-offset: -2px;
+	}
+
+	.mine-group-name {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.mine-group-count {
+		margin-left: auto;
+		color: var(--text-placeholder);
+		font-family: var(--font-mono);
+		font-size: 10px;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.mine-chevron {
+		display: grid;
+		width: 14px;
+		height: 14px;
+		flex: 0 0 auto;
+		place-items: center;
+		color: var(--text-tertiary);
+		transition: transform 120ms cubic-bezier(0.25, 1, 0.5, 1);
+	}
+
+	.mine-chevron.collapsed {
+		transform: rotate(-90deg);
+	}
+
+	.mine-group-delete {
+		display: grid;
+		place-items: center;
+		width: 28px;
+		height: 28px;
+		border: 0;
+		border-radius: 7px;
+		background: transparent;
+		color: var(--text-tertiary);
+		opacity: 0;
+		cursor: pointer;
+	}
+
+	.mine-group-header:hover .mine-group-delete,
+	.mine-group-delete:focus-visible {
+		opacity: 1;
+	}
+
+	.mine-group-delete:hover {
+		background: var(--bg-hover);
+		color: var(--error-700);
+	}
+
+	.mine-group-empty {
+		padding: 6px 16px 8px 36px;
+		color: var(--text-placeholder);
+		font-size: 12px;
+	}
+
+	.mine-ungrouped-label {
+		padding: 8px 12px 2px;
+		color: var(--text-placeholder);
+		font-size: 11px;
+		font-weight: 500;
+	}
+
+	.mine-create {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 6px;
+		padding: 6px 8px 4px;
+	}
+
+	.mine-create-btn,
+	.mine-create-submit,
+	.mine-create-cancel {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		border: 0;
+		border-radius: 6px;
+		background: transparent;
+		padding: 4px 8px;
+		color: var(--text-tertiary);
+		font-size: 12px;
+		cursor: pointer;
+	}
+
+	.mine-create-btn:hover,
+	.mine-create-submit:hover,
+	.mine-create-cancel:hover {
+		background: var(--bg-hover);
+		color: var(--text-secondary);
+	}
+
+	.mine-create-input {
+		min-width: 0;
+		flex: 1;
+		border: 1px solid var(--border-subtle);
+		border-radius: 6px;
+		background: var(--bg-primary);
+		padding: 4px 8px;
+		color: var(--text-primary);
+		font-size: 12px;
+	}
+
+	.mine-create-error {
+		width: 100%;
+		color: var(--error-700);
+		font-size: 11px;
+	}
+
+	@media (max-width: 640px) {
+		.mine-group-delete {
+			opacity: 1;
+			width: 44px;
+			height: 44px;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.mine-chevron {
+			transition: none;
+		}
+	}
+</style>

--- a/apps/web/src/lib/stores/space-group-collapse.ts
+++ b/apps/web/src/lib/stores/space-group-collapse.ts
@@ -1,0 +1,34 @@
+import { getCacheUserKey } from "$lib/cache/keys";
+
+const VERSION = 1;
+const PREFIX = "cohub:space-group-collapse";
+
+function isBrowser() {
+	return typeof window !== "undefined" && typeof localStorage !== "undefined";
+}
+
+function storageKey() {
+	return `${PREFIX}:${encodeURIComponent(getCacheUserKey())}:v${VERSION}`;
+}
+
+export function getCollapsedSpaceGroupIds(): Set<string> {
+	if (!isBrowser()) return new Set();
+	try {
+		const raw = localStorage.getItem(storageKey());
+		if (!raw) return new Set();
+		const parsed = JSON.parse(raw) as unknown;
+		if (!Array.isArray(parsed)) return new Set();
+		return new Set(parsed.filter((id): id is string => typeof id === "string"));
+	} catch {
+		return new Set();
+	}
+}
+
+export function setCollapsedSpaceGroupIds(ids: Set<string>) {
+	if (!isBrowser()) return;
+	try {
+		localStorage.setItem(storageKey(), JSON.stringify([...ids]));
+	} catch {
+		// localStorage may be unavailable or full; runtime state remains authoritative.
+	}
+}

--- a/apps/web/src/lib/stores/space-groups.svelte.ts
+++ b/apps/web/src/lib/stores/space-groups.svelte.ts
@@ -1,0 +1,161 @@
+import type { UserSpaceGroup } from "@neta-art/cohub";
+import { sdk } from "$lib/sdk";
+import { authStore } from "$lib/stores/auth.svelte";
+import { createLocalListCache } from "$lib/stores/create-local-list-cache";
+
+/**
+ * Personal Space group cache — viewer-private user labels with space ids.
+ *
+ * Reuses the space-list cache helper so Mine can render immediately from
+ * localStorage, then silently refresh. Realtime `label.assignments.updated`
+ * events (user room) refetch the snapshot.
+ */
+
+const GROUPS_SCOPE = "mine";
+
+function normalizeGroups(groups: UserSpaceGroup[]) {
+	const byId = new Map<string, UserSpaceGroup>();
+	for (const group of groups) {
+		byId.set(group.id, {
+			...group,
+			spaceIds: [...new Set(group.spaceIds)],
+		});
+	}
+	return Array.from(byId.values()).sort((a, b) =>
+		a.rank !== b.rank ? a.rank - b.rank : a.name.localeCompare(b.name),
+	);
+}
+
+const cache = createLocalListCache<UserSpaceGroup>({
+	storagePrefix: "cohub:space-groups",
+	cacheVersion: 1,
+	updatedEventName: "cohub:space-groups-updated",
+	ttlMs: 60_000,
+	normalize: normalizeGroups,
+});
+
+let realtimeBound = false;
+
+export function initSpaceGroupRealtime() {
+	if (realtimeBound || typeof window === "undefined") return;
+	realtimeBound = true;
+	sdk.onUserEvent((event) => {
+		if (event.type !== "label.assignments.updated") return;
+		void refreshSpaceGroups();
+	});
+}
+
+export function getCachedSpaceGroups(): UserSpaceGroup[] | null {
+	return cache.getCached(GROUPS_SCOPE);
+}
+
+export function onSpaceGroupsCacheUpdated(
+	handler: (event: { groups: UserSpaceGroup[] }) => void,
+) {
+	return cache.onUpdated(({ data }) => {
+		handler({ groups: data });
+	});
+}
+
+async function loadSpaceGroups() {
+	const result = await sdk.user.labels.listSpaceGroups();
+	return result.groups;
+}
+
+export async function fetchSpaceGroupsWithCache(options?: { force?: boolean }) {
+	await authStore.ensureLoaded();
+	return cache.fetchWithCache(GROUPS_SCOPE, loadSpaceGroups, options);
+}
+
+async function refreshSpaceGroups() {
+	try {
+		await fetchSpaceGroupsWithCache({ force: true });
+	} catch {
+		// Non-critical: the next picker open will reconcile.
+	}
+}
+
+function setGroups(groups: UserSpaceGroup[]) {
+	return cache.setCached(GROUPS_SCOPE, groups);
+}
+
+export async function createSpaceGroup(name: string) {
+	await authStore.ensureLoaded();
+	const result = await sdk.user.labels.create(name);
+	const label = result.label;
+	cache.patchCached(GROUPS_SCOPE, (groups) => {
+		if (groups.some((group) => group.id === label.id)) {
+			return groups.map((group) =>
+				group.id === label.id
+					? { ...group, name: label.name, rank: label.rank }
+					: group,
+			);
+		}
+		return [
+			...groups,
+			{
+				id: label.id,
+				name: label.name,
+				systemKey: label.systemKey,
+				rank: label.rank,
+				spaceIds: [],
+			},
+		];
+	});
+	return label;
+}
+
+export async function deleteSpaceGroup(name: string) {
+	await authStore.ensureLoaded();
+	const previous = getCachedSpaceGroups() ?? [];
+	setGroups(
+		previous.filter((group) => group.name.toLowerCase() !== name.toLowerCase()),
+	);
+	try {
+		await sdk.user.labels.remove(name);
+	} catch (error) {
+		setGroups(previous);
+		throw error;
+	}
+}
+
+export async function addSpaceToGroup(spaceId: string, groupName: string) {
+	await authStore.ensureLoaded();
+	const previous = getCachedSpaceGroups() ?? [];
+	setGroups(
+		previous.map((group) =>
+			group.name.toLowerCase() === groupName.toLowerCase() &&
+			!group.spaceIds.includes(spaceId)
+				? { ...group, spaceIds: [...group.spaceIds, spaceId] }
+				: group,
+		),
+	);
+	try {
+		await sdk.user.labels.patchResourceLabels("space", spaceId, {
+			addLabelRefs: [groupName],
+		});
+	} catch (error) {
+		setGroups(previous);
+		throw error;
+	}
+}
+
+export async function removeSpaceFromGroup(spaceId: string, groupName: string) {
+	await authStore.ensureLoaded();
+	const previous = getCachedSpaceGroups() ?? [];
+	setGroups(
+		previous.map((group) =>
+			group.name.toLowerCase() === groupName.toLowerCase()
+				? { ...group, spaceIds: group.spaceIds.filter((id) => id !== spaceId) }
+				: group,
+		),
+	);
+	try {
+		await sdk.user.labels.patchResourceLabels("space", spaceId, {
+			removeLabelRefs: [groupName],
+		});
+	} catch (error) {
+		setGroups(previous);
+		throw error;
+	}
+}

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -40,6 +40,7 @@ import {
 } from "$lib/navigation-transition";
 import { activateSpaceStyle, deactivateSpaceStyle } from "$lib/space-style";
 import { authStore } from "$lib/stores/auth.svelte";
+import { initSpaceGroupRealtime } from "$lib/stores/space-groups.svelte";
 import { initSpacePinRealtime } from "$lib/stores/space-pins.svelte";
 import { turnNotifications } from "$lib/stores/turn-notifications.svelte";
 import {
@@ -571,6 +572,7 @@ onMount(() => {
 			stopUiCommands = startUiCommandListener();
 		}
 		initSpacePinRealtime();
+		initSpaceGroupRealtime();
 	});
 
 	// Register PWA Service Worker (conservative update: closes all tabs to activate)

--- a/apps/web/src/tests/space-picker-mine-groups.test.ts
+++ b/apps/web/src/tests/space-picker-mine-groups.test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { UserSpaceGroup } from "@neta-art/cohub";
+import {
+	PINNED_USER_SYSTEM_KEY,
+	sectionMineSpaceItems,
+	visibleUserSpaceGroups,
+} from "../lib/command-palette/space-groups";
+import type { CommandPaletteItem } from "../lib/command-palette/types";
+
+function spaceItem(
+	partial: Pick<CommandPaletteItem, "id" | "title"> &
+		Partial<CommandPaletteItem> & { ownerUuid?: string },
+): CommandPaletteItem {
+	return {
+		type: "space",
+		id: partial.id,
+		spaceId: partial.spaceId ?? partial.id,
+		sessionId: null,
+		turnId: null,
+		sequence: null,
+		title: partial.title,
+		excerpt: partial.excerpt ?? null,
+		spaceName: partial.spaceName ?? partial.title,
+		ownerProfile: {
+			userUuid: partial.ownerUuid ?? "me",
+			displayName: "Me",
+			avatarUrl: null,
+		},
+		spaceProfile: null,
+		sessionTitle: null,
+		matchedField: "name",
+		href: `/spaces/${partial.id}`,
+		score: 1,
+		textScore: 1,
+		recencyScore: 1,
+		typePriorityScore: 1,
+		updatedAt: null,
+		source: "default",
+		isPinned: partial.isPinned ?? false,
+	};
+}
+
+function group(
+	partial: Pick<UserSpaceGroup, "id" | "name"> & Partial<UserSpaceGroup>,
+): UserSpaceGroup {
+	return {
+		id: partial.id,
+		name: partial.name,
+		systemKey: partial.systemKey ?? null,
+		rank: partial.rank ?? 10,
+		spaceIds: partial.spaceIds ?? [],
+	};
+}
+
+const mine = spaceItem({ id: "owned-1", title: "Alpha", ownerUuid: "me" });
+const mineBeta = spaceItem({
+	id: "owned-2",
+	title: "Beta Lab",
+	ownerUuid: "me",
+});
+const other = spaceItem({ id: "other-1", title: "Shared", ownerUuid: "them" });
+const command: CommandPaletteItem = {
+	...spaceItem({ id: "new-space", title: "New Space" }),
+	type: "command",
+	spaceId: "",
+	excerpt: "Create a space",
+	matchedField: "command",
+	href: "/spaces/new",
+};
+
+describe("visibleUserSpaceGroups", () => {
+	test("hides Pinned from the Mine group list", () => {
+		const visible = visibleUserSpaceGroups([
+			group({
+				id: "pinned",
+				name: "Pinned",
+				systemKey: PINNED_USER_SYSTEM_KEY,
+				spaceIds: ["owned-1"],
+			}),
+			group({ id: "work", name: "Work", spaceIds: ["owned-1"] }),
+		]);
+		assert.deepEqual(
+			visible.map((item) => item.name),
+			["Work"],
+		);
+	});
+});
+
+describe("sectionMineSpaceItems", () => {
+	test("keeps owned spaces only and leaves others out", () => {
+		const view = sectionMineSpaceItems({
+			items: [mine, other, command],
+			groups: [],
+			ownerUuid: "me",
+		});
+		assert.deepEqual(
+			view.rows.map((item) => item.id),
+			["new-space", "owned-1"],
+		);
+		assert.equal(view.ungrouped[0]?.item.id, "owned-1");
+	});
+
+	test("hides Pinned and still shows those spaces as ungrouped", () => {
+		const view = sectionMineSpaceItems({
+			items: [mine, mineBeta],
+			groups: [
+				group({
+					id: "pinned",
+					name: "Pinned",
+					systemKey: PINNED_USER_SYSTEM_KEY,
+					spaceIds: ["owned-1"],
+				}),
+			],
+			ownerUuid: "me",
+		});
+		assert.deepEqual(view.sections, []);
+		assert.deepEqual(
+			view.ungrouped.map((row) => row.item.id),
+			["owned-1", "owned-2"],
+		);
+	});
+
+	test("allows a space to appear in multiple groups", () => {
+		const view = sectionMineSpaceItems({
+			items: [mine, mineBeta],
+			groups: [
+				group({
+					id: "clients",
+					name: "Clients",
+					rank: 10,
+					spaceIds: ["owned-1"],
+				}),
+				group({
+					id: "urgent",
+					name: "Urgent",
+					rank: 20,
+					spaceIds: ["owned-1", "owned-2"],
+				}),
+			],
+			ownerUuid: "me",
+		});
+		assert.deepEqual(
+			view.sections.map((section) => [
+				section.name,
+				section.items.map((row) => row.item.id),
+			]),
+			[
+				["Clients", ["owned-1"]],
+				["Urgent", ["owned-1", "owned-2"]],
+			],
+		);
+		assert.deepEqual(view.ungrouped, []);
+		assert.deepEqual(
+			view.rows.map((item) => item.id),
+			["owned-1", "owned-1", "owned-2"],
+		);
+	});
+
+	test("filters spaces by query and hides groups with no match", () => {
+		const view = sectionMineSpaceItems({
+			items: [mine, mineBeta],
+			groups: [
+				group({ id: "clients", name: "Clients", spaceIds: ["owned-1"] }),
+				group({ id: "labs", name: "Labs", spaceIds: ["owned-2"] }),
+				group({ id: "empty", name: "Empty", spaceIds: [] }),
+			],
+			ownerUuid: "me",
+			query: "lab",
+		});
+		assert.deepEqual(
+			view.sections.map((section) => section.name),
+			["Labs"],
+		);
+		assert.deepEqual(
+			view.sections[0]?.items.map((row) => row.item.id),
+			["owned-2"],
+		);
+		assert.deepEqual(view.ungrouped, []);
+	});
+
+	test("puts remaining owned spaces in the ungrouped remainder", () => {
+		const view = sectionMineSpaceItems({
+			items: [mine, mineBeta],
+			groups: [
+				group({ id: "clients", name: "Clients", spaceIds: ["owned-1"] }),
+			],
+			ownerUuid: "me",
+		});
+		assert.deepEqual(
+			view.sections[0]?.items.map((row) => row.item.id),
+			["owned-1"],
+		);
+		assert.deepEqual(
+			view.ungrouped.map((row) => row.item.id),
+			["owned-2"],
+		);
+	});
+
+	test("omits collapsed group spaces from keyboard rows", () => {
+		const view = sectionMineSpaceItems({
+			items: [mine, mineBeta],
+			groups: [
+				group({ id: "clients", name: "Clients", spaceIds: ["owned-1"] }),
+				group({ id: "labs", name: "Labs", spaceIds: ["owned-2"] }),
+			],
+			ownerUuid: "me",
+			collapsedGroupIds: new Set(["clients"]),
+		});
+		assert.equal(view.sections[0]?.items[0]?.index, -1);
+		assert.deepEqual(
+			view.rows.map((item) => item.id),
+			["owned-2"],
+		);
+	});
+
+	test("keeps empty groups when not filtering", () => {
+		const view = sectionMineSpaceItems({
+			items: [mine],
+			groups: [group({ id: "empty", name: "Empty", spaceIds: [] })],
+			ownerUuid: "me",
+		});
+		assert.equal(view.sections[0]?.name, "Empty");
+		assert.deepEqual(view.sections[0]?.items, []);
+		assert.equal(view.ungrouped[0]?.item.id, "owned-1");
+	});
+});

--- a/packages/cli/src/commands/spaces.ts
+++ b/packages/cli/src/commands/spaces.ts
@@ -515,18 +515,28 @@ export function registerSpaces(program: Command): void {
     .description("List all spaces")
     .option("--mine", "Only spaces you own")
     .option("--pinned", "Only pinned spaces")
+    .option("--group <name>", "Only spaces in this personal group")
     .option("--json", "Output as JSON")
-    .action(async (opts: { mine?: boolean; pinned?: boolean; json?: boolean }) => {
+    .action(async (opts: { mine?: boolean; pinned?: boolean; group?: string; json?: boolean }) => {
       const client = createClient();
       try {
-        const [items, me] = await Promise.all([
+        const [items, me, groups] = await Promise.all([
           client.spaces.list(),
           opts.mine ? client.user.getMe() : Promise.resolve(null),
+          opts.group ? client.user.labels.listSpaceGroups() : Promise.resolve(null),
         ]);
         const myUuid = me?.uuid ?? null;
+        const groupName = opts.group?.trim().toLowerCase() ?? "";
+        const groupSpaceIds = groupName
+          ? new Set(groups?.groups.find((group) => group.name.toLowerCase() === groupName)?.spaceIds ?? [])
+          : null;
+        if (opts.group && groupSpaceIds && !groups?.groups.some((group) => group.name.toLowerCase() === groupName)) {
+          return error("Group not found", `No personal group named "${opts.group.trim()}".`);
+        }
         const filtered = items.filter((item) => {
           if (opts.mine && myUuid && item.userUuid !== myUuid) return false;
           if (opts.pinned && !item.isPinned) return false;
+          if (groupSpaceIds && !groupSpaceIds.has(item.id)) return false;
           return true;
         });
         if (jsonRequested(opts)) return outJson(filtered);
@@ -748,6 +758,90 @@ export function registerSpaces(program: Command): void {
       try {
         await client.user.labels.patchResourceLabels("space", id.trim(), { removeLabelRefs: ["Pinned"] });
         ok("Space unpinned");
+      } catch (e: unknown) {
+        handleHttp(e);
+      }
+    });
+
+  // ── spaces groups (personal user-scope labels; not Space-scoped labels) ──
+  const groupsCmd = spacesCmd
+    .command("groups")
+    .description("Manage personal Space groups");
+
+  groupsCmd
+    .command("ls")
+    .alias("list")
+    .description("List personal Space groups")
+    .option("--json", "Output as JSON")
+    .action(async (opts: { json?: boolean }) => {
+      const client = createClient();
+      try {
+        const result = await client.user.labels.listSpaceGroups();
+        if (jsonRequested(opts)) return outJson(result.groups);
+        table(result.groups.map((group) => ({
+          name: group.name,
+          systemKey: group.systemKey ?? "",
+          spaces: group.spaceIds.length,
+        })), [
+          { key: "name", label: "Name" },
+          { key: "systemKey", label: "System" },
+          { key: "spaces", label: "Spaces" },
+        ]);
+      } catch (e: unknown) {
+        handleHttp(e);
+      }
+    });
+
+  groupsCmd
+    .command("create <name>")
+    .description("Create a personal Space group")
+    .option("--json", "Output as JSON")
+    .action(async (name: string, opts: { json?: boolean }) => {
+      const client = createClient();
+      try {
+        const result = await client.user.labels.create(name);
+        if (jsonRequested(opts)) return outJson(result.label);
+        ok(`Group "${result.label.name}" created`);
+      } catch (e: unknown) {
+        handleHttp(e);
+      }
+    });
+
+  groupsCmd
+    .command("rm <name>")
+    .alias("delete")
+    .description("Delete a personal Space group")
+    .action(async (name: string) => {
+      const client = createClient();
+      try {
+        await client.user.labels.remove(name);
+        ok(`Group "${name}" deleted`);
+      } catch (e: unknown) {
+        handleHttp(e);
+      }
+    });
+
+  groupsCmd
+    .command("add <name> <id>")
+    .description("Add a space to a personal group")
+    .action(async (name: string, id: string) => {
+      const client = createClient();
+      try {
+        await client.user.labels.patchResourceLabels("space", id.trim(), { addLabelRefs: [name] });
+        ok(`Space added to "${name}"`);
+      } catch (e: unknown) {
+        handleHttp(e);
+      }
+    });
+
+  groupsCmd
+    .command("remove <name> <id>")
+    .description("Remove a space from a personal group")
+    .action(async (name: string, id: string) => {
+      const client = createClient();
+      try {
+        await client.user.labels.patchResourceLabels("space", id.trim(), { removeLabelRefs: [name] });
+        ok(`Space removed from "${name}"`);
       } catch (e: unknown) {
         handleHttp(e);
       }

--- a/packages/core/src/labels/index.ts
+++ b/packages/core/src/labels/index.ts
@@ -221,13 +221,22 @@ export { assignSessionParticipantSystemLabels, getSessionUserLabelSystemKey, par
 export { assignSessionSourceSystemLabel, getSessionSourceLabelSystemKey, resolveKnownSessionSourceLabelSystemKey, resolveSessionSourceLabelRef, resolveSessionSourceLabelSystemKey, SESSION_SOURCE_LABEL_SYSTEM_KEY_PREFIX, SESSION_SOURCE_ROOT_LABEL_SYSTEM_KEY } from "./session-source.js";
 export { assignSessionChannelSystemLabel, getSessionChannelLabelSystemKey, parseSessionChannelLabelSystemKey, SESSION_CHANNEL_LABEL_SYSTEM_KEY_PREFIX, SESSION_CHANNEL_ROOT_LABEL_SYSTEM_KEY } from "./session-channel.js";
 export type { LabelResourceType } from "./resource-events.js";
-export type { UserLabelAssignment } from "./user-labels.js";
+export type { UserLabelAssignment, UserSpaceGroup } from "./user-labels.js";
 export {
+  buildUserSpaceGroupSnapshot,
+  createUserLabel,
+  deleteUserLabel,
   ensurePinnedLabel,
   getPinnedSpaceIds,
   getUserResourceLabelAssignments,
+  isProtectedUserLabel,
+  isReservedUserLabelName,
+  listUserLabels,
+  listUserSpaceGroups,
+  MAX_CUSTOM_USER_LABELS,
   patchUserResourceLabels,
   PINNED_LABEL_NAME,
   PINNED_LABEL_SYSTEM_KEY,
+  UserLabelError,
   USER_LABEL_SCOPE_TYPE,
 } from "./user-labels.js";

--- a/packages/core/src/labels/user-labels.test.ts
+++ b/packages/core/src/labels/user-labels.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildUserSpaceGroupSnapshot,
+  isProtectedUserLabel,
+  isReservedUserLabelName,
+  MAX_CUSTOM_USER_LABELS,
+  normalizeLabelName,
+  PINNED_LABEL_NAME,
+  PINNED_LABEL_SYSTEM_KEY,
+  UserLabelError,
+} from "./user-labels.js";
+
+test("normalizeLabelName trims and rejects empty, slash, and overlong names", () => {
+  assert.equal(normalizeLabelName("  Work  "), "Work");
+  assert.throws(() => normalizeLabelName(""), /1-80/);
+  assert.throws(() => normalizeLabelName("Area/Frontend"), /cannot contain "\/"/);
+  assert.throws(() => normalizeLabelName("x".repeat(81)), /1-80/);
+});
+
+test("create refuses reserved Pinned names", () => {
+  assert.equal(isReservedUserLabelName("Pinned"), true);
+  assert.equal(isReservedUserLabelName(" pinned "), true);
+  assert.equal(isReservedUserLabelName("PINNED"), true);
+  assert.equal(isReservedUserLabelName("Work"), false);
+});
+
+test("delete refuses Pinned and user:pinned", () => {
+  assert.equal(isProtectedUserLabel({ name: "Pinned", systemKey: PINNED_LABEL_SYSTEM_KEY }), true);
+  assert.equal(isProtectedUserLabel({ name: "Pinned", systemKey: null }), true);
+  assert.equal(isProtectedUserLabel({ name: "Work", systemKey: null }), false);
+});
+
+test("custom user labels are capped at 50", () => {
+  assert.equal(MAX_CUSTOM_USER_LABELS, 50);
+  const error = new UserLabelError(`custom user labels are limited to ${MAX_CUSTOM_USER_LABELS}`, "limit");
+  assert.equal(error.kind, "limit");
+  assert.match(error.message, /limited to 50/);
+});
+
+test("reserved and missing labels use conflict/not-found kinds", () => {
+  const reserved = new UserLabelError(`label name "${PINNED_LABEL_NAME}" is reserved`, "reserved");
+  const missing = new UserLabelError("label not found", "not_found");
+  assert.equal(reserved.kind, "reserved");
+  assert.equal(missing.kind, "not_found");
+});
+
+test("snapshot includes Pinned and groups ordered space ids", () => {
+  const groups = buildUserSpaceGroupSnapshot(
+    [
+      { id: "pinned", name: "Pinned", systemKey: PINNED_LABEL_SYSTEM_KEY, rank: 0 },
+      { id: "work", name: "Work", systemKey: null, rank: 20 },
+      { id: "empty", name: "Empty", systemKey: null, rank: 10 },
+    ],
+    [
+      { labelId: "work", resourceRef: "space-b", rank: 20, createdAt: new Date("2026-01-02"), id: "a2" },
+      { labelId: "work", resourceRef: "space-a", rank: 10, createdAt: new Date("2026-01-01"), id: "a1" },
+      { labelId: "pinned", resourceRef: "space-a", rank: 10, createdAt: new Date("2026-01-01"), id: "p1" },
+    ],
+  );
+
+  assert.deepEqual(groups.map((group) => group.name), ["Pinned", "Empty", "Work"]);
+  assert.deepEqual(groups[0]?.spaceIds, ["space-a"]);
+  assert.deepEqual(groups[1]?.spaceIds, []);
+  assert.deepEqual(groups[2]?.spaceIds, ["space-a", "space-b"]);
+});
+
+test("snapshot allows a space in multiple groups", () => {
+  const groups = buildUserSpaceGroupSnapshot(
+    [
+      { id: "clients", name: "Clients", systemKey: null, rank: 10 },
+      { id: "urgent", name: "Urgent", systemKey: null, rank: 20 },
+    ],
+    [
+      { labelId: "clients", resourceRef: "space-shared", rank: 10, createdAt: new Date("2026-01-01"), id: "c1" },
+      { labelId: "urgent", resourceRef: "space-shared", rank: 10, createdAt: new Date("2026-01-01"), id: "u1" },
+      { labelId: "urgent", resourceRef: "space-only-urgent", rank: 20, createdAt: new Date("2026-01-02"), id: "u2" },
+    ],
+  );
+
+  assert.deepEqual(groups[0]?.spaceIds, ["space-shared"]);
+  assert.deepEqual(groups[1]?.spaceIds, ["space-shared", "space-only-urgent"]);
+});

--- a/packages/core/src/labels/user-labels.ts
+++ b/packages/core/src/labels/user-labels.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, max, sql } from "drizzle-orm";
+import { and, asc, count, eq, max, sql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { labelAssignments, labels } from "@cohub/db";
 import type { LabelResourceType } from "./resource-events.js";
@@ -22,9 +22,36 @@ export type UserLabelAssignment = typeof labelAssignments.$inferSelect & {
 export const USER_LABEL_SCOPE_TYPE = "user";
 export const PINNED_LABEL_NAME = "Pinned";
 export const PINNED_LABEL_SYSTEM_KEY = "user:pinned";
+export const MAX_CUSTOM_USER_LABELS = 50;
 
 const MAX_LABEL_NAME_LENGTH = 80;
 const RESERVED_SYSTEM_ROOT_LABELS = new Set(["pinned"]);
+
+export type UserSpaceGroup = {
+  id: string;
+  name: string;
+  systemKey: string | null;
+  rank: number;
+  spaceIds: string[];
+};
+
+export class UserLabelError extends Error {
+  readonly kind: "reserved" | "limit" | "not_found";
+
+  constructor(message: string, kind: "reserved" | "limit" | "not_found") {
+    super(message);
+    this.name = "UserLabelError";
+    this.kind = kind;
+  }
+}
+
+export function isReservedUserLabelName(name: string) {
+  return RESERVED_SYSTEM_ROOT_LABELS.has(name.trim().toLowerCase());
+}
+
+export function isProtectedUserLabel(label: { name: string; systemKey: string | null }) {
+  return label.systemKey === PINNED_LABEL_SYSTEM_KEY || isReservedUserLabelName(label.name);
+}
 
 const hasControlCharacter = (value: string) => [...value].some((char) => {
   const code = char.charCodeAt(0);
@@ -253,4 +280,125 @@ export async function patchUserResourceLabels(db: LabelsDb, userUuid: string, re
     if (label) await detachUserLabel(db, userUuid, label.id, resourceType, resourceRef);
   }
   return getUserResourceLabelAssignments(db, userUuid, resourceType, resourceRef);
+}
+
+export function buildUserSpaceGroupSnapshot(
+  userLabels: Array<Pick<typeof labels.$inferSelect, "id" | "name" | "systemKey" | "rank">>,
+  assignments: Array<{
+    labelId: string;
+    resourceRef: string;
+    rank: number | null;
+    createdAt: Date | null;
+    id: string;
+  }>,
+): UserSpaceGroup[] {
+  const sortedAssignments = [...assignments].sort((a, b) => {
+    const aRank = a.rank ?? Number.POSITIVE_INFINITY;
+    const bRank = b.rank ?? Number.POSITIVE_INFINITY;
+    if (aRank !== bRank) return aRank - bRank;
+    const aTime = a.createdAt?.getTime() ?? 0;
+    const bTime = b.createdAt?.getTime() ?? 0;
+    if (aTime !== bTime) return aTime - bTime;
+    return a.id.localeCompare(b.id);
+  });
+  const spaceIdsByLabel = new Map<string, string[]>();
+  for (const row of sortedAssignments) {
+    const spaceIds = spaceIdsByLabel.get(row.labelId) ?? [];
+    if (!spaceIds.includes(row.resourceRef)) spaceIds.push(row.resourceRef);
+    spaceIdsByLabel.set(row.labelId, spaceIds);
+  }
+  return [...userLabels]
+    .sort((a, b) => (a.rank !== b.rank ? a.rank - b.rank : a.name.localeCompare(b.name)))
+    .map((label) => ({
+      id: label.id,
+      name: label.name,
+      systemKey: label.systemKey,
+      rank: label.rank,
+      spaceIds: spaceIdsByLabel.get(label.id) ?? [],
+    }));
+}
+
+async function countCustomUserLabels(db: LabelsDb, userUuid: string) {
+  const [{ value } = { value: 0 }] = await db
+    .select({ value: count() })
+    .from(labels)
+    .where(and(
+      eq(labels.scopeType, USER_LABEL_SCOPE_TYPE),
+      eq(labels.scopeId, userUuid),
+      eq(labels.source, "user"),
+    ));
+  return Number(value ?? 0);
+}
+
+/** Create a custom user-scope label. Idempotent for an existing name; refuses Pinned. */
+export async function createUserLabel(db: LabelsDb, userUuid: string, name: string) {
+  const normalized = normalizeLabelName(name);
+  if (isReservedUserLabelName(normalized)) {
+    throw new UserLabelError(`label name "${PINNED_LABEL_NAME}" is reserved`, "reserved");
+  }
+  const existing = await findUserLabelByName(db, userUuid, normalized);
+  if (existing) return existing;
+  if (await countCustomUserLabels(db, userUuid) >= MAX_CUSTOM_USER_LABELS) {
+    throw new UserLabelError(`custom user labels are limited to ${MAX_CUSTOM_USER_LABELS}`, "limit");
+  }
+
+  const [created] = await db.insert(labels).values({
+    scopeType: USER_LABEL_SCOPE_TYPE,
+    scopeId: userUuid,
+    name: normalized,
+    slug: slugifyLabelName(normalized),
+    parentId: null,
+    depth: 0,
+    rank: await nextUserLabelRank(db, userUuid),
+    source: "user",
+    createdBy: userUuid,
+  }).onConflictDoNothing().returning();
+  if (created) return created;
+
+  const raced = await findUserLabelByName(db, userUuid, normalized);
+  if (!raced) throw new Error("failed to create user label");
+  return raced;
+}
+
+/** Delete a custom user-scope label and its assignments. Refuses Pinned. */
+export async function deleteUserLabel(db: LabelsDb, userUuid: string, name: string) {
+  const normalized = normalizeLabelName(name);
+  const existing = await findUserLabelByName(db, userUuid, normalized);
+  if (!existing) throw new UserLabelError("label not found", "not_found");
+  if (isProtectedUserLabel(existing)) {
+    throw new UserLabelError(`system label "${PINNED_LABEL_NAME}" cannot be deleted`, "reserved");
+  }
+
+  await db.delete(labelAssignments).where(and(
+    eq(labelAssignments.labelId, existing.id),
+    eq(labelAssignments.scopeType, USER_LABEL_SCOPE_TYPE),
+    eq(labelAssignments.scopeId, userUuid),
+  ));
+  await db.delete(labels).where(and(
+    eq(labels.id, existing.id),
+    eq(labels.scopeType, USER_LABEL_SCOPE_TYPE),
+    eq(labels.scopeId, userUuid),
+  ));
+  return existing;
+}
+
+/** Snapshot each user label with ordered space assignment ids. Includes Pinned if present. */
+export async function listUserSpaceGroups(db: LabelsDb, userUuid: string): Promise<UserSpaceGroup[]> {
+  const userLabels = await listUserLabels(db, userUuid);
+  if (userLabels.length === 0) return [];
+  const assignments = await db
+    .select({
+      labelId: labelAssignments.labelId,
+      resourceRef: labelAssignments.resourceRef,
+      rank: labelAssignments.rank,
+      createdAt: labelAssignments.createdAt,
+      id: labelAssignments.id,
+    })
+    .from(labelAssignments)
+    .where(and(
+      eq(labelAssignments.scopeType, USER_LABEL_SCOPE_TYPE),
+      eq(labelAssignments.scopeId, userUuid),
+      eq(labelAssignments.resourceType, "space"),
+    ));
+  return buildUserSpaceGroupSnapshot(userLabels, assignments);
 }

--- a/packages/sdk/src/apis/user.ts
+++ b/packages/sdk/src/apis/user.ts
@@ -1,5 +1,5 @@
 import { HttpError, type HttpTransport, type Fetch } from "../transport.js";
-import type { LabelAssignmentRecord, LabelResourceType, MeResponse, SessionRecord, SpaceRecord, UserActivityQuery, UserActivityResponse, UserProfile, UserRulesResponse, UserSessionsResponse } from "../types.js";
+import type { LabelAssignmentRecord, LabelRecord, LabelResourceType, MeResponse, SessionRecord, SpaceRecord, UserActivityQuery, UserActivityResponse, UserProfile, UserRulesResponse, UserSessionsResponse, UserSpaceGroup } from "../types.js";
 
 const usageDate = (value: string | Date) => value instanceof Date ? value.toISOString() : value;
 
@@ -122,5 +122,28 @@ export class UserLabelsApi {
         body: JSON.stringify(input),
       },
     );
+  }
+
+  list() {
+    return this.transport.request<{ labels: LabelRecord[] }>("/api/me/labels");
+  }
+
+  create(name: string) {
+    return this.transport.request<{ label: LabelRecord }>("/api/me/labels", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    });
+  }
+
+  remove(name: string) {
+    const params = new URLSearchParams({ name });
+    return this.transport.request<{ ok: true }>(`/api/me/labels?${params.toString()}`, {
+      method: "DELETE",
+    });
+  }
+
+  listSpaceGroups() {
+    return this.transport.request<{ groups: UserSpaceGroup[] }>("/api/me/space-groups");
   }
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1398,6 +1398,15 @@ export type LabelListItem = LabelRecord & {
   children?: LabelListItem[];
 };
 
+/** Personal Space group — a user-scope label plus ordered space assignment ids. */
+export type UserSpaceGroup = {
+  id: string;
+  name: string;
+  systemKey: string | null;
+  rank: number;
+  spaceIds: string[];
+};
+
 export type LabelAssignmentRecord = {
   id: string;
   labelId: string;

--- a/packages/sdk/tests/user-labels.test.ts
+++ b/packages/sdk/tests/user-labels.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createHttpClient } from "../src/http.js";
+
+function createClient(onRequest: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  return createHttpClient({
+    baseUrl: "https://api.example.test",
+    fetch: async (url, init) => onRequest(String(url), init),
+  });
+}
+
+test("user labels list and space-groups hit /api/me", async () => {
+  const urls: string[] = [];
+  const client = createClient(async (url) => {
+    urls.push(url);
+    if (url.endsWith("/api/me/space-groups")) {
+      return new Response(JSON.stringify({ groups: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify({ labels: [] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  await client.user.labels.list();
+  await client.user.labels.listSpaceGroups();
+  assert.deepEqual(urls, [
+    "https://api.example.test/api/me/labels",
+    "https://api.example.test/api/me/space-groups",
+  ]);
+});
+
+test("user labels create and remove use name", async () => {
+  let createBody: string | undefined;
+  let deleteUrl = "";
+  const client = createClient(async (url, init) => {
+    if (init?.method === "POST") {
+      createBody = typeof init.body === "string" ? init.body : undefined;
+      return new Response(JSON.stringify({ label: { id: "1", name: "Work" } }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    deleteUrl = url;
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  await client.user.labels.create("Work");
+  await client.user.labels.remove("Work");
+  assert.equal(createBody, JSON.stringify({ name: "Work" }));
+  assert.equal(deleteUrl, "https://api.example.test/api/me/labels?name=Work");
+});
+
+test("user labels patch still assigns a space", async () => {
+  let request: { url: string; method?: string; body?: string } | null = null;
+  const client = createClient(async (url, init) => {
+    request = {
+      url,
+      method: init?.method,
+      body: typeof init?.body === "string" ? init.body : undefined,
+    };
+    return new Response(JSON.stringify({ assignments: [] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  await client.user.labels.patchResourceLabels("space", "space-1", {
+    addLabelRefs: ["Work"],
+  });
+  assert.equal(request?.url, "https://api.example.test/api/me/resources/space/labels?resourceRef=space-1");
+  assert.equal(request?.method, "PATCH");
+  assert.equal(request?.body, JSON.stringify({ addLabelRefs: ["Work"] }));
+});


### PR DESCRIPTION
## Summary
- Extend official user-scope labels with create/list/delete and a Mine snapshot (`GET /api/me/space-groups`). Groups stay private viewer data on `v2.labels` / `v2.label_assignments`.
- Keep Pinned as the reserved system bookmark. It cannot be created or deleted as a group, and the Mine picker hides `systemKey === 'user:pinned'`.
- Show collapsible personal groups under Mine in the existing Space picker (⌘K / sidebar switcher / `a:`). All / Pinned stay flat. Owners can create a group, drag a Space onto it, remove a Space from a group, or delete the group.
- SDK and CLI stay consistent: `UserLabelsApi.list/create/remove/listSpaceGroups`, plus `spaces groups ls|create|rm|add|remove` and `spaces ls --group`.

## Test plan
- [ ] Create a group from Mine, leave it empty, reload
- [ ] Drag an owned Space onto a group header
- [ ] One Space can appear in two groups
- [ ] Remove a Space from a group (the Space remains)
- [ ] Delete a group (Spaces remain)
- [ ] Collapse state persists across reload
- [ ] Pin/unpin still works; creating or deleting "Pinned" as a group is refused
- [ ] All / Pinned stay flat lists
- [ ] `cohub spaces groups ls|create|rm|add|remove` and `cohub spaces ls --group` work


Made with [Cursor](https://cursor.com)