### PR TITLE
fix(web): use Bowser for device classification

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
 		"@neta-art/cohub": "workspace:*",
 		"@shikijs/langs": "^4.3.1",
 		"@shikijs/themes": "^4.3.1",
+		"bowser": "^2.14.1",
 		"codemirror": "^6.0.2",
 		"isomorphic-dompurify": "3.18.0",
 		"lucide-svelte": "^1.0.1",

--- a/apps/web/src/lib/composer-keyboard.ts
+++ b/apps/web/src/lib/composer-keyboard.ts
@@ -1,3 +1,4 @@
+import { getCurrentDeviceType } from "$lib/device-detection";
 import { isComposingKeyboardEvent } from "$lib/keyboard";
 
 export type ComposerKeyAction = "none" | "newline" | "submit";
@@ -18,10 +19,7 @@ export function getComposerKeyAction(
 }
 
 export function isMobileComposerInput(): boolean {
-	if (typeof window === "undefined") return false;
-	return (
-		"ontouchstart" in window ||
-		window.matchMedia("(pointer: coarse)").matches ||
-		navigator.maxTouchPoints > 0
-	);
+	// Tablets use the mobile composer layout; touch-enabled desktops remain desktop.
+	const deviceType = getCurrentDeviceType();
+	return deviceType === "mobile" || deviceType === "tablet";
 }

--- a/apps/web/src/lib/device-detection.ts
+++ b/apps/web/src/lib/device-detection.ts
@@ -1,0 +1,42 @@
+import Bowser from "bowser";
+
+export type DeviceType =
+	| "bot"
+	| "desktop"
+	| "mobile"
+	| "tablet"
+	| "tv"
+	| "unknown";
+
+type NavigatorWithUserAgentData = Navigator & {
+	userAgentData?: Bowser.ClientHints;
+};
+
+/** Classifies the user agent's form factor independently of touch hardware. */
+export function getDeviceType(
+	userAgent: string,
+	clientHints?: Bowser.ClientHints,
+): DeviceType {
+	if (!userAgent) return "unknown";
+
+	const type = Bowser.getParser(userAgent, clientHints).getPlatformType();
+	switch (type) {
+		case "bot":
+		case "desktop":
+		case "mobile":
+		case "tablet":
+		case "tv":
+			return type;
+		default:
+			return "unknown";
+	}
+}
+
+export function getCurrentDeviceType(): DeviceType {
+	if (typeof window === "undefined") return "unknown";
+	const navigatorWithHints = window.navigator as NavigatorWithUserAgentData;
+	return getDeviceType(
+		navigatorWithHints.userAgent,
+		navigatorWithHints.userAgentData,
+	);
+}

--- a/apps/web/src/tests/device-detection.test.ts
+++ b/apps/web/src/tests/device-detection.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { getDeviceType } from "$lib/device-detection";
+
+const WINDOWS_CHROME_USER_AGENT =
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+	"(KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36";
+const IPHONE_USER_AGENT =
+	"Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) " +
+	"AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 " +
+	"Mobile/15E148 Safari/604.1";
+const IPAD_USER_AGENT =
+	"Mozilla/5.0 (iPad; CPU OS 18_6 like Mac OS X) AppleWebKit/605.1.15 " +
+	"(KHTML, like Gecko) Version/18.6 Mobile/15E148 Safari/604.1";
+
+test("classifies a Windows touchscreen browser as desktop", () => {
+	assert.equal(getDeviceType(WINDOWS_CHROME_USER_AGENT), "desktop");
+});
+
+test("classifies mobile and tablet user agents", () => {
+	assert.equal(getDeviceType(IPHONE_USER_AGENT), "mobile");
+	assert.equal(getDeviceType(IPAD_USER_AGENT), "tablet");
+});
+
+test("returns unknown when the user agent has no platform classification", () => {
+	assert.equal(getDeviceType("Mozilla/5.0"), "unknown");
+	assert.equal(getDeviceType(""), "unknown");
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,6 +418,9 @@ importers:
       '@shikijs/themes':
         specifier: ^4.3.1
         version: 4.3.1
+      bowser:
+        specifier: ^2.14.1
+        version: 2.14.1
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2


### PR DESCRIPTION
## Summary

- Add a shared Bowser-backed form-factor classifier for `mobile`, `tablet`, `desktop`, `tv`, `bot`, and `unknown`.
- Replace touch API and `maxTouchPoints` heuristics in composer mobile detection.
- Keep touchscreen Windows desktops classified as desktop and add regression coverage.

## Validation

- `pnpm --filter web lint`
- Targeted device detection tests: 3 passed
- Direct TypeScript check for the new detector passed
- GitHub CI: `Lint, typecheck, test, build` passed
- GitHub CI: `Format, vet, test (sandbox)` passed

The local pre-commit hook ran lint-staged successfully, but its full typecheck was blocked by the incomplete local workspace (`@neta-art/generation` and generated workspace artifacts). The remote CI completed the full validation successfully.