### PR TITLE
fix(web): pass app data to public app surface

### DIFF
--- a/apps/web/src/routes/(public)/[username]/[spaceSlug]/w/[appSlug]/+page.server.ts
+++ b/apps/web/src/routes/(public)/[username]/[spaceSlug]/w/[appSlug]/+page.server.ts
@@ -25,7 +25,7 @@ export const load: PageServerLoad = async ({
 		});
 		return {
 			mode: "ready" as const,
-			work: result.detail.app,
+			app: result.detail.app,
 			space: result.detail.space,
 			owner: result.detail.owner,
 			content: result.detail.content,


### PR DESCRIPTION
## 问题
公开 App 页面 SSR 返回字段 `work`，但重构后的页面组件读取 `data.app`。浏览器 hydration 时 `app` 为 undefined，AppSurface 访问 `app.targetType` 抛出 TypeError，页面停留在空白占位。

## 修复
将 SSR ready 数据字段改为 `app`，与 `ReadyData` 类型和 `AppSurface` props 保持一致。