### PR TITLE
fix(upload): handle outdated sandbox capabilities

### DIFF
--- a/apps/agent/src/sandbox-bash.ts
+++ b/apps/agent/src/sandbox-bash.ts
@@ -5,11 +5,16 @@ import { recordJobFailure } from "@cohub/infra/bullmq";
 import { getAgentTracer, wrapToolCall } from "@cohub/infra/tracing/agent";
 import { SandboxRpcError, type SandboxConnection } from "@cohub/sandbox-client";
 import { createSandboxCodingTools, tracedRpc } from "./sandbox/tools.js";
+import {
+  SANDBOX_UPLOAD_UNSUPPORTED_MESSAGE,
+  sandboxUploadUnsupportedErrorMessage,
+  supportsAtomicUpload,
+} from "./sandbox-upload-capabilities.js";
 import { runWithToolExecutionContext } from "./tool-context.js";
 import { logger } from "./logger.js";
 import { AGENT_SANDBOX_BASH_ATOMIC_JOB_NAME, type AgentSandboxBashUploadJobData } from "./queue.js";
 import { loadSpaceEnvSnapshot } from "./runtime/env-cache.js";
-import { ensureSandboxConnection } from "./sandbox-pool.js";
+import { ensureSandboxConnection, recoverSandboxForUpgrade } from "./sandbox-pool.js";
 
 const SCRIPT_PATH = new URL("./jobs/sandbox-bash/upload-files.sh", import.meta.url);
 const tools = createSandboxCodingTools();
@@ -198,25 +203,40 @@ async function cleanupStagedFiles(spaceId: string, paths: string[]) {
   }
 }
 
-function supportsAtomicMaterialization(connection: SandboxConnection) {
-  return connection.capabilities?.fsWriteSource === true &&
-    connection.capabilities?.fsWriteExpected === true &&
-    connection.capabilities?.fsWriteDisposition === true;
+function throwSandboxUploadUnsupported(): never {
+  throw new UnrecoverableError(sandboxUploadUnsupportedErrorMessage());
 }
 
-async function assertAtomicMaterializationSupport(spaceId: string) {
-  const connection = await ensureSandboxConnection(spaceId);
-  if (!supportsAtomicMaterialization(connection)) {
-    throw new Error("sandbox does not support atomic upload materialization");
+async function ensureAtomicUploadConnection(spaceId: string) {
+  let connection = await ensureSandboxConnection(spaceId);
+  if (supportsAtomicUpload(connection.capabilities)) return connection;
+
+  logger.warn("[SandboxBash] sandbox lacks atomic upload capabilities; requesting upgrade", { spaceId });
+  const recovery = await recoverSandboxForUpgrade(
+    spaceId,
+    "upload_requires_atomic_materialization",
+  );
+  if ((recovery.throttled && !recovery.recovering) || (!recovery.ok && !recovery.recovering)) {
+    throwSandboxUploadUnsupported();
   }
+
+  connection = await ensureSandboxConnection(spaceId, { timeoutMs: 180_000 });
+  if (!supportsAtomicUpload(connection.capabilities)) {
+    logger.error("[SandboxBash] sandbox upgrade did not provide atomic upload capabilities", {
+      spaceId,
+      message: SANDBOX_UPLOAD_UNSUPPORTED_MESSAGE,
+    });
+    throwSandboxUploadUnsupported();
+  }
+  return connection;
 }
 
 async function materializeAtomicUpload(data: AgentSandboxBashUploadJobData, output: string): Promise<UploadedFile[]> {
   const staged = parseStagedLines(output, data);
   const sources = staged.map((item) => item.sourcePath);
   const connection = await ensureSandboxConnection(data.spaceId);
-  if (!supportsAtomicMaterialization(connection)) {
-    throw new Error("sandbox does not support atomic upload materialization");
+  if (!supportsAtomicUpload(connection.capabilities)) {
+    throwSandboxUploadUnsupported();
   }
 
   const uploaded: UploadedFile[] = [];
@@ -265,7 +285,7 @@ export async function processSandboxBashJob(job: Job<AgentSandboxBashUploadJobDa
     throw new UnrecoverableError("upload_conflict: upload target version is unavailable");
   }
   if (data.materialize === "atomic") {
-    await assertAtomicMaterializationSupport(data.spaceId);
+    await ensureAtomicUploadConnection(data.spaceId);
   }
 
   const bashTool = tools.find((tool) => tool.name === "bash");

--- a/apps/agent/src/sandbox-pool.ts
+++ b/apps/agent/src/sandbox-pool.ts
@@ -41,7 +41,7 @@ type PoolEntry = {
   idleTimer: ReturnType<typeof setTimeout> | null;
 };
 
-type SandboxRecoverOutcome = {
+export type SandboxRecoverOutcome = {
   ok: boolean;
   recovering: boolean;
   throttled: boolean;
@@ -219,6 +219,11 @@ function disconnectEntry(spaceId: string, reason: string) {
 export function invalidateSandboxConnection(spaceId: string, reason: string) {
   disconnectEntry(spaceId, reason);
   wsUrlResolutions.delete(spaceId);
+}
+
+export async function recoverSandboxForUpgrade(spaceId: string, reason: string): Promise<SandboxRecoverOutcome> {
+  invalidateSandboxConnection(spaceId, reason);
+  return recoverSandboxOnce(spaceId, reason);
 }
 
 function scheduleIdleEviction(entry: PoolEntry) {

--- a/apps/agent/src/sandbox-upload-capabilities.ts
+++ b/apps/agent/src/sandbox-upload-capabilities.ts
@@ -1,0 +1,20 @@
+import type { SandboxCapabilities } from "@cohub/protocol/sandbox";
+
+export const SANDBOX_UPLOAD_UNSUPPORTED_PREFIX = "sandbox_unsupported:";
+export const SANDBOX_UPLOAD_UNSUPPORTED_MESSAGE =
+  "sandbox must be upgraded before this upload can be completed";
+
+type AtomicUploadCapabilities = Pick<
+  SandboxCapabilities,
+  "fsWriteSource" | "fsWriteExpected" | "fsWriteDisposition"
+>;
+
+export function supportsAtomicUpload(capabilities: AtomicUploadCapabilities | undefined) {
+  return capabilities?.fsWriteSource === true &&
+    capabilities.fsWriteExpected === true &&
+    capabilities.fsWriteDisposition === true;
+}
+
+export function sandboxUploadUnsupportedErrorMessage() {
+  return `${SANDBOX_UPLOAD_UNSUPPORTED_PREFIX} ${SANDBOX_UPLOAD_UNSUPPORTED_MESSAGE}`;
+}

--- a/apps/agent/src/tests/sandbox-upload-capabilities.test.ts
+++ b/apps/agent/src/tests/sandbox-upload-capabilities.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SANDBOX_UPLOAD_UNSUPPORTED_PREFIX,
+  sandboxUploadUnsupportedErrorMessage,
+  supportsAtomicUpload,
+} from "../sandbox-upload-capabilities.js";
+
+const supported = {
+  fsWriteSource: true,
+  fsWriteExpected: true,
+  fsWriteDisposition: true,
+};
+
+test("atomic uploads require all write capabilities", () => {
+  assert.equal(supportsAtomicUpload(supported), true);
+  assert.equal(supportsAtomicUpload({ ...supported, fsWriteSource: false }), false);
+  assert.equal(supportsAtomicUpload({ ...supported, fsWriteExpected: false }), false);
+  assert.equal(supportsAtomicUpload({ ...supported, fsWriteDisposition: false }), false);
+  assert.equal(supportsAtomicUpload(undefined), false);
+});
+
+test("unsupported upload errors use the queue error prefix", () => {
+  assert.equal(
+    sandboxUploadUnsupportedErrorMessage(),
+    `${SANDBOX_UPLOAD_UNSUPPORTED_PREFIX} sandbox must be upgraded before this upload can be completed`,
+  );
+});

--- a/apps/api/src/routes/spaces/fs.route.ts
+++ b/apps/api/src/routes/spaces/fs.route.ts
@@ -51,6 +51,7 @@ import {
   enqueueSandboxUploadFilesJob,
   SandboxUploadConflictError,
   SandboxUploadSizeMismatchError,
+  SandboxUploadUnsupportedError,
 } from "../../sandbox-bash-queue.js";
 import { isAllowedPublicAssetDownloadUrl } from "../../public-asset-storage.js";
 import type {
@@ -603,6 +604,9 @@ router.post("/uploads/:uploadId/complete", async (c) => {
     }
     if (error instanceof SandboxUploadConflictError) {
       return c.json({ code: "upload_conflict", message: "upload target changed while uploading" }, 409);
+    }
+    if (error instanceof SandboxUploadUnsupportedError) {
+      return c.json({ code: "sandbox_unsupported", message: "sandbox must be upgraded before this upload can be completed" }, 503);
     }
     logger.error("[space-fs] failed to complete upload", error, {
       spaceId,

--- a/apps/api/src/sandbox-bash-queue.ts
+++ b/apps/api/src/sandbox-bash-queue.ts
@@ -48,6 +48,10 @@ export class SandboxUploadConflictError extends Error {
   override name = "SandboxUploadConflictError";
 }
 
+export class SandboxUploadUnsupportedError extends Error {
+  override name = "SandboxUploadUnsupportedError";
+}
+
 export const sandboxBashQueue = createBullmqQueue<SandboxBashUploadJobData, SandboxBashUploadJobResult>(COHUB_AGENT_TURNS_QUEUE, {
   redisUrl: config.bullmqRedisUrl,
   telemetryServiceName: "cohub-api-sandbox-bash",
@@ -69,8 +73,11 @@ export async function enqueueSandboxUploadFilesJob(input: Omit<SandboxBashUpload
     jobId: input.materialize === "atomic"
       ? `${jobName}-${input.uploadId}`
       : `sandbox-bash-${input.uploadId}`,
-    attempts: input.materialize === "atomic" ? 12 : 2,
-    backoff: { type: "fixed", delay: input.materialize === "atomic" ? 5000 : 1000 },
+    // Capability mismatches are permanent for a running sandbox. The agent
+    // attempts one in-place upgrade; keep queue retries short for old workers
+    // that do not know the atomic job name yet.
+    attempts: 2,
+    backoff: { type: "fixed", delay: 1000 },
     ...defaultJobRetention,
   });
 
@@ -83,6 +90,9 @@ export async function enqueueSandboxUploadFilesJob(input: Omit<SandboxBashUpload
     }
     if (message.startsWith("upload_conflict:")) {
       throw new SandboxUploadConflictError(message.slice("upload_conflict:".length).trim());
+    }
+    if (message.startsWith("sandbox_unsupported:")) {
+      throw new SandboxUploadUnsupportedError(message.slice("sandbox_unsupported:".length).trim());
     }
     throw error;
   }


### PR DESCRIPTION
## Summary

- Recover cloud sandboxes that predate atomic upload capabilities before materializing workspace uploads.
- Fail clearly with `sandbox_unsupported` when recovery cannot provide the required capabilities; never fall back to unconditional overwrite.
- Mark capability mismatches as unrecoverable and reduce queue retries so old Agent workers do not delay completion for ~55 seconds.

## Verification

- `pnpm --filter @cohub/agent test` (46 tests)
- `pnpm --filter @cohub/api test` (127 tests)
- Agent/API Biome lint
- Agent production build

Full local typecheck is blocked by the unavailable private `@talesofai-billing/sdk`; CI has the package credentials.