### PR TITLE
fix(agent): make edit failures recoverable

### DIFF
--- a/apps/agent/src/runtime/session-runtime.ts
+++ b/apps/agent/src/runtime/session-runtime.ts
@@ -694,7 +694,7 @@ function toolSnippets(toolName: string): string | undefined {
   switch (toolName) {
     case "read": return "Read file contents";
     case "bash": return "Execute bash commands";
-    case "edit": return "Make precise file edits with exact text replacement";
+    case "edit": return "Read the target first, copy oldText verbatim, and use unique surrounding context for precise edits";
     case "write": return "Create or overwrite files";
     case "grep": return "Search file contents";
     case "find": return "Search files by glob pattern";

--- a/apps/agent/src/runtime/tools/basic-tools.ts
+++ b/apps/agent/src/runtime/tools/basic-tools.ts
@@ -159,25 +159,187 @@ function resolveToCwd(path: string, cwd: string): string {
   return `${cwd.replace(/\/$/, "")}/${path}`;
 }
 
+type EditMatch = {
+  start: number;
+  end: number;
+  fuzzy: boolean;
+};
+
+type NormalizedEditText = {
+  text: string;
+  offsets: number[];
+};
+
 /**
- * Apply exact-text replacements to content, matching each oldText exactly
- * once. Throws when an oldText is missing or not unique. Shared by the edit
- * tool's fallback path and sandbox capability-degraded applyEdits so the
- * matching semantics and error messages never diverge.
+ * Normalize only representation-level differences that are safe to repair:
+ * line endings and spaces or tabs at the end of a line. The boundary map lets
+ * a fuzzy match replace the original range without rewriting untouched bytes.
+ */
+function normalizeEditText(text: string): NormalizedEditText {
+  let normalized = "";
+  const offsets = [0];
+
+  for (let lineStart = 0; lineStart < text.length;) {
+    let lineEnd = lineStart;
+    while (lineEnd < text.length && text[lineEnd] !== "\n" && text[lineEnd] !== "\r") lineEnd += 1;
+
+    let contentEnd = lineEnd;
+    while (contentEnd > lineStart && (text[contentEnd - 1] === " " || text[contentEnd - 1] === "\t")) contentEnd -= 1;
+    normalized += text.slice(lineStart, contentEnd);
+    for (let index = lineStart; index < contentEnd; index += 1) offsets.push(index + 1);
+
+    if (lineEnd === text.length) break;
+    let newlineEnd = lineEnd + 1;
+    if (text[lineEnd] === "\r" && text[newlineEnd] === "\n") newlineEnd += 1;
+    normalized += "\n";
+    offsets.push(newlineEnd);
+    lineStart = newlineEnd;
+  }
+
+  return { text: normalized, offsets };
+}
+
+function findEditOccurrences(text: string, pattern: string): number[] {
+  if (pattern.length === 0) return [];
+  const occurrences: number[] = [];
+  for (let cursor = 0; cursor <= text.length - pattern.length;) {
+    const index = text.indexOf(pattern, cursor);
+    if (index === -1) break;
+    occurrences.push(index);
+    cursor = index + pattern.length;
+  }
+  return occurrences;
+}
+
+function findEditMatches(content: string, oldText: string): EditMatch[] {
+  const exactOccurrences = findEditOccurrences(content, oldText);
+  if (exactOccurrences.length > 0) {
+    return exactOccurrences.map((start) => ({ start, end: start + oldText.length, fuzzy: false }));
+  }
+
+  const normalizedContent = normalizeEditText(content);
+  const normalizedOldText = normalizeEditText(oldText);
+  if (normalizedOldText.text.length === 0) return [];
+
+  return findEditOccurrences(normalizedContent.text, normalizedOldText.text).flatMap((start) => {
+    const end = start + normalizedOldText.text.length;
+    const originalStart = normalizedContent.offsets[start];
+    const originalEnd = normalizedContent.offsets[end];
+    return originalStart === undefined || originalEnd === undefined
+      ? []
+      : [{ start: originalStart, end: originalEnd, fuzzy: true }];
+  });
+}
+
+function editLineNumber(content: string, offset: number): number {
+  return content.slice(0, offset).split(/\r\n|\r|\n/).length;
+}
+
+function findEditHintBlock(content: string, oldText: string): string | undefined {
+  const contentLines = content.split(/\r\n|\r|\n/);
+  const oldLines = oldText.split(/\r\n|\r|\n/);
+  const anchors = oldLines
+    .map((line) => line.trim())
+    .filter((line) => line.length >= 4)
+    .sort((left, right) => right.length - left.length);
+  const tokens = oldText.match(/[A-Za-z0-9_./:-]{4,}/g) ?? [];
+  const candidates = [...anchors, ...[...new Set(tokens)].sort((left, right) => right.length - left.length)];
+
+  for (const candidate of candidates) {
+    const lineIndex = contentLines.findIndex((line) => line.includes(candidate));
+    if (lineIndex === -1) continue;
+    const start = Math.max(0, lineIndex - 1);
+    const end = Math.min(contentLines.length, lineIndex + 2);
+    return contentLines
+      .slice(start, end)
+      .map((line, index) => {
+        const lineCharacters = Array.from(line);
+        const displayLine = lineCharacters.length > 240 ? `${lineCharacters.slice(0, 240).join("")}...` : line;
+        return `${start + index + 1}: ${displayLine}`;
+      })
+      .join("\n");
+  }
+  return undefined;
+}
+
+function restoreEditLineEndings(text: string, content: string): string {
+  const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  if (content.includes("\r\n")) return normalized.replace(/\n/g, "\r\n");
+  if (content.includes("\r")) return normalized.replace(/\n/g, "\r");
+  return normalized;
+}
+
+function formatEditMatchError(
+  content: string,
+  oldText: string,
+  path: string,
+  index: number,
+  total: number,
+  matches: EditMatch[],
+): string {
+  const label = total === 1 ? "oldText" : `edits[${index}].oldText`;
+  if (matches.length === 0) {
+    const hintBlock = findEditHintBlock(content, oldText);
+    const hint = hintBlock
+      ? `\nCurrent nearby text:\n${hintBlock}\nCopy the current text exactly; do not reuse stale oldText.`
+      : "";
+    return `${label} must match exactly one region in ${path}, found 0. Re-read the file and retry with the current text, including whitespace, newlines, and escaping.${hint}`;
+  }
+  const lines = matches.slice(0, 8).map((match) => editLineNumber(content, match.start));
+  const suffix = matches.length > lines.length ? ", ..." : "";
+  return `${label} must match exactly one region in ${path}, found ${matches.length} at lines [${lines.join(", ")}${suffix}]. Add surrounding context to oldText`;
+}
+
+/**
+ * Apply replacements against one original snapshot. Exact matching remains
+ * the first choice; normalized matching is accepted only when it is unique.
+ * No write occurs unless every edit validates and no ranges overlap.
  */
 export function applyEditsToContent(
   content: string,
   edits: Array<{ oldText: string; newText: string }>,
   path: string,
 ): string {
-  for (const edit of edits) {
-    const occurrences = content.split(edit.oldText).length - 1;
-    if (occurrences !== 1) {
-      throw new Error(`oldText must match exactly one region in ${path}, found ${occurrences}`);
+  const bom = content.startsWith("\uFEFF") ? "\uFEFF" : "";
+  const original = bom ? content.slice(1) : content;
+  const replacements: Array<{ start: number; end: number; newText: string; index: number }> = [];
+
+  for (const [index, edit] of edits.entries()) {
+    if (edit.oldText.length === 0) throw new Error(`edits[${index}].oldText must not be empty in ${path}`);
+    if (edit.oldText === edit.newText) throw new Error(`edits[${index}].oldText and newText must differ in ${path}`);
+
+    const matches = findEditMatches(original, edit.oldText);
+    if (matches.length !== 1) {
+      throw new Error(formatEditMatchError(original, edit.oldText, path, index, edits.length, matches));
     }
-    content = content.replace(edit.oldText, edit.newText);
+
+    const match = matches[0];
+    if (!match) throw new Error(`No match was available for edits[${index}] in ${path}`);
+    replacements.push({
+      start: match.start,
+      end: match.end,
+      newText: match.fuzzy ? restoreEditLineEndings(edit.newText, original) : edit.newText,
+      index,
+    });
   }
-  return content;
+
+  replacements.sort((left, right) => left.start - right.start);
+  for (let index = 1; index < replacements.length; index += 1) {
+    const previous = replacements[index - 1];
+    const current = replacements[index];
+    if (!previous || !current) continue;
+    if (previous.end > current.start) {
+      throw new Error(`edits[${previous.index}] and edits[${current.index}] overlap in ${path}; merge nearby changes into one edit`);
+    }
+  }
+
+  let updated = original;
+  for (let index = replacements.length - 1; index >= 0; index -= 1) {
+    const replacement = replacements[index];
+    if (!replacement) continue;
+    updated = updated.slice(0, replacement.start) + replacement.newText + updated.slice(replacement.end);
+  }
+  return bom + updated;
 }
 
 export function createReadTool(cwd: string, options: { operations: ReadOperations }): AgentTool {
@@ -271,14 +433,14 @@ export function createEditTool(cwd: string, options: { operations: EditOperation
   const parameters = Type.Object({
     path: Type.String({ description: "Path to the file to edit (relative or absolute)" }),
     edits: Type.Array(Type.Object({
-      oldText: Type.String({ description: "Exact text for one targeted replacement. It must match a unique region in the original file." }),
-      newText: Type.String({ description: "Replacement text for this targeted edit." }),
-    }), { description: "One or more targeted replacements." }),
+      oldText: Type.String({ description: "Text copied verbatim from a recent read result. Include real newlines and whitespace; do not use the two characters \\n for a newline. It must match one unique region in the current file." }),
+      newText: Type.String({ description: "Literal replacement text for this targeted edit. Use an empty string to delete the match." }),
+    }), { description: "One or more targeted replacements. All oldText values are checked against the same original file snapshot and must not overlap." }),
   });
   return {
     name: "edit",
     label: "edit",
-    description: "Edit a file by applying exact text replacements.",
+    description: "Edit a file by applying targeted text replacements. Read the target file first and copy oldText verbatim, including whitespace, newlines, and escaping. Use enough surrounding context to make each oldText unique; do not guess file contents or use literal \\n where the file has a real newline. Nearby changes should be merged into one edit, and edits must not overlap.",
     parameters,
     async execute(_toolCallId, rawParams) {
       const params = rawParams as Static<typeof parameters>;

--- a/apps/agent/src/runtime/tools/basic-tools.ts
+++ b/apps/agent/src/runtime/tools/basic-tools.ts
@@ -167,17 +167,28 @@ type EditMatch = {
 
 type NormalizedEditText = {
   text: string;
-  offsets: number[];
 };
+
+type EditOccurrenceSearch = {
+  positions: number[];
+  truncated: boolean;
+};
+
+type EditMatchSearch = {
+  matches: EditMatch[];
+  truncated: boolean;
+};
+
+const MAX_EDIT_MATCHES = 9;
 
 /**
  * Normalize only representation-level differences that are safe to repair:
- * line endings and spaces or tabs at the end of a line. The boundary map lets
- * a fuzzy match replace the original range without rewriting untouched bytes.
+ * line endings and spaces or tabs at the end of a line. Match offsets are
+ * mapped back lazily so a failed high-frequency search never allocates one
+ * entry per source character.
  */
 function normalizeEditText(text: string): NormalizedEditText {
   let normalized = "";
-  const offsets = [0];
 
   for (let lineStart = 0; lineStart < text.length;) {
     let lineEnd = lineStart;
@@ -186,87 +197,187 @@ function normalizeEditText(text: string): NormalizedEditText {
     let contentEnd = lineEnd;
     while (contentEnd > lineStart && (text[contentEnd - 1] === " " || text[contentEnd - 1] === "\t")) contentEnd -= 1;
     normalized += text.slice(lineStart, contentEnd);
-    for (let index = lineStart; index < contentEnd; index += 1) offsets.push(index + 1);
 
     if (lineEnd === text.length) break;
     let newlineEnd = lineEnd + 1;
     if (text[lineEnd] === "\r" && text[newlineEnd] === "\n") newlineEnd += 1;
     normalized += "\n";
-    offsets.push(newlineEnd);
     lineStart = newlineEnd;
   }
 
-  return { text: normalized, offsets };
+  return { text: normalized };
 }
 
-function findEditOccurrences(text: string, pattern: string): number[] {
-  if (pattern.length === 0) return [];
-  const occurrences: number[] = [];
+function findEditOccurrences(text: string, pattern: string): EditOccurrenceSearch {
+  if (pattern.length === 0) return { positions: [], truncated: false };
+  const positions: number[] = [];
   for (let cursor = 0; cursor <= text.length - pattern.length;) {
     const index = text.indexOf(pattern, cursor);
     if (index === -1) break;
-    occurrences.push(index);
+    positions.push(index);
+    if (positions.length >= MAX_EDIT_MATCHES) return { positions, truncated: true };
     cursor = index + pattern.length;
   }
-  return occurrences;
+  return { positions, truncated: false };
 }
 
-function findEditMatches(content: string, oldText: string): EditMatch[] {
+function originalOffsetForNormalizedBoundary(text: string, target: number): number | undefined {
+  if (target < 0) return undefined;
+  if (text.length === 0) return target === 0 ? 0 : undefined;
+
+  let normalizedOffset = 0;
+  for (let lineStart = 0; lineStart < text.length;) {
+    let lineEnd = lineStart;
+    while (lineEnd < text.length && text[lineEnd] !== "\n" && text[lineEnd] !== "\r") lineEnd += 1;
+
+    let contentEnd = lineEnd;
+    while (contentEnd > lineStart && (text[contentEnd - 1] === " " || text[contentEnd - 1] === "\t")) contentEnd -= 1;
+    const contentLength = contentEnd - lineStart;
+    if (target <= normalizedOffset + contentLength) return lineStart + target - normalizedOffset;
+    normalizedOffset += contentLength;
+
+    if (lineEnd === text.length) return target === normalizedOffset ? contentEnd : undefined;
+    let newlineEnd = lineEnd + 1;
+    if (text[lineEnd] === "\r" && text[newlineEnd] === "\n") newlineEnd += 1;
+    normalizedOffset += 1;
+    if (target <= normalizedOffset) return newlineEnd;
+    lineStart = newlineEnd;
+  }
+
+  return target === normalizedOffset ? text.length : undefined;
+}
+
+function findEditMatches(content: string, oldText: string): EditMatchSearch {
   const exactOccurrences = findEditOccurrences(content, oldText);
-  if (exactOccurrences.length > 0) {
-    return exactOccurrences.map((start) => ({ start, end: start + oldText.length, fuzzy: false }));
+  if (exactOccurrences.positions.length > 0) {
+    return {
+      matches: exactOccurrences.positions.map((start) => ({ start, end: start + oldText.length, fuzzy: false })),
+      truncated: exactOccurrences.truncated,
+    };
   }
 
   const normalizedContent = normalizeEditText(content);
   const normalizedOldText = normalizeEditText(oldText);
-  if (normalizedOldText.text.length === 0) return [];
+  if (normalizedOldText.text.length === 0) return { matches: [], truncated: false };
 
-  return findEditOccurrences(normalizedContent.text, normalizedOldText.text).flatMap((start) => {
+  const normalizedOccurrences = findEditOccurrences(normalizedContent.text, normalizedOldText.text);
+  const matches = normalizedOccurrences.positions.flatMap((start) => {
     const end = start + normalizedOldText.text.length;
-    const originalStart = normalizedContent.offsets[start];
-    const originalEnd = normalizedContent.offsets[end];
+    const originalStart = originalOffsetForNormalizedBoundary(content, start);
+    const originalEnd = originalOffsetForNormalizedBoundary(content, end);
     return originalStart === undefined || originalEnd === undefined
       ? []
       : [{ start: originalStart, end: originalEnd, fuzzy: true }];
   });
+  return { matches, truncated: normalizedOccurrences.truncated };
 }
 
 function editLineNumber(content: string, offset: number): number {
-  return content.slice(0, offset).split(/\r\n|\r|\n/).length;
+  const end = Math.min(Math.max(offset, 0), content.length);
+  let line = 1;
+  for (let index = 0; index < end; index += 1) {
+    if (content[index] === "\r") {
+      line += 1;
+      if (content[index + 1] === "\n") index += 1;
+    } else if (content[index] === "\n") {
+      line += 1;
+    }
+  }
+  return line;
+}
+
+function editLineBounds(content: string, start: number): { end: number; nextStart: number } {
+  let end = start;
+  while (end < content.length && content[end] !== "\n" && content[end] !== "\r") end += 1;
+  if (end === content.length) return { end, nextStart: end };
+  let nextStart = end + 1;
+  if (content[end] === "\r" && content[nextStart] === "\n") nextStart += 1;
+  return { end, nextStart };
+}
+
+function formatEditHintLine(content: string, start: number, end: number, lineNumber: number): string {
+  const preview = Array.from(content.slice(start, Math.min(end, start + 480))).slice(0, 240).join("");
+  return `${lineNumber}: ${preview}${end - start > 240 ? "..." : ""}`;
+}
+
+function collectEditHintCandidates(text: string): string[] {
+  const candidates: string[] = [];
+  const add = (raw: string) => {
+    const candidate = Array.from(raw.trim()).slice(0, 240).join("");
+    if (candidate.length < 4 || candidates.includes(candidate)) return;
+    candidates.push(candidate);
+    candidates.sort((left, right) => right.length - left.length);
+    if (candidates.length > 16) candidates.pop();
+  };
+
+  let line: string[] = [];
+  let token: string[] = [];
+  const flushLine = () => {
+    add(line.join(""));
+    line = [];
+  };
+  const flushToken = () => {
+    add(token.join(""));
+    token = [];
+  };
+
+  for (const character of text) {
+    if (character === "\r" || character === "\n") {
+      flushLine();
+      flushToken();
+      continue;
+    }
+    if (line.length < 240) line.push(character);
+    if (/^[A-Za-z0-9_./:-]$/.test(character)) {
+      if (token.length < 240) token.push(character);
+    } else {
+      flushToken();
+    }
+  }
+  flushLine();
+  flushToken();
+  return candidates;
 }
 
 function findEditHintBlock(content: string, oldText: string): string | undefined {
-  const contentLines = content.split(/\r\n|\r|\n/);
-  const oldLines = oldText.split(/\r\n|\r|\n/);
-  const anchors = oldLines
-    .map((line) => line.trim())
-    .filter((line) => line.length >= 4)
-    .sort((left, right) => right.length - left.length);
-  const tokens = oldText.match(/[A-Za-z0-9_./:-]{4,}/g) ?? [];
-  const candidates = [...anchors, ...[...new Set(tokens)].sort((left, right) => right.length - left.length)];
-
+  const candidates = collectEditHintCandidates(oldText);
   for (const candidate of candidates) {
-    const lineIndex = contentLines.findIndex((line) => line.includes(candidate));
-    if (lineIndex === -1) continue;
-    const start = Math.max(0, lineIndex - 1);
-    const end = Math.min(contentLines.length, lineIndex + 2);
-    return contentLines
-      .slice(start, end)
-      .map((line, index) => {
-        const lineCharacters = Array.from(line);
-        const displayLine = lineCharacters.length > 240 ? `${lineCharacters.slice(0, 240).join("")}...` : line;
-        return `${start + index + 1}: ${displayLine}`;
-      })
-      .join("\n");
+    let lineStart = 0;
+    let lineNumber = 1;
+    let previousLine: string | undefined;
+    while (lineStart <= content.length) {
+      const { end, nextStart } = editLineBounds(content, lineStart);
+      const candidateStart = content.indexOf(candidate, lineStart);
+      if (candidateStart >= lineStart && candidateStart < end) {
+        const lines = previousLine ? [previousLine] : [];
+        lines.push(formatEditHintLine(content, lineStart, end, lineNumber));
+        if (end < content.length) {
+          const nextBounds = editLineBounds(content, nextStart);
+          lines.push(formatEditHintLine(content, nextStart, nextBounds.end, lineNumber + 1));
+        }
+        return lines.join("\n");
+      }
+      previousLine = formatEditHintLine(content, lineStart, end, lineNumber);
+      if (end === content.length) break;
+      lineStart = nextStart;
+      lineNumber += 1;
+    }
   }
   return undefined;
 }
 
+function detectEditLineEnding(content: string): "\r\n" | "\r" | "\n" {
+  for (let index = 0; index < content.length; index += 1) {
+    if (content[index] === "\r") return content[index + 1] === "\n" ? "\r\n" : "\r";
+    if (content[index] === "\n") return "\n";
+  }
+  return "\n";
+}
+
 function restoreEditLineEndings(text: string, content: string): string {
   const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-  if (content.includes("\r\n")) return normalized.replace(/\n/g, "\r\n");
-  if (content.includes("\r")) return normalized.replace(/\n/g, "\r");
-  return normalized;
+  const ending = detectEditLineEnding(content);
+  return ending === "\n" ? normalized : normalized.replace(/\n/g, ending);
 }
 
 function formatEditMatchError(
@@ -276,6 +387,7 @@ function formatEditMatchError(
   index: number,
   total: number,
   matches: EditMatch[],
+  truncated: boolean,
 ): string {
   const label = total === 1 ? "oldText" : `edits[${index}].oldText`;
   if (matches.length === 0) {
@@ -286,8 +398,9 @@ function formatEditMatchError(
     return `${label} must match exactly one region in ${path}, found 0. Re-read the file and retry with the current text, including whitespace, newlines, and escaping.${hint}`;
   }
   const lines = matches.slice(0, 8).map((match) => editLineNumber(content, match.start));
-  const suffix = matches.length > lines.length ? ", ..." : "";
-  return `${label} must match exactly one region in ${path}, found ${matches.length} at lines [${lines.join(", ")}${suffix}]. Add surrounding context to oldText`;
+  const suffix = truncated || matches.length > lines.length ? ", ..." : "";
+  const count = truncated ? `${matches.length}+` : `${matches.length}`;
+  return `${label} must match exactly one region in ${path}, found ${count} at lines [${lines.join(", ")}${suffix}]. Add surrounding context to oldText`;
 }
 
 /**
@@ -300,20 +413,22 @@ export function applyEditsToContent(
   edits: Array<{ oldText: string; newText: string }>,
   path: string,
 ): string {
+  if (edits.length === 0) throw new Error("edits must contain at least one replacement");
   const bom = content.startsWith("\uFEFF") ? "\uFEFF" : "";
   const original = bom ? content.slice(1) : content;
   const replacements: Array<{ start: number; end: number; newText: string; index: number }> = [];
 
   for (const [index, edit] of edits.entries()) {
-    if (edit.oldText.length === 0) throw new Error(`edits[${index}].oldText must not be empty in ${path}`);
-    if (edit.oldText === edit.newText) throw new Error(`edits[${index}].oldText and newText must differ in ${path}`);
+    const oldText = edit.oldText.startsWith("\uFEFF") ? edit.oldText.slice(1) : edit.oldText;
+    if (oldText.length === 0) throw new Error(`edits[${index}].oldText must not be empty in ${path}`);
+    if (oldText === edit.newText) throw new Error(`edits[${index}].oldText and newText must differ in ${path}`);
 
-    const matches = findEditMatches(original, edit.oldText);
-    if (matches.length !== 1) {
-      throw new Error(formatEditMatchError(original, edit.oldText, path, index, edits.length, matches));
+    const search = findEditMatches(original, oldText);
+    if (search.matches.length !== 1) {
+      throw new Error(formatEditMatchError(original, oldText, path, index, edits.length, search.matches, search.truncated));
     }
 
-    const match = matches[0];
+      const match = search.matches[0];
     if (!match) throw new Error(`No match was available for edits[${index}] in ${path}`);
     replacements.push({
       start: match.start,
@@ -444,6 +559,7 @@ export function createEditTool(cwd: string, options: { operations: EditOperation
     parameters,
     async execute(_toolCallId, rawParams) {
       const params = rawParams as Static<typeof parameters>;
+      if (params.edits.length === 0) throw new Error("edits must contain at least one replacement");
       const absolutePath = resolveToCwd(params.path, cwd);
       await options.operations.access(absolutePath);
       if (options.operations.applyEdits) {

--- a/apps/agent/src/sandbox/tools.ts
+++ b/apps/agent/src/sandbox/tools.ts
@@ -426,6 +426,7 @@ function createRemoteWriteOperations(): WriteOperations {
 }
 
 function createRemoteEditOperations(): EditOperations {
+  const tracer = getAgentTracer();
   const readOps = createRemoteReadOperations();
   const writeOps = createRemoteWriteOperations();
   return {
@@ -439,19 +440,34 @@ function createRemoteEditOperations(): EditOperations {
     // retries are disabled: an edit that succeeded but lost its response must
     // not be replayed (the oldText would no longer match).
     async applyEdits(absolutePath, edits) {
-      const path = mapLocalAbsolutePathToSandboxPath(absolutePath);
-      const connection = await getCurrentConnection();
-      if (connection.capabilities?.fsEdit !== true) {
-        // Older sandboxes (e.g. a pinned local sandboxd) do not support
-        // fs.edit: fall back to the plain read-modify-write cycle, matching
-        // the pre-fs.edit behavior.
-        let content = (await readOps.readFile(absolutePath)).toString("utf-8");
-        content = applyEditsToContent(content, edits, absolutePath);
-        await writeOps.writeFile(absolutePath, content);
-        return edits.length;
-      }
-      const result = await tracedRpc(connection, "fs.edit", { path, edits }, undefined, false);
-      return result.applied;
+      const spaceId = getCurrentSpaceId();
+      const toolCtx = getCurrentToolExecutionContext();
+      incrementToolCallCount(toolCtx?.metrics);
+      const toolCallId = randomUUID();
+      return runWithToolExecutionContext({
+        spaceId: toolCtx?.spaceId ?? spaceId,
+        sessionId: toolCtx?.sessionId ?? "",
+        turnId: toolCtx?.turnId,
+        toolCallId,
+      }, async () => wrapToolCall(tracer, {
+        toolName: "edit",
+        input: { path: absolutePath, edits: edits.length },
+        ...getCurrentTraceContext(),
+      }, async () => {
+        const path = mapLocalAbsolutePathToSandboxPath(absolutePath);
+        const connection = await getCurrentConnection();
+        if (connection.capabilities?.fsEdit !== true) {
+          // Older sandboxes (e.g. a pinned local sandboxd) do not support
+          // fs.edit: fall back to the plain read-modify-write cycle, matching
+          // the pre-fs.edit behavior.
+          let content = (await readOps.readFile(absolutePath)).toString("utf-8");
+          content = applyEditsToContent(content, edits, absolutePath);
+          await writeOps.writeFile(absolutePath, content);
+          return edits.length;
+        }
+        const result = await tracedRpc(connection, "fs.edit", { path, edits }, undefined, false);
+        return result.applied;
+      }));
     },
   };
 }

--- a/apps/agent/src/tests/tool-optimistic-concurrency.test.ts
+++ b/apps/agent/src/tests/tool-optimistic-concurrency.test.ts
@@ -60,9 +60,52 @@ test("edit tolerates line ending and trailing whitespace differences", () => {
   assert.equal(updated, "prefix  \r\nnew\r\nsuffix\t\r\n");
 });
 
-test("edit preserves a UTF-8 BOM", () => {
-  const updated = applyEditsToContent("\uFEFFalpha\n", [{ oldText: "alpha", newText: "beta" }], PATH);
-  assert.equal(updated, "\uFEFFbeta\n");
+test("edit preserves a UTF-8 BOM whether oldText includes it or not", () => {
+  assert.equal(
+    applyEditsToContent("\uFEFFalpha\n", [{ oldText: "alpha", newText: "beta" }], PATH),
+    "\uFEFFbeta\n",
+  );
+  assert.equal(
+    applyEditsToContent("\uFEFFalpha\n", [{ oldText: "\uFEFFalpha", newText: "beta" }], PATH),
+    "\uFEFFbeta\n",
+  );
+});
+
+test("edit uses the same first line ending for mixed newline files", () => {
+  const updated = applyEditsToContent("a\rb\n", [{ oldText: "a\nb", newText: "x\ny" }], PATH);
+  assert.equal(updated, "x\ry\n");
+});
+
+test("edit rejects empty edits before touching the filesystem", async () => {
+  let accesses = 0;
+  let writes = 0;
+  const tool = createEditTool(CWD, {
+    operations: {
+      async access() {
+        accesses += 1;
+      },
+      async readFile() {
+        throw new Error("readFile must not be called");
+      },
+      async writeFile() {
+        writes += 1;
+      },
+    },
+  });
+
+  await assert.rejects(
+    tool.execute("call-1", { path: PATH, edits: [] }),
+    /edits must contain at least one replacement/,
+  );
+  assert.equal(accesses, 0);
+  assert.equal(writes, 0);
+});
+
+test("edit caps high-frequency match diagnostics", () => {
+  assert.throws(
+    () => applyEditsToContent("a".repeat(2_000_000), [{ oldText: "a", newText: "b" }], PATH),
+    /found 9\+ at lines \[1, 1, 1, 1, 1, 1, 1, 1, \.\.\.,?\]/,
+  );
 });
 
 test("edit matches all replacements against the original snapshot", () => {

--- a/apps/agent/src/tests/tool-optimistic-concurrency.test.ts
+++ b/apps/agent/src/tests/tool-optimistic-concurrency.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createEditTool, createWriteTool, type EditOperations, type WriteOperations } from "../runtime/tools/basic-tools.js";
+import { applyEditsToContent, createEditTool, createWriteTool, type EditOperations, type WriteOperations } from "../runtime/tools/basic-tools.js";
 
 const CWD = "/workspace";
 const PATH = "/workspace/a.ts";
@@ -52,6 +52,55 @@ test("edit falls back to read-modify-write without applyEdits", async () => {
   await tool.execute("call-1", { path: PATH, edits: [{ oldText: "alpha", newText: "ALPHA" }] });
   assert.equal(reads, 1);
   assert.equal(writes, 1);
+});
+
+test("edit tolerates line ending and trailing whitespace differences", () => {
+  const content = "prefix  \r\nold  \r\nsuffix\t\r\n";
+  const updated = applyEditsToContent(content, [{ oldText: "old\n", newText: "new\n" }], PATH);
+  assert.equal(updated, "prefix  \r\nnew\r\nsuffix\t\r\n");
+});
+
+test("edit preserves a UTF-8 BOM", () => {
+  const updated = applyEditsToContent("\uFEFFalpha\n", [{ oldText: "alpha", newText: "beta" }], PATH);
+  assert.equal(updated, "\uFEFFbeta\n");
+});
+
+test("edit matches all replacements against the original snapshot", () => {
+  assert.throws(
+    () => applyEditsToContent("alpha\n", [
+      { oldText: "alpha", newText: "beta" },
+      { oldText: "beta", newText: "gamma" },
+    ], PATH),
+    /edits\[1\]\.oldText must match exactly one region.*found 0/,
+  );
+});
+
+test("edit rejects overlapping replacements before writing", () => {
+  assert.throws(
+    () => applyEditsToContent("alpha\n", [
+      { oldText: "alpha", newText: "ALPHA" },
+      { oldText: "alpha\n", newText: "ALPHA\n" },
+    ], PATH),
+    /edits\[0\] and edits\[1\] overlap/,
+  );
+});
+
+test("edit keeps normalized duplicate matches ambiguous", () => {
+  assert.throws(
+    () => applyEditsToContent("alpha  \r\nalpha\t\r\n", [{ oldText: "alpha\n", newText: "x" }], PATH),
+    /found 2 at lines \[1, 2\]/,
+  );
+});
+
+test("edit reports match line numbers and a recovery instruction", () => {
+  assert.throws(
+    () => applyEditsToContent("alpha\nalpha\nbeta\n", [{ oldText: "alpha", newText: "x" }], PATH),
+    /found 2 at lines \[1, 2\].*Add surrounding context/,
+  );
+  assert.throws(
+    () => applyEditsToContent("alpha\nbeta\n", [{ oldText: "alpah", newText: "x" }], PATH),
+    /found 0.*Re-read the file and retry/,
+  );
 });
 
 test("write stays a plain write", async () => {

--- a/apps/sandbox/rpc/dispatcher.go
+++ b/apps/sandbox/rpc/dispatcher.go
@@ -160,14 +160,6 @@ type fsReadParams struct {
 	Binary bool   `json:"binary"`
 }
 
-func fileCtimeMs(info os.FileInfo) (int64, bool) {
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return 0, false
-	}
-	return stat.Ctim.Sec*1000 + stat.Ctim.Nsec/1_000_000, true
-}
-
 type fsWriteParams struct {
 	Path      string          `json:"path"`
 	CWD       string          `json:"cwd"`

--- a/apps/sandbox/rpc/dispatcher.go
+++ b/apps/sandbox/rpc/dispatcher.go
@@ -195,15 +195,6 @@ type fsEditParams struct {
 	Edits []fsEditItem `json:"edits"`
 }
 
-// editMatchError reports an oldText that matches 0 or multiple regions.
-type editMatchError struct {
-	matches int
-}
-
-func (e *editMatchError) Error() string {
-	return fmt.Sprintf("oldText matched %d regions", e.matches)
-}
-
 type fsMkdirParams struct {
 	Path string `json:"path"`
 	CWD  string `json:"cwd"`
@@ -474,29 +465,27 @@ func (d *Dispatcher) handleFSEdit(request protocol.RPCRequest) interface{} {
 		return d.failed(request, "", "NOT_DIRECTORY", fmt.Sprintf("cannot edit a directory: %s", resolved.path))
 	}
 
-	// Read, edit application, and write run atomically under the per-path
-	// lock: edits are always applied to the latest content, so concurrent
-	// edits to disjoint regions compose instead of losing updates. Each
-	// oldText is matched incrementally against the result of the previous
-	// edit, mirroring the tool-layer semantics it replaces. The response
-	// version (bytesWritten/mtimeMs) is captured under the lock so it cannot
-	// belong to a subsequent writer.
+	// Read, edit validation, and write run atomically under the per-path lock:
+	// all edits are matched against the same latest snapshot, then applied only
+	// after every range is valid and non-overlapping. The response version
+	// (bytesWritten/mtimeMs) is captured under the lock so it cannot belong to a
+	// subsequent writer.
 	var applied int
 	var bytesWritten int64
 	var mtimeMs int64
+	var currentContent string
 	lockErr := withPathLock(resolved.path, func() error {
 		content, err := os.ReadFile(resolved.path)
 		if err != nil {
 			return err
 		}
 		text := string(content)
-		for _, edit := range params.Edits {
-			matches := strings.Count(text, edit.OldText)
-			if matches != 1 {
-				return &editMatchError{matches: matches}
-			}
-			text = strings.Replace(text, edit.OldText, edit.NewText, 1)
+		currentContent = text
+		updated, err := applyFSEdits(text, params.Edits)
+		if err != nil {
+			return err
 		}
+		text = updated
 		applied = len(params.Edits)
 		if err := os.WriteFile(resolved.path, []byte(text), 0o644); err != nil {
 			return err
@@ -508,10 +497,19 @@ func (d *Dispatcher) handleFSEdit(request protocol.RPCRequest) interface{} {
 	if lockErr != nil {
 		var matchErr *editMatchError
 		if errors.As(lockErr, &matchErr) {
+			message := formatFSEditMatchError(resolved.path, currentContent, matchErr, params.Edits[matchErr.index].OldText, len(params.Edits))
 			if matchErr.matches == 0 {
-				return d.failed(request, "", "EDIT_NOT_FOUND", fmt.Sprintf("oldText must match exactly one region in %s, found 0", resolved.path))
+				return d.failed(request, "", "EDIT_NOT_FOUND", message)
 			}
-			return d.failed(request, "", "EDIT_NOT_UNIQUE", fmt.Sprintf("oldText must match exactly one region in %s, found %d", resolved.path, matchErr.matches))
+			return d.failed(request, "", "EDIT_NOT_UNIQUE", message)
+		}
+		var inputErr *editInputError
+		if errors.As(lockErr, &inputErr) {
+			return d.failed(request, "", "BAD_REQUEST", inputErr.Error())
+		}
+		var overlapErr *editOverlapError
+		if errors.As(lockErr, &overlapErr) {
+			return d.failed(request, "", "BAD_REQUEST", overlapErr.Error()+"; merge nearby changes into one edit")
 		}
 		if errors.Is(lockErr, os.ErrNotExist) {
 			return d.failed(request, "", "NOT_FOUND", fmt.Sprintf("file not found: %s", resolved.path))

--- a/apps/sandbox/rpc/edit.go
+++ b/apps/sandbox/rpc/edit.go
@@ -1,0 +1,324 @@
+package rpc
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type editReplacement struct {
+	index   int
+	start   int
+	end     int
+	newText string
+}
+
+type editMatch struct {
+	start int
+	end   int
+	fuzzy bool
+}
+
+type editMatchError struct {
+	index   int
+	matches int
+	lines   []int
+}
+
+func (e *editMatchError) Error() string {
+	return fmt.Sprintf("edit %d matched %d regions", e.index+1, e.matches)
+}
+
+type editInputError struct {
+	index   int
+	message string
+}
+
+func (e *editInputError) Error() string {
+	return fmt.Sprintf("edits[%d].%s", e.index, e.message)
+}
+
+type editOverlapError struct {
+	first  int
+	second int
+}
+
+func (e *editOverlapError) Error() string {
+	return fmt.Sprintf("edits[%d] and edits[%d] overlap", e.first, e.second)
+}
+
+type normalizedEditText struct {
+	text    string
+	offsets []int
+}
+
+// normalizeEditText only removes representational differences that are safe to
+// repair without changing untouched lines: CRLF/CR line endings and spaces or
+// tabs at the end of a line. offsets maps normalized byte boundaries back to
+// the original content so fuzzy edits preserve the rest of the file verbatim.
+func normalizeEditText(text string) normalizedEditText {
+	var normalized strings.Builder
+	offsets := make([]int, 1, len(text)+1)
+
+	for lineStart := 0; lineStart < len(text); {
+		lineEnd := lineStart
+		for lineEnd < len(text) && text[lineEnd] != '\n' && text[lineEnd] != '\r' {
+			lineEnd++
+		}
+
+		contentEnd := lineEnd
+		for contentEnd > lineStart && (text[contentEnd-1] == ' ' || text[contentEnd-1] == '\t') {
+			contentEnd--
+		}
+		normalized.WriteString(text[lineStart:contentEnd])
+		for index := lineStart; index < contentEnd; index++ {
+			offsets = append(offsets, index+1)
+		}
+
+		if lineEnd == len(text) {
+			break
+		}
+		newlineEnd := lineEnd + 1
+		if text[lineEnd] == '\r' && newlineEnd < len(text) && text[newlineEnd] == '\n' {
+			newlineEnd++
+		}
+		normalized.WriteByte('\n')
+		offsets = append(offsets, newlineEnd)
+		lineStart = newlineEnd
+	}
+
+	return normalizedEditText{text: normalized.String(), offsets: offsets}
+}
+
+func findEditOccurrences(text, pattern string) []int {
+	if pattern == "" {
+		return nil
+	}
+	occurrences := make([]int, 0, 1)
+	for cursor := 0; cursor <= len(text)-len(pattern); {
+		relative := strings.Index(text[cursor:], pattern)
+		if relative < 0 {
+			break
+		}
+		index := cursor + relative
+		occurrences = append(occurrences, index)
+		cursor = index + len(pattern)
+	}
+	return occurrences
+}
+
+func findEditMatches(content, oldText string) []editMatch {
+	exactOccurrences := findEditOccurrences(content, oldText)
+	if len(exactOccurrences) > 0 {
+		matches := make([]editMatch, 0, len(exactOccurrences))
+		for _, start := range exactOccurrences {
+			matches = append(matches, editMatch{start: start, end: start + len(oldText)})
+		}
+		return matches
+	}
+
+	normalizedContent := normalizeEditText(content)
+	normalizedOldText := normalizeEditText(oldText)
+	if normalizedOldText.text == "" {
+		return nil
+	}
+	normalizedOccurrences := findEditOccurrences(normalizedContent.text, normalizedOldText.text)
+	matches := make([]editMatch, 0, len(normalizedOccurrences))
+	for _, start := range normalizedOccurrences {
+		end := start + len(normalizedOldText.text)
+		if start >= len(normalizedContent.offsets) || end >= len(normalizedContent.offsets) {
+			continue
+		}
+		matches = append(matches, editMatch{
+			start: normalizedContent.offsets[start],
+			end:   normalizedContent.offsets[end],
+			fuzzy: true,
+		})
+	}
+	return matches
+}
+
+func editLineNumber(content string, offset int) int {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > len(content) {
+		offset = len(content)
+	}
+	return len(splitEditLines(content[:offset]))
+}
+
+func editLineEnding(content string) string {
+	if strings.Contains(content, "\r\n") {
+		return "\r\n"
+	}
+	if strings.Contains(content, "\r") && !strings.Contains(content, "\n") {
+		return "\r"
+	}
+	return "\n"
+}
+
+func restoreEditLineEndings(text, content string) string {
+	normalized := strings.ReplaceAll(strings.ReplaceAll(text, "\r\n", "\n"), "\r", "\n")
+	ending := editLineEnding(content)
+	if ending == "\n" {
+		return normalized
+	}
+	return strings.ReplaceAll(normalized, "\n", ending)
+}
+
+func splitEditLines(text string) []string {
+	return strings.Split(strings.ReplaceAll(strings.ReplaceAll(text, "\r\n", "\n"), "\r", "\n"), "\n")
+}
+
+func editTokens(text string) []string {
+	var tokens []string
+	var current strings.Builder
+	flush := func() {
+		if current.Len() >= 4 {
+			tokens = append(tokens, current.String())
+		}
+		current.Reset()
+	}
+	for _, char := range text {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') || strings.ContainsRune("_./:-", char) {
+			current.WriteRune(char)
+			continue
+		}
+		flush()
+	}
+	flush()
+	return tokens
+}
+
+func editHintBlock(content, oldText string) string {
+	contentLines := splitEditLines(content)
+	oldLines := splitEditLines(oldText)
+	candidates := make([]string, 0, len(oldLines)+4)
+	for _, line := range oldLines {
+		line = strings.TrimSpace(line)
+		if len(line) >= 4 {
+			candidates = append(candidates, line)
+		}
+	}
+	candidates = append(candidates, editTokens(oldText)...)
+	sort.SliceStable(candidates, func(left, right int) bool { return len(candidates[left]) > len(candidates[right]) })
+	for _, candidate := range candidates {
+		lineIndex := -1
+		for index, line := range contentLines {
+			if strings.Contains(line, candidate) {
+				lineIndex = index
+				break
+			}
+		}
+		if lineIndex < 0 {
+			continue
+		}
+		start := lineIndex - 1
+		if start < 0 {
+			start = 0
+		}
+		end := lineIndex + 2
+		if end > len(contentLines) {
+			end = len(contentLines)
+		}
+		var hint strings.Builder
+		for index := start; index < end; index++ {
+			line := contentLines[index]
+			lineRunes := []rune(line)
+			if len(lineRunes) > 240 {
+				line = string(lineRunes[:240]) + "..."
+			}
+			if hint.Len() > 0 {
+				hint.WriteByte('\n')
+			}
+			fmt.Fprintf(&hint, "%d: %s", index+1, line)
+		}
+		return hint.String()
+	}
+	return ""
+}
+
+func formatFSEditMatchError(path, content string, matchErr *editMatchError, oldText string, total int) string {
+	label := "oldText"
+	if total > 1 {
+		label = fmt.Sprintf("edits[%d].oldText", matchErr.index)
+	}
+	if matchErr.matches == 0 {
+		hintBlock := editHintBlock(content, oldText)
+		if hintBlock != "" {
+			return fmt.Sprintf("%s must match exactly one region in %s, found 0. Re-read the file and retry with the current text, including whitespace, newlines, and escaping. Current nearby text:\n%s\nCopy the current text exactly; do not reuse stale oldText", label, path, hintBlock)
+		}
+		return fmt.Sprintf("%s must match exactly one region in %s, found 0. Re-read the file and retry with the current text, including whitespace, newlines, and escaping", label, path)
+	}
+	lineValues := make([]string, 0, len(matchErr.lines))
+	for _, line := range matchErr.lines {
+		lineValues = append(lineValues, fmt.Sprintf("%d", line))
+		if len(lineValues) == 8 {
+			break
+		}
+	}
+	suffix := ""
+	if len(matchErr.lines) > len(lineValues) {
+		suffix = ", ..."
+	}
+	return fmt.Sprintf("%s must match exactly one region in %s, found %d at lines [%s%s]. Add surrounding context to oldText", label, path, matchErr.matches, strings.Join(lineValues, ", "), suffix)
+}
+
+func applyFSEdits(content string, edits []fsEditItem) (string, error) {
+	bom := ""
+	matchingContent := content
+	if strings.HasPrefix(matchingContent, "\uFEFF") {
+		bom = "\uFEFF"
+		matchingContent = matchingContent[len(bom):]
+	}
+
+	replacements := make([]editReplacement, 0, len(edits))
+	for index, edit := range edits {
+		if edit.OldText == "" {
+			return "", &editInputError{index: index, message: "oldText must not be empty"}
+		}
+		if edit.OldText == edit.NewText {
+			return "", &editInputError{index: index, message: "oldText and newText must differ"}
+		}
+
+		matches := findEditMatches(matchingContent, edit.OldText)
+		if len(matches) != 1 {
+			lines := make([]int, 0, len(matches))
+			for _, match := range matches {
+				lines = append(lines, editLineNumber(matchingContent, match.start))
+			}
+			return "", &editMatchError{index: index, matches: len(matches), lines: lines}
+		}
+
+		match := matches[0]
+		newText := edit.NewText
+		if match.fuzzy {
+			newText = restoreEditLineEndings(edit.NewText, matchingContent)
+		}
+		replacements = append(replacements, editReplacement{
+			index:   index,
+			start:   match.start,
+			end:     match.end,
+			newText: newText,
+		})
+	}
+
+	sort.SliceStable(replacements, func(left, right int) bool {
+		return replacements[left].start < replacements[right].start
+	})
+	for index := 1; index < len(replacements); index++ {
+		previous := replacements[index-1]
+		current := replacements[index]
+		if previous.end > current.start {
+			return "", &editOverlapError{first: previous.index, second: current.index}
+		}
+	}
+
+	updated := matchingContent
+	for index := len(replacements) - 1; index >= 0; index-- {
+		replacement := replacements[index]
+		updated = updated[:replacement.start] + replacement.newText + updated[replacement.end:]
+	}
+	return bom + updated, nil
+}

--- a/apps/sandbox/rpc/edit.go
+++ b/apps/sandbox/rpc/edit.go
@@ -20,9 +20,10 @@ type editMatch struct {
 }
 
 type editMatchError struct {
-	index   int
-	matches int
-	lines   []int
+	index     int
+	matches   int
+	lines     []int
+	truncated bool
 }
 
 func (e *editMatchError) Error() string {
@@ -35,6 +36,9 @@ type editInputError struct {
 }
 
 func (e *editInputError) Error() string {
+	if e.index < 0 {
+		return e.message
+	}
 	return fmt.Sprintf("edits[%d].%s", e.index, e.message)
 }
 
@@ -48,17 +52,28 @@ func (e *editOverlapError) Error() string {
 }
 
 type normalizedEditText struct {
-	text    string
-	offsets []int
+	text string
+}
+
+const maxEditMatches = 9
+
+type editOccurrenceSearch struct {
+	positions []int
+	truncated bool
+}
+
+type editMatchSearch struct {
+	matches   []editMatch
+	truncated bool
 }
 
 // normalizeEditText only removes representational differences that are safe to
 // repair without changing untouched lines: CRLF/CR line endings and spaces or
-// tabs at the end of a line. offsets maps normalized byte boundaries back to
-// the original content so fuzzy edits preserve the rest of the file verbatim.
+// tabs at the end of a line. Match boundaries are mapped back lazily so a
+// high-frequency failed search never allocates one entry per source byte.
 func normalizeEditText(text string) normalizedEditText {
 	var normalized strings.Builder
-	offsets := make([]int, 1, len(text)+1)
+	normalized.Grow(len(text))
 
 	for lineStart := 0; lineStart < len(text); {
 		lineEnd := lineStart
@@ -71,9 +86,6 @@ func normalizeEditText(text string) normalizedEditText {
 			contentEnd--
 		}
 		normalized.WriteString(text[lineStart:contentEnd])
-		for index := lineStart; index < contentEnd; index++ {
-			offsets = append(offsets, index+1)
-		}
 
 		if lineEnd == len(text) {
 			break
@@ -83,18 +95,17 @@ func normalizeEditText(text string) normalizedEditText {
 			newlineEnd++
 		}
 		normalized.WriteByte('\n')
-		offsets = append(offsets, newlineEnd)
 		lineStart = newlineEnd
 	}
 
-	return normalizedEditText{text: normalized.String(), offsets: offsets}
+	return normalizedEditText{text: normalized.String()}
 }
 
-func findEditOccurrences(text, pattern string) []int {
+func findEditOccurrences(text, pattern string) editOccurrenceSearch {
 	if pattern == "" {
-		return nil
+		return editOccurrenceSearch{}
 	}
-	occurrences := make([]int, 0, 1)
+	occurrences := make([]int, 0, maxEditMatches)
 	for cursor := 0; cursor <= len(text)-len(pattern); {
 		relative := strings.Index(text[cursor:], pattern)
 		if relative < 0 {
@@ -102,40 +113,82 @@ func findEditOccurrences(text, pattern string) []int {
 		}
 		index := cursor + relative
 		occurrences = append(occurrences, index)
+		if len(occurrences) >= maxEditMatches {
+			return editOccurrenceSearch{positions: occurrences, truncated: true}
+		}
 		cursor = index + len(pattern)
 	}
-	return occurrences
+	return editOccurrenceSearch{positions: occurrences}
 }
 
-func findEditMatches(content, oldText string) []editMatch {
+func originalOffsetForNormalizedBoundary(text string, target int) (int, bool) {
+	if target < 0 {
+		return 0, false
+	}
+	if len(text) == 0 {
+		return 0, target == 0
+	}
+
+	normalizedOffset := 0
+	for lineStart := 0; lineStart < len(text); {
+		lineEnd := lineStart
+		for lineEnd < len(text) && text[lineEnd] != '\n' && text[lineEnd] != '\r' {
+			lineEnd++
+		}
+
+		contentEnd := lineEnd
+		for contentEnd > lineStart && (text[contentEnd-1] == ' ' || text[contentEnd-1] == '\t') {
+			contentEnd--
+		}
+		contentLength := contentEnd - lineStart
+		if target <= normalizedOffset+contentLength {
+			return lineStart + target - normalizedOffset, true
+		}
+		normalizedOffset += contentLength
+
+		if lineEnd == len(text) {
+			return contentEnd, target == normalizedOffset
+		}
+		newlineEnd := lineEnd + 1
+		if text[lineEnd] == '\r' && text[newlineEnd] == '\n' {
+			newlineEnd++
+		}
+		normalizedOffset++
+		if target <= normalizedOffset {
+			return newlineEnd, true
+		}
+		lineStart = newlineEnd
+	}
+	return len(text), target == normalizedOffset
+}
+
+func findEditMatches(content, oldText string) editMatchSearch {
 	exactOccurrences := findEditOccurrences(content, oldText)
-	if len(exactOccurrences) > 0 {
-		matches := make([]editMatch, 0, len(exactOccurrences))
-		for _, start := range exactOccurrences {
+	if len(exactOccurrences.positions) > 0 {
+		matches := make([]editMatch, 0, len(exactOccurrences.positions))
+		for _, start := range exactOccurrences.positions {
 			matches = append(matches, editMatch{start: start, end: start + len(oldText)})
 		}
-		return matches
+		return editMatchSearch{matches: matches, truncated: exactOccurrences.truncated}
 	}
 
 	normalizedContent := normalizeEditText(content)
 	normalizedOldText := normalizeEditText(oldText)
 	if normalizedOldText.text == "" {
-		return nil
+		return editMatchSearch{}
 	}
 	normalizedOccurrences := findEditOccurrences(normalizedContent.text, normalizedOldText.text)
-	matches := make([]editMatch, 0, len(normalizedOccurrences))
-	for _, start := range normalizedOccurrences {
+	matches := make([]editMatch, 0, len(normalizedOccurrences.positions))
+	for _, start := range normalizedOccurrences.positions {
 		end := start + len(normalizedOldText.text)
-		if start >= len(normalizedContent.offsets) || end >= len(normalizedContent.offsets) {
+		originalStart, startOK := originalOffsetForNormalizedBoundary(content, start)
+		originalEnd, endOK := originalOffsetForNormalizedBoundary(content, end)
+		if !startOK || !endOK {
 			continue
 		}
-		matches = append(matches, editMatch{
-			start: normalizedContent.offsets[start],
-			end:   normalizedContent.offsets[end],
-			fuzzy: true,
-		})
+		matches = append(matches, editMatch{start: originalStart, end: originalEnd, fuzzy: true})
 	}
-	return matches
+	return editMatchSearch{matches: matches, truncated: normalizedOccurrences.truncated}
 }
 
 func editLineNumber(content string, offset int) int {
@@ -145,15 +198,32 @@ func editLineNumber(content string, offset int) int {
 	if offset > len(content) {
 		offset = len(content)
 	}
-	return len(splitEditLines(content[:offset]))
+	line := 1
+	for index := 0; index < offset; index++ {
+		switch content[index] {
+		case '\r':
+			line++
+			if index+1 < offset && content[index+1] == '\n' {
+				index++
+			}
+		case '\n':
+			line++
+		}
+	}
+	return line
 }
 
 func editLineEnding(content string) string {
-	if strings.Contains(content, "\r\n") {
-		return "\r\n"
-	}
-	if strings.Contains(content, "\r") && !strings.Contains(content, "\n") {
-		return "\r"
+	for index := 0; index < len(content); index++ {
+		switch content[index] {
+		case '\r':
+			if index+1 < len(content) && content[index+1] == '\n' {
+				return "\r\n"
+			}
+			return "\r"
+		case '\n':
+			return "\n"
+		}
 	}
 	return "\n"
 }
@@ -167,33 +237,97 @@ func restoreEditLineEndings(text, content string) string {
 	return strings.ReplaceAll(normalized, "\n", ending)
 }
 
-func splitEditLines(text string) []string {
-	return strings.Split(strings.ReplaceAll(strings.ReplaceAll(text, "\r\n", "\n"), "\r", "\n"), "\n")
-}
-
-func editTokens(text string) []string {
-	var tokens []string
-	var current strings.Builder
-	flush := func() {
-		if current.Len() >= 4 {
-			tokens = append(tokens, current.String())
+func collectEditHintCandidates(text string) []string {
+	candidates := make([]string, 0, 16)
+	add := func(raw string) {
+		candidate := strings.TrimSpace(raw)
+		runes := []rune(candidate)
+		if len(runes) < 4 {
+			return
 		}
-		current.Reset()
+		if len(runes) > 240 {
+			candidate = string(runes[:240])
+		}
+		for _, existing := range candidates {
+			if existing == candidate {
+				return
+			}
+		}
+		candidates = append(candidates, candidate)
+		sort.SliceStable(candidates, func(left, right int) bool { return len(candidates[left]) > len(candidates[right]) })
+		if len(candidates) > 16 {
+			candidates = candidates[:16]
+		}
+	}
+
+	var line strings.Builder
+	var token strings.Builder
+	lineRunes := 0
+	tokenRunes := 0
+	flushLine := func() {
+		add(line.String())
+		line.Reset()
+		lineRunes = 0
+	}
+	flushToken := func() {
+		add(token.String())
+		token.Reset()
+		tokenRunes = 0
 	}
 	for _, char := range text {
-		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') || strings.ContainsRune("_./:-", char) {
-			current.WriteRune(char)
+		if char == '\n' || char == '\r' {
+			flushLine()
+			flushToken()
 			continue
 		}
-		flush()
+		if lineRunes < 240 {
+			line.WriteRune(char)
+			lineRunes++
+		}
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') || strings.ContainsRune("_./:-", char) {
+			if tokenRunes < 240 {
+				token.WriteRune(char)
+				tokenRunes++
+			}
+		} else {
+			flushToken()
+		}
 	}
-	flush()
-	return tokens
+	flushLine()
+	flushToken()
+	return candidates
+}
+
+func editLineBounds(content string, start int) (end int, nextStart int) {
+	end = start
+	for end < len(content) && content[end] != '\n' && content[end] != '\r' {
+		end++
+	}
+	if end == len(content) {
+		return end, end
+	}
+	nextStart = end + 1
+	if content[end] == '\r' && nextStart < len(content) && content[nextStart] == '\n' {
+		nextStart++
+	}
+	return end, nextStart
+}
+
+func formatEditHintLine(content string, start, end, lineNumber int) string {
+	line := content[start:end]
+	runeCount := 0
+	for index := range line {
+		if runeCount == 240 {
+			line = line[:index] + "..."
+			break
+		}
+		runeCount++
+	}
+	return fmt.Sprintf("%d: %s", lineNumber, line)
 }
 
 func editHintBlock(content, oldText string) string {
-	contentLines := splitEditLines(content)
-	oldLines := splitEditLines(oldText)
+	oldLines := strings.Split(strings.ReplaceAll(strings.ReplaceAll(oldText, "\r\n", "\n"), "\r", "\n"), "\n")
 	candidates := make([]string, 0, len(oldLines)+4)
 	for _, line := range oldLines {
 		line = strings.TrimSpace(line)
@@ -201,40 +335,37 @@ func editHintBlock(content, oldText string) string {
 			candidates = append(candidates, line)
 		}
 	}
-	candidates = append(candidates, editTokens(oldText)...)
+	candidates = append(candidates, collectEditHintCandidates(oldText)...)
 	sort.SliceStable(candidates, func(left, right int) bool { return len(candidates[left]) > len(candidates[right]) })
+	if len(candidates) > 16 {
+		candidates = candidates[:16]
+	}
 	for _, candidate := range candidates {
-		lineIndex := -1
-		for index, line := range contentLines {
-			if strings.Contains(line, candidate) {
-				lineIndex = index
+		lineStart := 0
+		lineNumber := 1
+		previousLine := ""
+		for lineStart <= len(content) {
+			lineEnd, nextStart := editLineBounds(content, lineStart)
+			candidateStart := strings.Index(content[lineStart:lineEnd], candidate)
+			if candidateStart >= 0 {
+				lines := make([]string, 0, 3)
+				if previousLine != "" {
+					lines = append(lines, previousLine)
+				}
+				lines = append(lines, formatEditHintLine(content, lineStart, lineEnd, lineNumber))
+				if lineEnd < len(content) {
+					nextEnd, _ := editLineBounds(content, nextStart)
+					lines = append(lines, formatEditHintLine(content, nextStart, nextEnd, lineNumber+1))
+				}
+				return strings.Join(lines, "\n")
+			}
+			previousLine = formatEditHintLine(content, lineStart, lineEnd, lineNumber)
+			if lineEnd == len(content) {
 				break
 			}
+			lineStart = nextStart
+			lineNumber++
 		}
-		if lineIndex < 0 {
-			continue
-		}
-		start := lineIndex - 1
-		if start < 0 {
-			start = 0
-		}
-		end := lineIndex + 2
-		if end > len(contentLines) {
-			end = len(contentLines)
-		}
-		var hint strings.Builder
-		for index := start; index < end; index++ {
-			line := contentLines[index]
-			lineRunes := []rune(line)
-			if len(lineRunes) > 240 {
-				line = string(lineRunes[:240]) + "..."
-			}
-			if hint.Len() > 0 {
-				hint.WriteByte('\n')
-			}
-			fmt.Fprintf(&hint, "%d: %s", index+1, line)
-		}
-		return hint.String()
 	}
 	return ""
 }
@@ -259,13 +390,20 @@ func formatFSEditMatchError(path, content string, matchErr *editMatchError, oldT
 		}
 	}
 	suffix := ""
-	if len(matchErr.lines) > len(lineValues) {
+	if matchErr.truncated || len(matchErr.lines) > len(lineValues) {
 		suffix = ", ..."
 	}
-	return fmt.Sprintf("%s must match exactly one region in %s, found %d at lines [%s%s]. Add surrounding context to oldText", label, path, matchErr.matches, strings.Join(lineValues, ", "), suffix)
+	count := fmt.Sprintf("%d", matchErr.matches)
+	if matchErr.truncated {
+		count += "+"
+	}
+	return fmt.Sprintf("%s must match exactly one region in %s, found %s at lines [%s%s]. Add surrounding context to oldText", label, path, count, strings.Join(lineValues, ", "), suffix)
 }
 
 func applyFSEdits(content string, edits []fsEditItem) (string, error) {
+	if len(edits) == 0 {
+		return "", &editInputError{index: -1, message: "edits must contain at least one replacement"}
+	}
 	bom := ""
 	matchingContent := content
 	if strings.HasPrefix(matchingContent, "\uFEFF") {
@@ -275,23 +413,24 @@ func applyFSEdits(content string, edits []fsEditItem) (string, error) {
 
 	replacements := make([]editReplacement, 0, len(edits))
 	for index, edit := range edits {
-		if edit.OldText == "" {
+		oldText := strings.TrimPrefix(edit.OldText, "\uFEFF")
+		if oldText == "" {
 			return "", &editInputError{index: index, message: "oldText must not be empty"}
 		}
-		if edit.OldText == edit.NewText {
+		if oldText == edit.NewText {
 			return "", &editInputError{index: index, message: "oldText and newText must differ"}
 		}
 
-		matches := findEditMatches(matchingContent, edit.OldText)
-		if len(matches) != 1 {
-			lines := make([]int, 0, len(matches))
-			for _, match := range matches {
+		search := findEditMatches(matchingContent, oldText)
+		if len(search.matches) != 1 {
+			lines := make([]int, 0, len(search.matches))
+			for _, match := range search.matches {
 				lines = append(lines, editLineNumber(matchingContent, match.start))
 			}
-			return "", &editMatchError{index: index, matches: len(matches), lines: lines}
+			return "", &editMatchError{index: index, matches: len(search.matches), lines: lines, truncated: search.truncated}
 		}
 
-		match := matches[0]
+		match := search.matches[0]
 		newText := edit.NewText
 		if match.fuzzy {
 			newText = restoreEditLineEndings(edit.NewText, matchingContent)

--- a/apps/sandbox/rpc/edit_test.go
+++ b/apps/sandbox/rpc/edit_test.go
@@ -1,0 +1,105 @@
+package rpc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cohub/apps/sandbox/protocol"
+)
+
+func TestApplyFSEditsNormalizesRepresentationDifferences(t *testing.T) {
+	content := "prefix  \r\nold  \r\nsuffix\t\r\n"
+	updated, err := applyFSEdits(content, []fsEditItem{{OldText: "old\n", NewText: "new\n"}})
+	if err != nil {
+		t.Fatalf("apply edits: %v", err)
+	}
+	want := "prefix  \r\nnew\r\nsuffix\t\r\n"
+	if updated != want {
+		t.Fatalf("updated content = %q, want %q", updated, want)
+	}
+}
+
+func TestApplyFSEditsKeepsNormalizedDuplicateMatchesAmbiguous(t *testing.T) {
+	_, err := applyFSEdits("alpha  \r\nalpha\t\r\n", []fsEditItem{{OldText: "alpha\n", NewText: "x"}})
+	matchErr, ok := err.(*editMatchError)
+	if !ok {
+		t.Fatalf("error = %T (%v), want editMatchError", err, err)
+	}
+	if matchErr.matches != 2 || len(matchErr.lines) != 2 || matchErr.lines[0] != 1 || matchErr.lines[1] != 2 {
+		t.Fatalf("match error = %+v, want two matches on lines 1 and 2", matchErr)
+	}
+}
+
+func TestApplyFSEditsPreservesBOM(t *testing.T) {
+	updated, err := applyFSEdits("\uFEFFalpha\n", []fsEditItem{{OldText: "alpha", NewText: "beta"}})
+	if err != nil {
+		t.Fatalf("apply edits: %v", err)
+	}
+	if updated != "\uFEFFbeta\n" {
+		t.Fatalf("updated content = %q, want BOM-preserving replacement", updated)
+	}
+}
+
+func TestApplyFSEditsMatchesAgainstOriginalSnapshot(t *testing.T) {
+	_, err := applyFSEdits("alpha\n", []fsEditItem{
+		{OldText: "alpha", NewText: "beta"},
+		{OldText: "beta", NewText: "gamma"},
+	})
+	matchErr, ok := err.(*editMatchError)
+	if !ok {
+		t.Fatalf("error = %T (%v), want editMatchError", err, err)
+	}
+	if matchErr.index != 1 || matchErr.matches != 0 {
+		t.Fatalf("match error = %+v, want edit index 1 with zero matches", matchErr)
+	}
+}
+
+func TestApplyFSEditsRejectsOverlappingRanges(t *testing.T) {
+	_, err := applyFSEdits("alpha\n", []fsEditItem{
+		{OldText: "alpha", NewText: "ALPHA"},
+		{OldText: "alpha\n", NewText: "ALPHA\n"},
+	})
+	overlapErr, ok := err.(*editOverlapError)
+	if !ok {
+		t.Fatalf("error = %T (%v), want editOverlapError", err, err)
+	}
+	if overlapErr.first != 0 || overlapErr.second != 1 {
+		t.Fatalf("overlap error = %+v, want edits 0 and 1", overlapErr)
+	}
+}
+
+func TestFSEditMatchErrorIncludesRecoveryAndLineHints(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+	if err := writeTextForEditTest(root, "a.txt", "alpha\nalpha\nbeta\n"); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	notFound := d.handleFSEdit(editRequest(t, fsEditParams{Path: "a.txt", Edits: []fsEditItem{{OldText: "alpah", NewText: "x"}}}))
+	failed, ok := notFound.(protocol.RPCFailed)
+	if !ok {
+		t.Fatalf("not-found result = %T (%v)", notFound, notFound)
+	}
+	if !strings.Contains(failed.Error.Message, "Re-read the file and retry") {
+		t.Fatalf("not-found message = %q, missing recovery instruction", failed.Error.Message)
+	}
+
+	notUnique := d.handleFSEdit(editRequest(t, fsEditParams{Path: "a.txt", Edits: []fsEditItem{{OldText: "alpha", NewText: "x"}}}))
+	failed, ok = notUnique.(protocol.RPCFailed)
+	if !ok {
+		t.Fatalf("not-unique result = %T (%v)", notUnique, notUnique)
+	}
+	if !strings.Contains(failed.Error.Message, "lines [1, 2]") {
+		t.Fatalf("not-unique message = %q, missing line hints", failed.Error.Message)
+	}
+}
+
+func writeTextForEditTest(root, name, content string) error {
+	return writeFileForEditTest(root, name, []byte(content))
+}
+
+func writeFileForEditTest(root, name string, content []byte) error {
+	return os.WriteFile(filepath.Join(root, name), content, 0o644)
+}

--- a/apps/sandbox/rpc/edit_test.go
+++ b/apps/sandbox/rpc/edit_test.go
@@ -32,13 +32,36 @@ func TestApplyFSEditsKeepsNormalizedDuplicateMatchesAmbiguous(t *testing.T) {
 	}
 }
 
-func TestApplyFSEditsPreservesBOM(t *testing.T) {
-	updated, err := applyFSEdits("\uFEFFalpha\n", []fsEditItem{{OldText: "alpha", NewText: "beta"}})
+func TestApplyFSEditsPreservesBOMWhetherOldTextIncludesItOrNot(t *testing.T) {
+	for _, oldText := range []string{"alpha", "\uFEFFalpha"} {
+		updated, err := applyFSEdits("\uFEFFalpha\n", []fsEditItem{{OldText: oldText, NewText: "beta"}})
+		if err != nil {
+			t.Fatalf("apply edits with oldText %q: %v", oldText, err)
+		}
+		if updated != "\uFEFFbeta\n" {
+			t.Fatalf("updated content = %q, want BOM-preserving replacement", updated)
+		}
+	}
+}
+
+func TestApplyFSEditsUsesSameFirstLineEndingForMixedNewlines(t *testing.T) {
+	updated, err := applyFSEdits("a\rb\n", []fsEditItem{{OldText: "a\nb", NewText: "x\ny"}})
 	if err != nil {
 		t.Fatalf("apply edits: %v", err)
 	}
-	if updated != "\uFEFFbeta\n" {
-		t.Fatalf("updated content = %q, want BOM-preserving replacement", updated)
+	if updated != "x\ry\n" {
+		t.Fatalf("updated content = %q, want first-ending preservation", updated)
+	}
+}
+
+func TestApplyFSEditsCapsHighFrequencyMatchDiagnostics(t *testing.T) {
+	_, err := applyFSEdits(strings.Repeat("a", 2_000_000), []fsEditItem{{OldText: "a", NewText: "b"}})
+	matchErr, ok := err.(*editMatchError)
+	if !ok {
+		t.Fatalf("error = %T (%v), want editMatchError", err, err)
+	}
+	if !matchErr.truncated || matchErr.matches != maxEditMatches || len(matchErr.lines) != maxEditMatches {
+		t.Fatalf("match error = %+v, want capped and truncated diagnostics", matchErr)
 	}
 }
 

--- a/apps/sandbox/rpc/file-ctime_darwin.go
+++ b/apps/sandbox/rpc/file-ctime_darwin.go
@@ -1,0 +1,16 @@
+//go:build darwin
+
+package rpc
+
+import (
+	"os"
+	"syscall"
+)
+
+func fileCtimeMs(info os.FileInfo) (int64, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return stat.Ctimespec.Sec*1000 + stat.Ctimespec.Nsec/1_000_000, true
+}

--- a/apps/sandbox/rpc/file-ctime_linux.go
+++ b/apps/sandbox/rpc/file-ctime_linux.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package rpc
+
+import (
+	"os"
+	"syscall"
+)
+
+func fileCtimeMs(info os.FileInfo) (int64, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return stat.Ctim.Sec*1000 + stat.Ctim.Nsec/1_000_000, true
+}

--- a/apps/sandbox/rpc/file-ctime_other.go
+++ b/apps/sandbox/rpc/file-ctime_other.go
@@ -1,0 +1,9 @@
+//go:build !linux && !darwin
+
+package rpc
+
+import "os"
+
+func fileCtimeMs(os.FileInfo) (int64, bool) {
+	return 0, false
+}

--- a/packages/sandbox-client/src/rpc-error.test.ts
+++ b/packages/sandbox-client/src/rpc-error.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SANDBOX_CONNECTION_LOST_MESSAGE,
+  SandboxRpcError,
+  getSandboxRpcFailurePresentation,
+} from "./rpc-error.js";
+
+test("business RPC errors are not classified from file content", () => {
+  const error = new SandboxRpcError(
+    "oldText failed; current line says connection closed",
+    {
+      method: "fs.edit",
+      rpcErrorCode: "EDIT_NOT_FOUND",
+      retryable: false,
+      transportReason: "oldText failed; current line says connection closed",
+    },
+  );
+
+  assert.deepEqual(getSandboxRpcFailurePresentation(error), {
+    kind: "rpc_error",
+    message: error.message,
+    infrastructure: false,
+  });
+});
+
+test("structured IO errors retain connection-lost presentation", () => {
+  const error = new SandboxRpcError(SANDBOX_CONNECTION_LOST_MESSAGE, {
+    method: "fs.edit",
+    rpcErrorCode: "IO_ERROR",
+    retryable: false,
+    transportReason: "connection replaced",
+  });
+
+  assert.deepEqual(getSandboxRpcFailurePresentation(error), {
+    kind: "connection_lost",
+    message: SANDBOX_CONNECTION_LOST_MESSAGE,
+    infrastructure: true,
+  });
+});

--- a/packages/sandbox-client/src/rpc-error.ts
+++ b/packages/sandbox-client/src/rpc-error.ts
@@ -79,9 +79,20 @@ export function isSandboxRpcError(error: unknown): error is SandboxRpcError {
 }
 
 export function getSandboxRpcFailurePresentation(error: SandboxRpcError): SandboxRpcFailurePresentation {
-  const text = `${error.transportReason ?? ""} ${error.message}`.toLowerCase();
+  // Business errors can contain arbitrary file content in their message. Only
+  // IO_ERROR represents a transport/infrastructure failure, so never classify
+  // other RPC codes by scanning their text for connection-looking words.
+  if (error.rpcErrorCode !== "IO_ERROR") {
+    return {
+      kind: "rpc_error",
+      message: error.message,
+      infrastructure: false,
+    };
+  }
 
-  if (error.message === SANDBOX_NOT_READY_MESSAGE || includesAny(text, CONNECTION_NOT_READY_PATTERNS)) {
+  const transportText = (error.transportReason ?? "").toLowerCase();
+
+  if (includesAny(transportText, CONNECTION_NOT_READY_PATTERNS)) {
     return {
       kind: "connect_failed",
       message: SANDBOX_NOT_READY_MESSAGE,
@@ -89,7 +100,7 @@ export function getSandboxRpcFailurePresentation(error: SandboxRpcError): Sandbo
     };
   }
 
-  if (error.message === SANDBOX_CONNECTION_LOST_MESSAGE || includesAny(text, CONNECTION_LOST_PATTERNS)) {
+  if (includesAny(transportText, CONNECTION_LOST_PATTERNS)) {
     return {
       kind: "connection_lost",
       message: SANDBOX_CONNECTION_LOST_MESSAGE,

--- a/packages/sandbox-client/src/ws-client.ts
+++ b/packages/sandbox-client/src/ws-client.ts
@@ -263,14 +263,15 @@ export class SandboxConnection {
       const { requestId, pending } = this.getPendingForOperationMessage(message);
       if (!pending) return;
       this.clearPending(requestId, pending, message.opId);
-      const errorMessage = truncateLogValue(message.error.message);
+      const errorMessage = message.error.code === "IO_ERROR" ? truncateLogValue(message.error.message) : undefined;
       const diagnosticText = formatDiagnostics(pending.diagnostics);
-      logger.warn(`[SandboxWS] rpc:failed spaceId=${this.spaceId} identity=${this.identity} method=${pending.method} requestId=${requestId.slice(0, 8)} opId=${message.opId.slice(0, 8)} rpcErrorCode=${message.error.code} retryable=${message.error.retryable ?? false} errorMessage=${JSON.stringify(errorMessage)}${diagnosticText ? ` ${diagnosticText}` : ""}`);
+      const errorText = errorMessage ? ` errorMessage=${JSON.stringify(errorMessage)}` : "";
+      logger.warn(`[SandboxWS] rpc:failed spaceId=${this.spaceId} identity=${this.identity} method=${pending.method} requestId=${requestId.slice(0, 8)} opId=${message.opId.slice(0, 8)} rpcErrorCode=${message.error.code} retryable=${message.error.retryable ?? false}${errorText}${diagnosticText ? ` ${diagnosticText}` : ""}`);
       pending.reject(new SandboxRpcError(message.error.message, {
         method: pending.method,
         rpcErrorCode: message.error.code,
         retryable: message.error.retryable ?? false,
-        transportReason: message.error.message,
+        ...(message.error.code === "IO_ERROR" ? { transportReason: message.error.message } : {}),
         diagnostics: pending.diagnostics,
       }));
     }


### PR DESCRIPTION
## Summary

- Keep exact unique matching as the default while safely tolerating CRLF/LF, BOM, and trailing whitespace differences.
- Validate all edits against one file snapshot, reject overlapping ranges before writing, and preserve atomic failure behavior.
- Return actionable edit errors with edit indexes, match line numbers, nearby current text, and a re-read instruction.
- Add edit-level tracing so `tool.name=edit` can be queried directly in ARMS.
- Update model-facing edit guidance and add regression coverage for the new matching and error behavior.

## Validation

- `pnpm --filter @cohub/agent test`
- `pnpm --filter @cohub/agent build`
- `pnpm --filter @cohub/protocol build`
- `go test ./...` in `apps/sandbox`
- Biome check and clean-worktree patch application check

The repository pre-commit full typecheck remains blocked by existing missing `@talesofai-billing/sdk` modules; the changed agent files have no reported TypeScript errors.