### PR TITLE
fix(fs): prevent uploads from overwriting concurrent edits

### DIFF
--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -9,7 +9,7 @@ import {
   createQueueTelemetry,
 } from "@cohub/infra/bullmq";
 import { env } from "./env.js";
-import { AGENT_SANDBOX_BASH_JOB_NAME, AGENT_RUN_COMMAND_JOB_NAME, AGENT_SESSION_FORK_JOB_NAME, AGENT_TURN_JOB_NAME, AGENT_TURN_QUEUE_NAME, AGENT_SANDBOX_FS_MUTATION_JOB_NAME, type AgentJobData, type AgentTurnJobData, type AgentSessionForkJobData, type AgentSandboxBashUploadJobData, type AgentRunCommandJobData, type AgentSandboxFsMutationJobData } from "./queue.js";
+import { AGENT_SANDBOX_BASH_JOB_NAME, AGENT_SANDBOX_BASH_ATOMIC_JOB_NAME, AGENT_RUN_COMMAND_JOB_NAME, AGENT_SESSION_FORK_JOB_NAME, AGENT_TURN_JOB_NAME, AGENT_TURN_QUEUE_NAME, AGENT_SANDBOX_FS_MUTATION_JOB_NAME, type AgentJobData, type AgentTurnJobData, type AgentSessionForkJobData, type AgentSandboxBashUploadJobData, type AgentRunCommandJobData, type AgentSandboxFsMutationJobData } from "./queue.js";
 import { processAgentTurnJob, disposeAllSessionHandles } from "./processor.js";
 import { processSessionForkJob } from "./fork.js";
 import { processSandboxBashJob } from "./sandbox-bash.js";
@@ -38,7 +38,7 @@ const processor: Processor<AgentJobData> = async (job) => {
   if (job.name === AGENT_TURN_JOB_NAME) {
     return processAgentTurnJob(job as Job<AgentTurnJobData>);
   }
-  if (job.name === AGENT_SANDBOX_BASH_JOB_NAME) {
+  if (job.name === AGENT_SANDBOX_BASH_JOB_NAME || job.name === AGENT_SANDBOX_BASH_ATOMIC_JOB_NAME) {
     return processSandboxBashJob(job as Job<AgentSandboxBashUploadJobData>);
   }
   if (job.name === AGENT_SANDBOX_FS_MUTATION_JOB_NAME) {

--- a/apps/agent/src/jobs/sandbox-bash/upload-files.sh
+++ b/apps/agent/src/jobs/sandbox-bash/upload-files.sh
@@ -2,6 +2,14 @@
 set -euo pipefail
 
 : "${UPLOAD_ROOT:?UPLOAD_ROOT is required}"
+: "${MATERIALIZE_MODE:=replace}"
+case "$MATERIALIZE_MODE" in
+  replace|stage) ;;
+  *)
+    echo "invalid materialize mode" >&2
+    exit 2
+    ;;
+esac
 
 b64_decode() {
   if base64 --help 2>&1 | grep -q -- '-d'; then
@@ -13,8 +21,14 @@ b64_decode() {
 
 root_real="$(mkdir -p "$UPLOAD_ROOT" && cd "$UPLOAD_ROOT" && pwd -P)"
 tmp=""
+# Atomic workspace uploads hand these files to fs.write after the download
+# completes. Keep every staged path until the agent has installed it.
+staged=()
 cleanup_tmp() {
-  [ -z "$tmp" ] || rm -f "$tmp"
+  [ -z "$tmp" ] || rm -f -- "$tmp"
+  for staged_path in "${staged[@]}"; do
+    rm -f -- "$staged_path"
+  done
 }
 trap cleanup_tmp EXIT
 
@@ -69,7 +83,19 @@ while IFS=$'\t' read -r rel_b64 expected_size url_b64; do
     exit 3
   fi
 
-  mv -f "$tmp" "$target"
-  tmp=""
-  printf 'uploaded\t%s\t%s\n' "$relative_path" "$target"
+  if [ "$MATERIALIZE_MODE" = "stage" ]; then
+    staged+=("$tmp")
+    printf 'staged\t%s\t%s\t%s\n' "$relative_path" "$target" "$tmp"
+    tmp=""
+  else
+    mv -f "$tmp" "$target"
+    tmp=""
+    printf 'uploaded\t%s\t%s\n' "$relative_path" "$target"
+  fi
 done
+
+# The agent owns staged files after this point and will remove each source as it
+# is installed (or clean the remaining paths on a conflict).
+if [ "$MATERIALIZE_MODE" = "stage" ]; then
+  staged=()
+fi

--- a/apps/agent/src/queue.ts
+++ b/apps/agent/src/queue.ts
@@ -5,6 +5,7 @@ import { injectTrace } from "@cohub/infra/tracing/propagator";
 import {
   createAgentTurnsQueue,
   AGENT_SANDBOX_BASH_JOB_NAME,
+  AGENT_SANDBOX_BASH_ATOMIC_JOB_NAME,
   AGENT_RUN_COMMAND_JOB_NAME,
   AGENT_SANDBOX_FS_MUTATION_JOB_NAME,
   buildAgentSandboxBashJobId,
@@ -24,6 +25,7 @@ export const AGENT_TURN_JOB_NAME = "agent_turns";
 export const AGENT_SESSION_FORK_JOB_NAME = "agent_session_fork";
 export {
   AGENT_SANDBOX_BASH_JOB_NAME,
+  AGENT_SANDBOX_BASH_ATOMIC_JOB_NAME,
   AGENT_RUN_COMMAND_JOB_NAME,
   AGENT_SANDBOX_FS_MUTATION_JOB_NAME,
 };

--- a/apps/agent/src/sandbox-bash.ts
+++ b/apps/agent/src/sandbox-bash.ts
@@ -3,11 +3,13 @@ import { randomUUID } from "node:crypto";
 import { UnrecoverableError, type Job } from "bullmq";
 import { recordJobFailure } from "@cohub/infra/bullmq";
 import { getAgentTracer, wrapToolCall } from "@cohub/infra/tracing/agent";
-import { createSandboxCodingTools } from "./sandbox/tools.js";
+import { SandboxRpcError, type SandboxConnection } from "@cohub/sandbox-client";
+import { createSandboxCodingTools, tracedRpc } from "./sandbox/tools.js";
 import { runWithToolExecutionContext } from "./tool-context.js";
 import { logger } from "./logger.js";
-import type { AgentSandboxBashUploadJobData } from "./queue.js";
+import { AGENT_SANDBOX_BASH_ATOMIC_JOB_NAME, type AgentSandboxBashUploadJobData } from "./queue.js";
 import { loadSpaceEnvSnapshot } from "./runtime/env-cache.js";
+import { ensureSandboxConnection } from "./sandbox-pool.js";
 
 const SCRIPT_PATH = new URL("./jobs/sandbox-bash/upload-files.sh", import.meta.url);
 const tools = createSandboxCodingTools();
@@ -42,7 +44,7 @@ async function buildUploadCommand(data: AgentSandboxBashUploadJobData) {
     script.trimEnd(),
     "COHUB_UPLOAD_SCRIPT",
     "chmod +x \"$script_path\"",
-    `UPLOAD_ROOT=${shellSingleQuote(data.destinationRoot)} bash "$script_path" <<'COHUB_UPLOAD_MANIFEST'`,
+    `MATERIALIZE_MODE=${shellSingleQuote(data.materialize === "atomic" ? "stage" : "replace")} UPLOAD_ROOT=${shellSingleQuote(data.destinationRoot)} bash "$script_path" <<'COHUB_UPLOAD_MANIFEST'`,
     manifest,
     "COHUB_UPLOAD_MANIFEST",
   ].join("\n");
@@ -67,9 +69,31 @@ function getExitCode(result: unknown) {
   return typeof exitCode === "number" ? exitCode : null;
 }
 
-function parseUploadedLines(output: string, data: AgentSandboxBashUploadJobData) {
+function extractRawOutput(result: unknown) {
+  if (!result || typeof result !== "object") return "";
+  const details = (result as { details?: unknown }).details;
+  if (!details || typeof details !== "object") return "";
+  const rawOutput = (details as { rawOutput?: unknown }).rawOutput;
+  return typeof rawOutput === "string" ? rawOutput : "";
+}
+
+type UploadedFile = {
+  path: string;
+  name: string;
+  size: number;
+  mimeType: string | null;
+  mtimeMs: number;
+};
+
+type StagedFile = {
+  file: AgentSandboxBashUploadJobData["files"][number];
+  targetPath: string;
+  sourcePath: string;
+};
+
+function parseUploadedLines(output: string, data: AgentSandboxBashUploadJobData): UploadedFile[] {
   const expected = new Map(data.files.map((file) => [file.relativePath, file]));
-  const uploaded = new Map<string, { path: string; name: string; size: number; mimeType: string | null; mtimeMs: number }>();
+  const uploaded = new Map<string, UploadedFile>();
 
   for (const line of output.split(/\r?\n/)) {
     const [kind, relativePath, targetPath] = line.split("\t");
@@ -92,10 +116,156 @@ function parseUploadedLines(output: string, data: AgentSandboxBashUploadJobData)
   return [...uploaded.values()];
 }
 
+function parseStagedLines(output: string, data: AgentSandboxBashUploadJobData): StagedFile[] {
+  const expected = new Map(data.files.map((file) => [file.relativePath, file]));
+  const staged = new Map<string, StagedFile>();
+
+  for (const line of output.split(/\r?\n/)) {
+    const [kind, relativePath, targetPath, sourcePath] = line.split("\t");
+    if (kind !== "staged" || !relativePath || !targetPath || !sourcePath) continue;
+    const file = expected.get(relativePath);
+    if (!file) continue;
+    staged.set(relativePath, { file, targetPath, sourcePath });
+  }
+
+  if (staged.size !== data.files.length) {
+    throw new Error(`Staged file count mismatch: expected ${data.files.length}, got ${staged.size}`);
+  }
+
+  return [...staged.values()];
+}
+
+function stagedSourcePaths(output: string) {
+  return output.split(/\r?\n/).flatMap((line) => {
+    const [kind, , , sourcePath] = line.split("\t");
+    return kind === "staged" && sourcePath ? [sourcePath] : [];
+  });
+}
+
+function stagedPathBatches(paths: string[]) {
+  const batches: string[][] = [];
+  let batch: string[] = [];
+  let bytes = 0;
+  for (const path of paths) {
+    const pathBytes = Buffer.byteLength(path, "utf8") + 16;
+    if (batch.length > 0 && (batch.length >= 200 || bytes + pathBytes > 48 * 1024)) {
+      batches.push(batch);
+      batch = [];
+      bytes = 0;
+    }
+    batch.push(path);
+    bytes += pathBytes;
+  }
+  if (batch.length > 0) batches.push(batch);
+  return batches;
+}
+
+async function cleanupStagedFiles(spaceId: string, paths: string[]) {
+  const uniquePaths = [...new Set(paths)];
+  if (uniquePaths.length === 0) return;
+  let connection: SandboxConnection;
+  try {
+    connection = await ensureSandboxConnection(spaceId);
+  } catch (error) {
+    logger.warn("[SandboxBash] failed to connect while cleaning staged upload files", {
+      spaceId,
+      fileCount: uniquePaths.length,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+  for (const batch of stagedPathBatches(uniquePaths)) {
+    try {
+      const result = await tracedRpc(connection, "process.start", {
+        argv: ["rm", "-f", "--", ...batch],
+        cwd: "/workspace",
+        timeoutSecs: 60,
+      }, undefined, false);
+      if (result.exitCode !== 0) {
+        logger.warn("[SandboxBash] staged upload cleanup command failed", {
+          spaceId,
+          fileCount: batch.length,
+          exitCode: result.exitCode,
+        });
+      }
+    } catch (error) {
+      logger.warn("[SandboxBash] failed to clean staged upload files", {
+        spaceId,
+        fileCount: batch.length,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+function supportsAtomicMaterialization(connection: SandboxConnection) {
+  return connection.capabilities?.fsWriteSource === true &&
+    connection.capabilities?.fsWriteExpected === true &&
+    connection.capabilities?.fsWriteDisposition === true;
+}
+
+async function assertAtomicMaterializationSupport(spaceId: string) {
+  const connection = await ensureSandboxConnection(spaceId);
+  if (!supportsAtomicMaterialization(connection)) {
+    throw new Error("sandbox does not support atomic upload materialization");
+  }
+}
+
+async function materializeAtomicUpload(data: AgentSandboxBashUploadJobData, output: string): Promise<UploadedFile[]> {
+  const staged = parseStagedLines(output, data);
+  const sources = staged.map((item) => item.sourcePath);
+  const connection = await ensureSandboxConnection(data.spaceId);
+  if (!supportsAtomicMaterialization(connection)) {
+    throw new Error("sandbox does not support atomic upload materialization");
+  }
+
+  const uploaded: UploadedFile[] = [];
+  try {
+    for (const item of staged) {
+      const targetVersion = item.file.targetVersion;
+      if (!targetVersion) {
+        throw new UnrecoverableError(`upload_conflict: missing upload target version for ${item.file.relativePath}`);
+      }
+      const result = await tracedRpc(connection, "fs.write", {
+        path: item.targetPath,
+        content: "",
+        sourcePath: item.sourcePath,
+        ...(targetVersion.exists
+          ? { expected: { size: targetVersion.size, mtimeMs: targetVersion.mtimeMs } }
+          : { exclusive: true }),
+      }, undefined, false);
+      uploaded.push({
+        path: item.targetPath,
+        name: item.file.name,
+        size: result.bytesWritten,
+        mimeType: item.file.mimeType,
+        mtimeMs: result.mtimeMs ?? Date.now(),
+      });
+    }
+    await cleanupStagedFiles(data.spaceId, sources);
+    return uploaded;
+  } catch (error) {
+    if (error instanceof SandboxRpcError && (error.rpcErrorCode === "CONFLICT" || error.rpcErrorCode === "ALREADY_EXISTS" || error.rpcErrorCode === "NOT_DIRECTORY")) {
+      const conflict = staged[uploaded.length]?.file.relativePath ?? "unknown";
+      throw new UnrecoverableError(`upload_conflict: ${conflict}`);
+    }
+    throw error;
+  }
+}
+
 export async function processSandboxBashJob(job: Job<AgentSandboxBashUploadJobData>) {
   const data = job.data;
   if (!data.spaceId || !data.sessionId || !data.uploadId || !data.destinationRoot || !Array.isArray(data.files)) {
     throw new Error("Invalid sandbox_bash upload job payload");
+  }
+  if (job.name === AGENT_SANDBOX_BASH_ATOMIC_JOB_NAME && data.materialize !== "atomic") {
+    throw new Error("Atomic sandbox upload job is missing its materialization mode");
+  }
+  if (data.materialize === "atomic" && data.files.some((file) => !file.targetVersion)) {
+    throw new UnrecoverableError("upload_conflict: upload target version is unavailable");
+  }
+  if (data.materialize === "atomic") {
+    await assertAtomicMaterializationSupport(data.spaceId);
   }
 
   const bashTool = tools.find((tool) => tool.name === "bash");
@@ -123,14 +293,15 @@ export async function processSandboxBashJob(job: Job<AgentSandboxBashUploadJobDa
   });
 
   const spaceEnv = await loadSpaceEnvSnapshot(data.spaceId);
-  await runWithToolExecutionContext({
+  const executionContext = {
     spaceId: data.spaceId,
     sessionId: data.sessionId,
     spaceEnv,
     llmRound: 0,
     toolCallId,
     requestId: data.requestId ?? undefined,
-  }, async () => wrapToolCall(tracer, {
+  };
+  await runWithToolExecutionContext(executionContext, async () => wrapToolCall(tracer, {
     toolName: "sandbox_bash",
     input: { task: "upload_files", uploadId: data.uploadId, files: data.files.length },
     spaceId: data.spaceId,
@@ -148,9 +319,12 @@ export async function processSandboxBashJob(job: Job<AgentSandboxBashUploadJobDa
         if (text) latestOutput = text;
       },
     );
-    latestOutput = extractResultText(result) || latestOutput;
+    latestOutput = extractRawOutput(result) || extractResultText(result) || latestOutput;
     const exitCode = getExitCode(result);
     if (exitCode !== 0) {
+      if (data.materialize === "atomic") {
+        await cleanupStagedFiles(data.spaceId, stagedSourcePaths(latestOutput));
+      }
       const error = new Error(latestOutput || `sandbox_bash upload_files failed with exit code ${exitCode ?? "unknown"}`);
       const failure = await recordJobFailure(job, error, {
         reason: "sandbox_bash_command_failed",
@@ -168,7 +342,9 @@ export async function processSandboxBashJob(job: Job<AgentSandboxBashUploadJobDa
   }));
 
   try {
-    const uploaded = parseUploadedLines(latestOutput, data);
+    const uploaded = data.materialize === "atomic"
+      ? await runWithToolExecutionContext(executionContext, () => materializeAtomicUpload(data, latestOutput))
+      : parseUploadedLines(latestOutput, data);
     await job.updateProgress({
       stage: "completed",
       ...logMeta,
@@ -177,8 +353,13 @@ export async function processSandboxBashJob(job: Job<AgentSandboxBashUploadJobDa
     });
     return { ok: true, uploaded, output: latestOutput };
   } catch (error) {
+    if (data.materialize === "atomic") {
+      await runWithToolExecutionContext(executionContext, () =>
+        cleanupStagedFiles(data.spaceId, stagedSourcePaths(latestOutput)),
+      );
+    }
     const failure = await recordJobFailure(job, error, {
-      reason: "sandbox_bash_result_parse_failed",
+      reason: data.materialize === "atomic" ? "sandbox_bash_materialize_failed" : "sandbox_bash_result_parse_failed",
       meta: {
         ...logMeta,
         outputTail: latestOutput.slice(-2000),

--- a/apps/api/src/routes/spaces/fs.route.ts
+++ b/apps/api/src/routes/spaces/fs.route.ts
@@ -19,6 +19,8 @@ import {
   readSpaceFile,
   readSpaceFiles,
   resolveSpaceFileDownload,
+  SpaceFsError,
+  statSpaceFileVersion,
   spaceFsJsonError,
   streamSpaceFile,
   uploadSpaceFiles,
@@ -45,7 +47,11 @@ import {
   type SpaceUploadDestination,
   type SpaceUploadManifestEntry,
 } from "../../space-upload-storage.js";
-import { enqueueSandboxUploadFilesJob, SandboxUploadSizeMismatchError } from "../../sandbox-bash-queue.js";
+import {
+  enqueueSandboxUploadFilesJob,
+  SandboxUploadConflictError,
+  SandboxUploadSizeMismatchError,
+} from "../../sandbox-bash-queue.js";
 import { isAllowedPublicAssetDownloadUrl } from "../../public-asset-storage.js";
 import type {
   SpaceFsCreateUploadInput,
@@ -59,6 +65,21 @@ const router = new Hono();
 /** Inline text writes are capped at the same limit as inline reads. */
 const MAX_INLINE_WRITE_BYTES = 10 * 1024 * 1024;
 const MAX_INLINE_WRITE_REQUEST_BYTES = Math.ceil(MAX_INLINE_WRITE_BYTES * 4 / 3) + 256 * 1024;
+const UPLOAD_TARGET_STAT_CONCURRENCY = 8;
+
+async function mapWithConcurrency<T, R>(items: T[], concurrency: number, mapper: (item: T, index: number) => Promise<R>) {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(items[index] as T, index);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
 
 /** Client mutation ids are bounded before they are used in queue job ids. */
 const isValidMutationId = (value: unknown) =>
@@ -462,6 +483,19 @@ router.post("/uploads", async (c) => {
       });
     }
 
+    // Capture the destination baseline before the client uploads the object;
+    // the async materializer uses it to reject a late overwrite.
+    if (destination.kind === "workspace") {
+      const targetDir = destination.targetDir ?? "";
+      const targetVersions = await mapWithConcurrency(entries, UPLOAD_TARGET_STAT_CONCURRENCY, (entry) => {
+        const targetPath = targetDir ? `${targetDir}/${entry.relativePath}` : entry.relativePath;
+        return statSpaceFileVersion(spaceId, targetPath);
+      });
+      for (const [index, entry] of entries.entries()) {
+        entry.targetVersion = targetVersions[index];
+      }
+    }
+
     // Charge quota only after full validation so bad requests cannot consume tokens.
     await consumeSpaceUploadQuota(user.uuid, entries.length);
 
@@ -487,6 +521,10 @@ router.post("/uploads", async (c) => {
     if (error instanceof SpaceUploadRateLimitError) {
       c.header("Retry-After", String(error.retryAfterSeconds));
       return c.json({ message: error.message, retryAfterSeconds: error.retryAfterSeconds }, 429);
+    }
+    if (error instanceof SpaceFsError || (error instanceof Error && error.name === "SandboxOfflineError")) {
+      const mapped = spaceFsJsonError(error);
+      return c.json(mapped.body, mapped.status as never);
     }
     const message = error instanceof Error ? error.message.toLowerCase().replace(/\.$/, "") : "failed to create upload";
     return c.json({ message }, 400);
@@ -522,6 +560,10 @@ router.post("/uploads/:uploadId/complete", async (c) => {
       await cancelSpaceUploadComplete(spaceId, uploadId);
       return c.json({ message: "no completed entries" }, 400);
     }
+    if (manifest.destination.kind === "workspace" && entries.some((entry) => !entry.targetVersion)) {
+      await cancelSpaceUploadComplete(spaceId, uploadId);
+      return c.json({ code: "upload_conflict", message: "upload target version is unavailable; upload the file again" }, 409);
+    }
 
     const destinationRoot = buildUploadDestinationRoot(manifest.destination, manifest.uploadId);
     const sessionId =
@@ -533,6 +575,7 @@ router.post("/uploads/:uploadId/complete", async (c) => {
       sessionId,
       uploadId,
       destinationRoot,
+      ...(manifest.destination.kind === "workspace" ? { materialize: "atomic" as const } : {}),
       files: entries.map((entry) => {
         const rawUrl = entry.downloadUrl
           ? entry.downloadUrl
@@ -543,6 +586,7 @@ router.post("/uploads/:uploadId/complete", async (c) => {
           size: entry.size,
           mimeType: entry.mimeType,
           downloadUrl: rawUrl,
+          targetVersion: entry.targetVersion,
         };
       }),
     });
@@ -556,6 +600,9 @@ router.post("/uploads/:uploadId/complete", async (c) => {
     await cancelSpaceUploadComplete(spaceId, uploadId);
     if (error instanceof SandboxUploadSizeMismatchError) {
       return c.json({ code: "upload_size_mismatch", message: "uploaded file size does not match" }, 422);
+    }
+    if (error instanceof SandboxUploadConflictError) {
+      return c.json({ code: "upload_conflict", message: "upload target changed while uploading" }, 409);
     }
     logger.error("[space-fs] failed to complete upload", error, {
       spaceId,

--- a/apps/api/src/sandbox-bash-queue.ts
+++ b/apps/api/src/sandbox-bash-queue.ts
@@ -2,9 +2,11 @@ import { QueueEvents } from "bullmq";
 import { COHUB_AGENT_TURNS_QUEUE, createBullmqConnectionOptions, createBullmqQueue, defaultJobRetention } from "@cohub/infra/bullmq";
 import { getCurrentRequestId } from "@cohub/infra/tracing";
 import { injectTrace } from "@cohub/infra/tracing/propagator";
+import type { SpaceFsUploadTargetVersion } from "@cohub/protocol/fs";
 import { config } from "./config.js";
 
 export const AGENT_SANDBOX_BASH_JOB_NAME = "sandbox_bash";
+export const AGENT_SANDBOX_BASH_ATOMIC_JOB_NAME = "sandbox_bash_atomic";
 
 export type SandboxBashUploadFile = {
   relativePath: string;
@@ -12,6 +14,7 @@ export type SandboxBashUploadFile = {
   size: number;
   mimeType: string | null;
   downloadUrl: string;
+  targetVersion?: SpaceFsUploadTargetVersion;
 };
 
 export type SandboxBashUploadJobData = {
@@ -19,6 +22,7 @@ export type SandboxBashUploadJobData = {
   sessionId: string;
   uploadId: string;
   destinationRoot: string;
+  materialize?: "atomic";
   files: SandboxBashUploadFile[];
   requestId?: string | null;
   trace?: Record<string, unknown>;
@@ -40,6 +44,10 @@ export class SandboxUploadSizeMismatchError extends Error {
   override name = "SandboxUploadSizeMismatchError";
 }
 
+export class SandboxUploadConflictError extends Error {
+  override name = "SandboxUploadConflictError";
+}
+
 export const sandboxBashQueue = createBullmqQueue<SandboxBashUploadJobData, SandboxBashUploadJobResult>(COHUB_AGENT_TURNS_QUEUE, {
   redisUrl: config.bullmqRedisUrl,
   telemetryServiceName: "cohub-api-sandbox-bash",
@@ -50,14 +58,19 @@ const sandboxBashQueueEvents = new QueueEvents(COHUB_AGENT_TURNS_QUEUE, {
 });
 
 export async function enqueueSandboxUploadFilesJob(input: Omit<SandboxBashUploadJobData, "requestId" | "trace">) {
-  const job = await sandboxBashQueue.add(AGENT_SANDBOX_BASH_JOB_NAME, {
+  // Keep atomic uploads on a distinct job name: an older agent must reject the
+  // job rather than execute the legacy unconditional mv path during rollout.
+  const jobName = input.materialize === "atomic" ? AGENT_SANDBOX_BASH_ATOMIC_JOB_NAME : AGENT_SANDBOX_BASH_JOB_NAME;
+  const job = await sandboxBashQueue.add(jobName, {
     ...input,
     requestId: getCurrentRequestId() ?? null,
     trace: injectTrace(),
   }, {
-    jobId: `sandbox-bash-${input.uploadId}`,
-    attempts: 2,
-    backoff: { type: "fixed", delay: 1000 },
+    jobId: input.materialize === "atomic"
+      ? `${jobName}-${input.uploadId}`
+      : `sandbox-bash-${input.uploadId}`,
+    attempts: input.materialize === "atomic" ? 12 : 2,
+    backoff: { type: "fixed", delay: input.materialize === "atomic" ? 5000 : 1000 },
     ...defaultJobRetention,
   });
 
@@ -67,6 +80,9 @@ export async function enqueueSandboxUploadFilesJob(input: Omit<SandboxBashUpload
     const message = error instanceof Error ? error.message : String(error);
     if (message.startsWith("upload_size_mismatch:")) {
       throw new SandboxUploadSizeMismatchError(message.slice("upload_size_mismatch:".length).trim());
+    }
+    if (message.startsWith("upload_conflict:")) {
+      throw new SandboxUploadConflictError(message.slice("upload_conflict:".length).trim());
     }
     throw error;
   }

--- a/apps/api/src/space-fs-backend.ts
+++ b/apps/api/src/space-fs-backend.ts
@@ -133,6 +133,12 @@ export async function readSpaceFile(spaceId: string, path: string, options?: Vis
     : direct.readSpaceFile(spaceId, path, options);
 }
 
+export async function statSpaceFileVersion(spaceId: string, path: string) {
+  return (await isLocal(spaceId))
+    ? remote.statSpaceFileVersion(spaceId, path)
+    : direct.statSpaceFileVersion(spaceId, path);
+}
+
 export async function readSpaceFiles(spaceId: string, paths: string[], options?: Visibility) {
   return (await isLocal(spaceId))
     ? remote.readSpaceFiles(spaceId, paths, options)

--- a/apps/api/src/space-fs-remote.ts
+++ b/apps/api/src/space-fs-remote.ts
@@ -8,6 +8,7 @@ import {
   type SpaceFsReadFilesResponse,
   type SpaceFsTreeResponse,
   type SpaceFsUploadResponse,
+  type SpaceFsUploadTargetVersion,
   type SpaceFsWriteFileInput,
 } from "@cohub/protocol/fs";
 import type { RpcEventPayload } from "@cohub/protocol/sandbox";
@@ -277,6 +278,23 @@ export async function readSpaceFiles(
   }
 
   return { files, errors };
+}
+
+export async function statSpaceFileVersion(spaceId: string, path: string): Promise<SpaceFsUploadTargetVersion> {
+  const safePath = assertSafeSubpath(path);
+  try {
+    const result = await callSandboxRpc(spaceId, "fs.stat", { path: safePath });
+    if (!result.exists) return { exists: false };
+    if (result.isDirectory || result.isFile === false) {
+      throw new SpaceFsError(400, "not_a_file", "The upload target is not a file.");
+    }
+    if (typeof result.size !== "number" || typeof result.mtimeMs !== "number") {
+      throw new SpaceFsError(500, "space_fs_error", "Upload target metadata is unavailable.");
+    }
+    return { exists: true, size: result.size, mtimeMs: Math.trunc(result.mtimeMs) };
+  } catch (error) {
+    mapRpcError(error);
+  }
 }
 
 export async function writeSpaceFile(spaceId: string, input: SpaceFsWriteFileInput) {

--- a/apps/api/src/space-fs.ts
+++ b/apps/api/src/space-fs.ts
@@ -30,6 +30,7 @@ import {
   type SpaceFsPreparingFile,
   type SpaceFsTreeResponse,
   type SpaceFsUploadResponse,
+  type SpaceFsUploadTargetVersion,
   type SpaceFsWriteFileInput,
 } from "@cohub/protocol/fs";
 import { isTextMime } from "./space-fs-mime.js";
@@ -1235,6 +1236,19 @@ export async function streamSpaceFile(
     observation.result = { fileSizeBytes: response.size, mimeType: response.mimeType };
     return response;
   });
+}
+
+export async function statSpaceFileVersion(spaceId: string, path: string): Promise<SpaceFsUploadTargetVersion> {
+  const { target } = await resolveTarget(spaceId, path);
+  let info: Stats;
+  try {
+    info = await lstat(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { exists: false };
+    throw error;
+  }
+  if (!info.isFile()) throw new SpaceFsError(400, "not_a_file", "The upload target is not a file.");
+  return { exists: true, size: info.size, mtimeMs: Math.trunc(info.mtimeMs) };
 }
 
 export async function writeSpaceFile(spaceId: string, input: SpaceFsWriteFileInput) {

--- a/apps/api/src/space-upload-storage.ts
+++ b/apps/api/src/space-upload-storage.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import type { SpaceFsUploadTargetVersion } from "@cohub/protocol/fs";
 import { config } from "./config.js";
 import { redisCommandClient } from "./redis.js";
 import { createUserUploadGetUrl, createUserUploadPutUrl } from "./user-upload-storage.js";
@@ -72,6 +73,8 @@ export type SpaceUploadManifestEntry = {
   objectKey?: string;
   /** Durable public URL already uploaded elsewhere; complete pulls from this. */
   downloadUrl?: string;
+  /** Target version captured before the client began uploading. */
+  targetVersion?: SpaceFsUploadTargetVersion;
 };
 
 export type SpaceUploadDestination =

--- a/apps/sandbox/protocol/types.go
+++ b/apps/sandbox/protocol/types.go
@@ -46,6 +46,7 @@ type SandboxCapabilities struct {
 	FSWrite            bool `json:"fsWrite"`
 	FSWriteDisposition bool `json:"fsWriteDisposition,omitempty"`
 	FSWriteExpected    bool `json:"fsWriteExpected,omitempty"`
+	FSWriteSource      bool `json:"fsWriteSource,omitempty"`
 	FSEdit             bool `json:"fsEdit,omitempty"`
 	FSMkdir            bool `json:"fsMkdir,omitempty"`
 	FSStat             bool `json:"fsStat"`

--- a/apps/sandbox/rpc/dispatcher.go
+++ b/apps/sandbox/rpc/dispatcher.go
@@ -161,12 +161,13 @@ type fsReadParams struct {
 }
 
 type fsWriteParams struct {
-	Path      string          `json:"path"`
-	CWD       string          `json:"cwd"`
-	Content   string          `json:"content"`
-	Encoding  string          `json:"encoding"`
-	Exclusive bool            `json:"exclusive"`
-	Expected  *fsWriteVersion `json:"expected"`
+	Path       string          `json:"path"`
+	CWD        string          `json:"cwd"`
+	Content    string          `json:"content"`
+	SourcePath string          `json:"sourcePath"`
+	Encoding   string          `json:"encoding"`
+	Exclusive  bool            `json:"exclusive"`
+	Expected   *fsWriteVersion `json:"expected"`
 }
 
 // fsWriteVersion is the caller's baseline for optimistic concurrency: reject
@@ -365,8 +366,34 @@ func (d *Dispatcher) handleFSWrite(request protocol.RPCRequest) interface{} {
 	if info, err := os.Stat(resolved.path); err == nil && info.IsDir() {
 		return d.failed(request, "", "NOT_DIRECTORY", fmt.Sprintf("cannot write to a directory: %s", resolved.path))
 	}
+
+	var source *resolvedSandboxPath
 	data := []byte(params.Content)
-	if params.Encoding == "base64" {
+	if params.SourcePath != "" {
+		if params.Content != "" || params.Encoding != "" || (params.Expected == nil && !params.Exclusive) {
+			return d.failed(request, "", "BAD_REQUEST", "sourcePath requires an expected version or exclusive create and no inline content")
+		}
+		resolvedSource, sourceErrResponse, sourceOK := d.resolvePathForRequest(request, params.SourcePath, params.CWD)
+		if !sourceOK {
+			return sourceErrResponse
+		}
+		if isReadOnlyPath(d.cfg, resolvedSource.path) {
+			return d.failed(request, "", "READ_ONLY_FILESYSTEM", fmt.Sprintf("source path is read-only: %s", resolvedSource.path))
+		}
+		if filepath.Base(resolvedSource.path) == filepath.Base(resolved.path) ||
+			!strings.HasPrefix(filepath.Base(resolvedSource.path), ".cohub-upload.") ||
+			resolvePathLockKey(filepath.Dir(resolvedSource.path)) != resolvePathLockKey(filepath.Dir(resolved.path)) {
+			return d.failed(request, "", "INVALID_PATH", "sourcePath must be an upload staging file next to the target")
+		}
+		info, err := os.Lstat(resolvedSource.path)
+		if err != nil {
+			return d.failedFSMutation(request, err)
+		}
+		if !info.Mode().IsRegular() {
+			return d.failed(request, "", "INVALID_PATH", "sourcePath must be a regular file")
+		}
+		source = &resolvedSource
+	} else if params.Encoding == "base64" {
 		decoded, decErr := decodeBase64(params.Content)
 		if decErr != nil {
 			return d.failed(request, "", "BAD_REQUEST", decErr.Error())
@@ -381,6 +408,7 @@ func (d *Dispatcher) handleFSWrite(request protocol.RPCRequest) interface{} {
 	// belong to a subsequent writer.
 	var created bool
 	var createdDirs []string
+	var bytesWritten int
 	var mtimeMs int64
 	lockErr := withPathLock(resolved.path, func() error {
 		if params.Expected != nil && !params.Exclusive {
@@ -395,23 +423,57 @@ func (d *Dispatcher) handleFSWrite(request protocol.RPCRequest) interface{} {
 				return errPathConflict
 			}
 		}
+		if source != nil {
+			targetInfo, targetErr := os.Lstat(resolved.path)
+			if targetErr == nil {
+				if targetInfo.Mode()&os.ModeSymlink != 0 || !targetInfo.Mode().IsRegular() {
+					return errPathConflict
+				}
+			} else if !os.IsNotExist(targetErr) {
+				return targetErr
+			}
+		}
 		var err error
 		createdDirs, err = ensureParentDirs(d.cfg.WorkspaceDir, resolved.path)
 		if err != nil {
 			return err
 		}
-		if params.Exclusive {
+		if source != nil {
+			// Install the already-downloaded file while holding the same path lock
+			// used by editor writes; never expose an unconditional late mv.
+			sourceInfo, statErr := os.Lstat(source.path)
+			if statErr != nil {
+				return statErr
+			}
+			if !sourceInfo.Mode().IsRegular() {
+				return errPathConflict
+			}
+			if params.Exclusive {
+				if err := installFileExclusive(source.path, resolved.path); err != nil {
+					return err
+				}
+				created = true
+			} else {
+				if err := os.Rename(source.path, resolved.path); err != nil {
+					return err
+				}
+				created = false
+			}
+			bytesWritten = int(sourceInfo.Size())
+		} else if params.Exclusive {
 			// Atomic create: O_EXCL fails if the path already exists, so concurrent
 			// exclusive creates cannot clobber each other.
 			if err := osWriteFileExclusive(resolved.path, data); err != nil {
 				return err
 			}
 			created = true
+			bytesWritten = len(data)
 		} else {
 			created, err = writeFileWithDisposition(resolved.path, data)
 			if err != nil {
 				return err
 			}
+			bytesWritten = len(data)
 		}
 		mtimeMs = statMtimeMs(resolved.path)
 		return nil
@@ -428,7 +490,7 @@ func (d *Dispatcher) handleFSWrite(request protocol.RPCRequest) interface{} {
 
 	result := map[string]interface{}{
 		"path":         resolved.path,
-		"bytesWritten": len(data),
+		"bytesWritten": bytesWritten,
 		"created":      created,
 		"createdDirs":  createdDirs,
 	}

--- a/apps/sandbox/rpc/helpers.go
+++ b/apps/sandbox/rpc/helpers.go
@@ -173,6 +173,18 @@ func osWriteFileExclusive(path string, content []byte) error {
 	return writeAndClose(f, content)
 }
 
+// installFileExclusive atomically claims a missing destination with a hard
+// link. Source and target are validated to share a directory, so they are on
+// the same filesystem. Removing the staging name is cleanup only; once the
+// link succeeds the uploaded data is already installed safely.
+func installFileExclusive(source, target string) error {
+	if err := os.Link(source, target); err != nil {
+		return err
+	}
+	_ = os.Remove(source)
+	return nil
+}
+
 func osReadFile(path string) (string, error) {
 	bytes, err := os.ReadFile(path)
 	if err != nil {

--- a/apps/sandbox/rpc/tree_test.go
+++ b/apps/sandbox/rpc/tree_test.go
@@ -416,6 +416,145 @@ func TestFSWriteReportsCreatedFileAndParentDirectories(t *testing.T) {
 	}
 }
 
+func TestFSWriteSourceExpectedVersion(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+	target := filepath.Join(root, "source.txt")
+	staging := filepath.Join(root, ".cohub-upload.source")
+	if err := os.WriteFile(target, []byte("old"), 0o644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if err := os.WriteFile(staging, []byte("uploaded"), 0o600); err != nil {
+		t.Fatalf("write staging file: %v", err)
+	}
+
+	res := d.handleFSWrite(writeRequest(t, fsWriteParams{
+		Path:       "source.txt",
+		SourcePath: staging,
+		Expected:   &fsWriteVersion{Size: info.Size(), MtimeMs: info.ModTime().UnixMilli()},
+	}))
+	if _, ok := res.(map[string]interface{}); !ok {
+		t.Fatalf("expected source install to succeed, got %T (%v)", res, res)
+	}
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(content) != "uploaded" {
+		t.Fatalf("target content = %q, want uploaded", content)
+	}
+	if _, err := os.Stat(staging); !os.IsNotExist(err) {
+		t.Fatalf("staging file should be consumed, stat error = %v", err)
+	}
+}
+
+func TestFSWriteSourceExpectedVersionConflict(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+	target := filepath.Join(root, "source-conflict.txt")
+	staging := filepath.Join(root, ".cohub-upload.conflict")
+	if err := os.WriteFile(target, []byte("old"), 0o644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if err := os.WriteFile(staging, []byte("uploaded"), 0o600); err != nil {
+		t.Fatalf("write staging file: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("edited by user"), 0o644); err != nil {
+		t.Fatalf("edit target: %v", err)
+	}
+
+	res := d.handleFSWrite(writeRequest(t, fsWriteParams{
+		Path:       "source-conflict.txt",
+		SourcePath: staging,
+		Expected:   &fsWriteVersion{Size: info.Size(), MtimeMs: info.ModTime().UnixMilli()},
+	}))
+	failed, ok := res.(protocol.RPCFailed)
+	if !ok {
+		t.Fatalf("expected source install conflict, got %T (%v)", res, res)
+	}
+	if failed.Error.Code != "CONFLICT" {
+		t.Fatalf("error code = %q, want CONFLICT", failed.Error.Code)
+	}
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(content) != "edited by user" {
+		t.Fatalf("conflict clobbered target: %q", content)
+	}
+	if _, err := os.Stat(staging); err != nil {
+		t.Fatalf("staging file should remain for cleanup, stat error = %v", err)
+	}
+}
+
+func TestFSWriteSourceExclusiveCreate(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+	staging := filepath.Join(root, ".cohub-upload.create")
+	if err := os.WriteFile(staging, []byte("created"), 0o600); err != nil {
+		t.Fatalf("write staging file: %v", err)
+	}
+
+	res := d.handleFSWrite(writeRequest(t, fsWriteParams{
+		Path:       "created-from-upload.txt",
+		SourcePath: staging,
+		Exclusive:  true,
+	}))
+	if _, ok := res.(map[string]interface{}); !ok {
+		t.Fatalf("expected source create to succeed, got %T (%v)", res, res)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "created-from-upload.txt"))
+	if err != nil {
+		t.Fatalf("read created target: %v", err)
+	}
+	if string(content) != "created" {
+		t.Fatalf("target content = %q, want created", content)
+	}
+	if _, err := os.Stat(staging); !os.IsNotExist(err) {
+		t.Fatalf("staging file should be consumed, stat error = %v", err)
+	}
+}
+
+func TestFSWriteSourceExclusiveCreateConflict(t *testing.T) {
+	root := setupTree(t)
+	d := newTreeDispatcher(t, root)
+	staging := filepath.Join(root, ".cohub-upload.create-conflict")
+	if err := os.WriteFile(staging, []byte("uploaded"), 0o600); err != nil {
+		t.Fatalf("write staging file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "created-by-user.txt"), []byte("user"), 0o644); err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+
+	res := d.handleFSWrite(writeRequest(t, fsWriteParams{
+		Path:       "created-by-user.txt",
+		SourcePath: staging,
+		Exclusive:  true,
+	}))
+	failed, ok := res.(protocol.RPCFailed)
+	if !ok {
+		t.Fatalf("expected source create conflict, got %T (%v)", res, res)
+	}
+	if failed.Error.Code != "ALREADY_EXISTS" {
+		t.Fatalf("error code = %q, want ALREADY_EXISTS", failed.Error.Code)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "created-by-user.txt"))
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(content) != "user" {
+		t.Fatalf("exclusive conflict clobbered target: %q", content)
+	}
+}
+
 func TestFSWriteExclusive(t *testing.T) {
 	root := setupTree(t)
 	d := newTreeDispatcher(t, root)

--- a/apps/sandbox/ws/session.go
+++ b/apps/sandbox/ws/session.go
@@ -209,6 +209,7 @@ func (s *Server) sendHeartbeat(session *connectionSession, includeSnapshot bool)
 			FSWrite:            true,
 			FSWriteDisposition: true,
 			FSWriteExpected:    true,
+			FSWriteSource:      true,
 			FSEdit:             true,
 			FSMkdir:            true,
 			FSStat:             true,

--- a/packages/infra/src/agent-queue/index.ts
+++ b/packages/infra/src/agent-queue/index.ts
@@ -1,9 +1,11 @@
 import type { GenerationPolicy } from "@cohub/protocol/generation";
+import type { SpaceFsUploadTargetVersion } from "@cohub/protocol/fs";
 import { createHash } from "node:crypto";
 import type { Queue, JobsOptions, QueueOptions } from "bullmq";
 import { COHUB_AGENT_TURNS_QUEUE, createBullmqConnectionOptions, createBullmqQueue, defaultJobRetention } from "../bullmq/index.js";
 
 export const AGENT_SANDBOX_BASH_JOB_NAME = "sandbox_bash" as const;
+export const AGENT_SANDBOX_BASH_ATOMIC_JOB_NAME = "sandbox_bash_atomic" as const;
 export const AGENT_RUN_COMMAND_JOB_NAME = "run_command" as const;
 export const AGENT_SANDBOX_FS_MUTATION_JOB_NAME = "sandbox_fs_mutation" as const;
 
@@ -12,6 +14,7 @@ export type AgentSandboxBashUploadJobData = {
   sessionId: string;
   uploadId: string;
   destinationRoot: string;
+  materialize?: "atomic";
   downloadHost: string;
   files: Array<{
     relativePath: string;
@@ -19,6 +22,7 @@ export type AgentSandboxBashUploadJobData = {
     size: number;
     mimeType: string | null;
     downloadUrl: string;
+    targetVersion?: SpaceFsUploadTargetVersion;
   }>;
   requestId?: string | null;
   trace?: Record<string, unknown>;

--- a/packages/infra/src/bullmq/index.ts
+++ b/packages/infra/src/bullmq/index.ts
@@ -29,7 +29,7 @@ export const queueDefinitions = [
     criticality: "critical",
     concurrencyEnv: "AGENT_WORKER_CONCURRENCY",
     defaultConcurrencyPerWorker: DEFAULT_AGENT_WORKER_CONCURRENCY,
-    registeredJobs: ["agent_turns", "agent_session_fork", "sandbox_bash", "run_command", "sandbox_fs_mutation"],
+    registeredJobs: ["agent_turns", "agent_session_fork", "sandbox_bash", "sandbox_bash_atomic", "run_command", "sandbox_fs_mutation"],
   },
   {
     name: COHUB_SYSTEM_QUEUE,

--- a/packages/protocol/src/board-codec.ts
+++ b/packages/protocol/src/board-codec.ts
@@ -21,8 +21,11 @@ import {
 } from "./board-geometry.js";
 
 export class BoardItemValidationError extends Error {
-	constructor(public diagnostics: BoardNodeValidationDiagnostic[]) {
+	diagnostics: BoardNodeValidationDiagnostic[];
+
+	constructor(diagnostics: BoardNodeValidationDiagnostic[]) {
 		super(diagnostics[0]?.message ?? "invalid Board item");
+		this.diagnostics = diagnostics;
 		this.name = "BoardItemValidationError";
 	}
 }

--- a/packages/protocol/src/fs/index.ts
+++ b/packages/protocol/src/fs/index.ts
@@ -93,6 +93,16 @@ export type SpaceFsVersion = {
 };
 
 /**
+ * Version captured for an upload target when the upload is planned. A missing
+ * target is represented explicitly so materialization can use atomic create
+ * semantics instead of overwriting a file created while the upload was in
+ * flight.
+ */
+export type SpaceFsUploadTargetVersion =
+  | { exists: false }
+  | { exists: true; size: number; mtimeMs: number };
+
+/**
  * Compare file versions at the integer-millisecond precision carried by every
  * filesystem transport. Node may expose fractional milliseconds while the Go
  * sandbox protocol uses Unix milliseconds, so comparing the raw values would

--- a/packages/protocol/src/sandbox/index.ts
+++ b/packages/protocol/src/sandbox/index.ts
@@ -117,6 +117,8 @@ export type SandboxCapabilities = {
   fsWriteDisposition?: boolean;
   /** fs.write honors the expected version baseline (atomic check-and-write). */
   fsWriteExpected?: boolean;
+  /** fs.write can atomically install a sandbox-local staging file. */
+  fsWriteSource?: boolean;
   /** Supports the atomic fs.edit read-apply-write method. */
   fsEdit?: boolean;
   fsMkdir?: boolean;
@@ -207,6 +209,8 @@ export type FsWriteParams = {
   path: string;
   cwd?: string;
   content: string;
+  /** Internal upload path: atomically install this staged file at path. */
+  sourcePath?: string;
   /** Content encoding; base64 enables binary-safe writes. Defaults to utf-8. */
   encoding?: "utf-8" | "base64";
   /** Fail with ALREADY_EXISTS instead of overwriting when the path exists (O_EXCL). */


### PR DESCRIPTION
## Summary

- Capture each workspace upload target version before the client uploads the object.
- Stage downloaded files and install them through the sandbox's locked `fs.write` path using CAS for existing files and exclusive create for new files.
- Return `409 upload_conflict` instead of silently overwriting an edit made while the upload was in flight.
- Route atomic workspace uploads through a separate job name so older Agents reject them instead of running the legacy unconditional `mv -f` path.
- Keep `BoardItemValidationError` compatible with Node strip-only TypeScript so the current `main` Web test suite can load protocol source.

## Root Cause

The upload materializer downloaded files asynchronously and then used `mv -f`, while the editor used version-aware writes. A delayed upload job could therefore overwrite a successful editor save.

The existing Web CI failure was independent: a recently added TypeScript constructor parameter property cannot be parsed by the test runner's native strip-only mode. The explicit field preserves behavior without weakening the test runner.

## Validation

- `go test -race ./...` and `go vet ./...` in `apps/sandbox`
- Protocol: 84 tests
- Infra: 25 tests
- Agent: 44 tests and build
- API: 127 tests and lint
- Web: 359 tests under native strip-only TypeScript
- Biome and `bash -n` checks

The local API typecheck/build still needs the private `@talesofai-billing/sdk` package; CI has that dependency and completed build/typecheck successfully.

## Deployment

Publish API, Agent, and sandbox images together. Workspace upload manifests created before this change do not contain a target version and are rejected with a clear `409`; those uploads need to be started again.