### PR TITLE
fix(sandbox): prevent stale websocket reconnect loops

### DIFF
--- a/packages/sandbox-client/package.json
+++ b/packages/sandbox-client/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "test": "node ../../scripts/test/run.mjs --experimental-test-module-mocks --disable-warning=ExperimentalWarning --test-isolation=none 'src/**/*.test.ts'",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/sandbox-client/src/ws-client.test.ts
+++ b/packages/sandbox-client/src/ws-client.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { setTimeout as delay } from "node:timers/promises";
+import { mock, test } from "node:test";
+
+process.env.LOG_LEVEL = "silent";
+
+class FakeWebSocket extends EventEmitter {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  readonly sent: string[] = [];
+  readyState = FakeWebSocket.CONNECTING;
+
+  constructor(readonly url: string) {
+    super();
+    FakeWebSocket.instances.push(this);
+  }
+
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.emit("open");
+  }
+
+  receive(message: unknown) {
+    this.emit("message", Buffer.from(JSON.stringify(message)));
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  fail(error: Error) {
+    this.emit("error", error);
+    this.finishClose(1006, "");
+  }
+
+  close(code = 1000, reason = "") {
+    this.finishClose(code, reason);
+  }
+
+  terminate() {
+    this.finishClose(1006, "");
+  }
+
+  private finishClose(code: number, reason: string) {
+    if (this.readyState === FakeWebSocket.CLOSED) return;
+    this.readyState = FakeWebSocket.CLOSED;
+    queueMicrotask(() => this.emit("close", code, Buffer.from(reason)));
+  }
+}
+
+mock.module("ws", { exports: { default: FakeWebSocket } });
+
+const {
+  disconnectSandboxWsClient,
+  getSandboxClientConnection,
+  startSandboxWsClient,
+  waitForSandboxConnection,
+} = await import("./ws-client.js");
+
+function beginAttach(socket: FakeWebSocket, spaceId: string) {
+  socket.open();
+  socket.receive({
+    version: "1",
+    type: "sandbox.heartbeat",
+    spaceId,
+    sandboxId: "sandbox-test",
+    timestamp: Date.now(),
+    status: "ready",
+  });
+  const attachRequest = socket.sent
+    .map((value) => JSON.parse(value) as { type: string; requestId: string })
+    .find((message) => message.type === "session.attach");
+  assert.ok(attachRequest);
+  return attachRequest.requestId;
+}
+
+function finishAttach(socket: FakeWebSocket, spaceId: string, requestId: string, connectionId: string) {
+  socket.receive({
+    version: "1",
+    type: "session.attach.ok",
+    spaceId,
+    sandboxId: "sandbox-test",
+    timestamp: Date.now(),
+    requestId,
+    connectionId,
+    identity: "agent-test",
+  });
+}
+
+function attach(socket: FakeWebSocket, spaceId: string, connectionId: string) {
+  finishAttach(socket, spaceId, beginAttach(socket, spaceId), connectionId);
+}
+
+test("a superseded connection attempt cannot replace the current connection", async () => {
+  const spaceId = "space-stale-attach";
+  FakeWebSocket.instances = [];
+
+  try {
+    await startSandboxWsClient({
+      spaceId,
+      wsUrl: "ws://stale.test/sandbox",
+      identity: "agent-test",
+    });
+    const staleSocket = FakeWebSocket.instances[0];
+    assert.ok(staleSocket);
+    const staleAttachRequestId = beginAttach(staleSocket, spaceId);
+
+    disconnectSandboxWsClient(spaceId, "endpoint replaced");
+    await startSandboxWsClient({
+      spaceId,
+      wsUrl: "ws://ready.test/sandbox",
+      identity: "agent-test",
+    });
+    const replacementSocket = FakeWebSocket.instances[1];
+    assert.ok(replacementSocket);
+    attach(replacementSocket, spaceId, "connection-current");
+    const currentConnection = await waitForSandboxConnection(spaceId, 100);
+
+    finishAttach(staleSocket, spaceId, staleAttachRequestId, "connection-stale");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    assert.equal(getSandboxClientConnection(spaceId), currentConnection);
+    assert.equal(replacementSocket.readyState, FakeWebSocket.OPEN);
+  } finally {
+    disconnectSandboxWsClient(spaceId, "test cleanup");
+    for (const socket of FakeWebSocket.instances) socket.terminate();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+});
+
+test("disconnect and restart cannot revive a run loop waiting in reconnect backoff", async () => {
+  const spaceId = "space-run-generation";
+  FakeWebSocket.instances = [];
+
+  let resolveConnectionError: (() => void) | undefined;
+  const connectionError = new Promise<void>((resolve) => {
+    resolveConnectionError = resolve;
+  });
+
+  try {
+    await startSandboxWsClient({
+      spaceId,
+      wsUrl: "ws://stale.test/sandbox",
+      identity: "agent-test",
+      hooks: {
+        onConnectionError: () => resolveConnectionError?.(),
+      },
+    });
+    const staleSocket = FakeWebSocket.instances[0];
+    assert.ok(staleSocket);
+    staleSocket.fail(new Error("connect ECONNREFUSED 10.0.0.1:8788"));
+    await connectionError;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    disconnectSandboxWsClient(spaceId, "endpoint replaced");
+    await startSandboxWsClient({
+      spaceId,
+      wsUrl: "ws://ready.test/sandbox",
+      identity: "agent-test",
+    });
+    const replacementSocket = FakeWebSocket.instances[1];
+    assert.ok(replacementSocket);
+    attach(replacementSocket, spaceId, "connection-current");
+    await waitForSandboxConnection(spaceId, 100);
+
+    await delay(500);
+    assert.equal(
+      FakeWebSocket.instances.length,
+      2,
+      "the superseded run loop must not reconnect after its backoff finishes",
+    );
+  } finally {
+    disconnectSandboxWsClient(spaceId, "test cleanup");
+    for (const socket of FakeWebSocket.instances) socket.terminate();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+});

--- a/packages/sandbox-client/src/ws-client.ts
+++ b/packages/sandbox-client/src/ws-client.ts
@@ -126,12 +126,19 @@ type SandboxStatusHooks = {
   onRefreshWsUrl?: (input: { spaceId: string; currentWsUrl: string; error?: Error }) => string | null | Promise<string | null>;
 };
 
+type SandboxClientRun = {
+  generation: number;
+  controller: AbortController;
+};
+
 type SandboxClientRegistration = {
   spaceId: string;
   wsUrl: string;
   identity: string;
   headers?: Record<string, string>;
   started: boolean;
+  generation: number;
+  activeRun: SandboxClientRun | null;
   connection: SandboxConnection | null;
   resolveWaiters: Array<(connection: SandboxConnection) => void>;
   hooks?: SandboxStatusHooks;
@@ -369,6 +376,8 @@ function getOrCreateRegistration(spaceId: string, wsUrl: string, identity: strin
     identity,
     headers,
     started: false,
+    generation: 0,
+    activeRun: null,
     connection: null,
     resolveWaiters: [],
     hooks,
@@ -417,20 +426,45 @@ export async function waitForSandboxConnection(spaceId: string, timeoutMs = 3000
   });
 }
 
+function isCurrentRun(registration: SandboxClientRegistration, run: SandboxClientRun) {
+  return registration.started
+    && registration.activeRun === run
+    && registration.generation === run.generation
+    && !run.controller.signal.aborted;
+}
+
 export async function startSandboxWsClient(input: { spaceId: string; wsUrl: string; identity: string; headers?: Record<string, string>; hooks?: SandboxStatusHooks }) {
   const spaceId = input.spaceId;
   const wsUrl = input.wsUrl;
   const registration = getOrCreateRegistration(spaceId, wsUrl, input.identity, input.headers, input.hooks);
   if (registration.started) return;
-  registration.started = true;
 
-  void runLoop(registration);
+  const run: SandboxClientRun = {
+    generation: registration.generation + 1,
+    controller: new AbortController(),
+  };
+  registration.started = true;
+  registration.generation = run.generation;
+  registration.activeRun = run;
+
+  void runLoop(registration, run)
+    .catch((error) => {
+      logger.error(`[SandboxWS] Client run failed for ${registration.spaceId}:`, error);
+    })
+    .finally(() => {
+      if (registration.activeRun !== run) return;
+      registration.started = false;
+      registration.activeRun = null;
+    });
 }
 
 export function disconnectSandboxWsClient(spaceId: string, reason = "ownership lost") {
   const registration = registrations.get(spaceId);
   if (!registration) return;
+  const activeRun = registration.activeRun;
   registration.started = false;
+  registration.generation += 1;
+  registration.activeRun = null;
   const previous = registration.connection;
   setActiveConnection(spaceId, null);
 
@@ -456,6 +490,7 @@ export function disconnectSandboxWsClient(spaceId: string, reason = "ownership l
   }
 
   previous?.close(reason);
+  activeRun?.controller.abort();
   logger.info(`[SandboxWS] disconnect spaceId=${spaceId} reason=${reason}`);
   callHookSafely(spaceId, "onDisconnected", () => registration.hooks?.onDisconnected?.({ spaceId, reason }));
 }
@@ -468,16 +503,18 @@ export function hasPendingSandboxRequests(spaceId: string) {
   return (registrations.get(spaceId)?.pendingByRequestId.size ?? 0) > 0;
 }
 
-async function runLoop(registration: SandboxClientRegistration) {
+async function runLoop(registration: SandboxClientRegistration, run: SandboxClientRun) {
   let attempt = 0;
   let lastRefreshAt = 0;
 
   for (;;) {
-    if (!registration.started) return;
+    if (!isCurrentRun(registration, run)) return;
     try {
-      await connectOnce(registration);
+      await connectOnce(registration, run);
+      if (!isCurrentRun(registration, run)) return;
       attempt = 0;
     } catch (error) {
+      if (!isCurrentRun(registration, run)) return;
       logger.error(`[SandboxWS] Client loop failed for ${registration.spaceId}:`, error);
       attempt += 1;
       if (error instanceof Error) {
@@ -499,6 +536,7 @@ async function runLoop(registration: SandboxClientRegistration) {
           logger.warn(`[SandboxWS] wsUrl refresh failed spaceId=${registration.spaceId}:`, refreshError);
           return null;
         });
+        if (!isCurrentRun(registration, run)) return;
         if (nextWsUrl && nextWsUrl !== currentWsUrl) {
           registration.wsUrl = nextWsUrl;
           attempt = 0;
@@ -507,41 +545,77 @@ async function runLoop(registration: SandboxClientRegistration) {
       }
     }
 
-    if (!registration.started) return;
+    if (!isCurrentRun(registration, run)) return;
     const delayMs = RECONNECT_DELAYS_MS[Math.min(Math.max(attempt - 1, 0), RECONNECT_DELAYS_MS.length - 1)];
-    await sleep(delayMs);
+    try {
+      await sleep(delayMs, undefined, { signal: run.controller.signal });
+    } catch (error) {
+      if (run.controller.signal.aborted) return;
+      throw error;
+    }
   }
 }
 
-async function connectOnce(registration: SandboxClientRegistration) {
+async function connectOnce(registration: SandboxClientRegistration, run: SandboxClientRun) {
   await new Promise<void>((resolve, reject) => {
     const socket = new WebSocket(registration.wsUrl, registration.headers ? { headers: registration.headers } : undefined);
+    const signal = run.controller.signal;
     let heartbeat: SandboxHeartbeat | null = null;
     let connection: SandboxConnection | null = null;
     let attached = false;
     let settled = false;
     let attachSent = false;
+    let onAbort: (() => void) | null = null;
     const attachRequestId = randomUUID();
 
     const isActiveConnection = () => registrations.get(registration.spaceId)?.connection === connection;
+    const cleanupAbortListener = () => {
+      if (onAbort) signal.removeEventListener("abort", onAbort);
+    };
 
     const finishResolve = () => {
       if (settled) return;
       settled = true;
+      cleanupAbortListener();
       resolve();
     };
 
     const finishReject = (error: Error) => {
       if (settled) return;
       settled = true;
+      cleanupAbortListener();
       reject(error);
     };
 
+    const closeSupersededSocket = () => {
+      if (socket.readyState === WebSocket.CONNECTING) {
+        socket.terminate();
+      } else if (socket.readyState === WebSocket.OPEN) {
+        socket.close(1000, "sandbox client superseded");
+      }
+    };
+
+    onAbort = () => {
+      closeSupersededSocket();
+      finishResolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+
     socket.on("open", () => {
+      if (!isCurrentRun(registration, run)) {
+        closeSupersededSocket();
+        finishResolve();
+        return;
+      }
       logger.info(`[SandboxWS] Connected ${registration.spaceId} to ${registration.wsUrl}`);
     });
 
     socket.on("message", (data: RawData) => {
+      if (!isCurrentRun(registration, run)) {
+        closeSupersededSocket();
+        finishResolve();
+        return;
+      }
       try {
         const raw = typeof data === "string" ? data : data.toString("utf8");
         const message = JSON.parse(raw) as AgentSandboxMessage;
@@ -638,14 +712,21 @@ async function connectOnce(registration: SandboxClientRegistration) {
       connection?.dispose();
       const reasonStr = reason?.toString() || "unknown";
       const isActive = isActiveConnection();
+      const isCurrent = isCurrentRun(registration, run);
       if (isActive) {
         setActiveConnection(registration.spaceId, null);
-        callHookSafely(registration.spaceId, "onDisconnected", () => registration.hooks?.onDisconnected?.({
-          spaceId: registration.spaceId,
-          reason: reasonStr,
-        }));
+        if (isCurrent) {
+          callHookSafely(registration.spaceId, "onDisconnected", () => registration.hooks?.onDisconnected?.({
+            spaceId: registration.spaceId,
+            reason: reasonStr,
+          }));
+        }
       }
       if (!attached) {
+        if (!isCurrent) {
+          finishResolve();
+          return;
+        }
         logger.warn(`[SandboxWS] closed before attach spaceId=${registration.spaceId} reason=${reasonStr}`);
         finishReject(new Error(`Sandbox websocket closed before attach: ${reasonStr}`));
         return;
@@ -659,6 +740,10 @@ async function connectOnce(registration: SandboxClientRegistration) {
     });
 
     socket.on("error", (error: Error) => {
+      if (!isCurrentRun(registration, run)) {
+        finishResolve();
+        return;
+      }
       logger.error(`[SandboxWS] Socket error for ${registration.spaceId}:`, error);
       const normalizedError = error instanceof Error ? error : new Error(String(error));
       connection?.dispose(normalizedError);


### PR DESCRIPTION
## Summary

- give each sandbox WebSocket client run its own generation and cancellation controller
- abort reconnect backoff and in-flight connection attempts when ownership is invalidated
- reject stale open/message/attach events before they can replace the current connection
- add regression coverage for backoff restart and late attach races

## Root cause

Endpoint recovery previously toggled a shared `started` boolean. If the old `runLoop` was waiting in reconnect backoff when `disconnectSandboxWsClient()` set `started=false`, a new start could set it back to `true` before the old sleep completed. The old loop then resumed against the refreshed endpoint, leaving two loops that attached every ~250ms and repeatedly closed each other with `sandbox connection replaced`.

The same ownership gap also allowed an old WebSocket handshake to attach after a replacement run had already connected.

This change assigns each run a generation, checks ownership after asynchronous boundaries and before processing socket events, and uses an `AbortController` to cancel backoff and unfinished sockets during disconnect.

## Verification

- `pnpm --filter @cohub/sandbox-client test`
- `pnpm --filter @cohub/sandbox-client typecheck`
- `pnpm --filter @cohub/sandbox-client build`
- `pnpm --filter @cohub/agent test` (32 tests)
- `pnpm exec biome check packages/sandbox-client/src/ws-client.ts packages/sandbox-client/src/ws-client.test.ts packages/sandbox-client/package.json`
- sandbox-client race regression repeated 5/5 successfully

The new regression test failed before the fix by creating a third WebSocket after stop/start (`3 !== 2`) and passes after the fix.

## Existing CI blockers

The workspace-wide test/typecheck path still encounters unrelated dependency setup failures already present on `main`:

- `@talesofai-billing/sdk/admin/discounts` is missing from the installed SDK exports, which blocks dependent Agent typecheck and several Billing tests
- `paraglide-js` is missing for the Web test bootstrap

The workspace test runner did execute and pass the new `@cohub/sandbox-client` tests before those failures.
