### PR TITLE
fix(agent): recover image-dominated overflow by omitting inline images

### DIFF
--- a/apps/agent/src/processor.ts
+++ b/apps/agent/src/processor.ts
@@ -20,6 +20,7 @@ import { loadRuntimeModelsConfigs } from "./runtime/models-loader.js";
 import { loadImageToTextConfig } from "./runtime/image-to-text-config.js";
 import { loadSpaceEnvSnapshot } from "./runtime/env-cache.js";
 import { CompactionStateRecoveryError, maybeAutoCompact, OverflowRecoveryError, type CompactionOutcome } from "./runtime/compaction.js";
+import { isContextOverflowErrorText, isRetryableProviderErrorMessage } from "./runtime/session-runtime.js";
 import { clearCurrentSessionExecutionAuth, setCurrentSessionExecutionAuth } from "./runtime/session-execution-auth.js";
 import { resolveSpaceFileVisibility } from "./runtime/cross-space-query-access.js";
 import { normalizeGenerationPolicy } from "@cohub/protocol/generation";
@@ -275,6 +276,21 @@ function clearActiveTurnContext(handle: SessionHandle, sessionId: string) {
   handle.lastActiveAt = Date.now();
 }
 
+/** Compaction failure reasons that image-omission can plausibly recover from. */
+const IMAGE_OMISSIBLE_COMPACTION_FAILURES = new Set([
+  "nothing_to_summarize",
+  "compaction_no_effect",
+  "compaction_still_over_budget",
+]);
+
+function isOmissibleCompactionFailure(reason: string): boolean {
+  if (IMAGE_OMISSIBLE_COMPACTION_FAILURES.has(reason)) return true;
+  // The summarization call itself may hit the same provider-side overflow
+  // (its request carries the history too). compact_failed: <provider error>
+  const detail = reason.startsWith("compact_failed: ") ? reason.slice("compact_failed: ".length) : "";
+  return detail ? isRetryableProviderErrorMessage(detail) && isContextOverflowErrorText(detail) : false;
+}
+
 async function runWithRoundAutoCompaction<T>(
   handle: SessionHandle,
   input: {
@@ -305,10 +321,34 @@ async function runWithRoundAutoCompaction<T>(
         if (compactOutcome.compacted) {
           input.onCompacted?.(compactOutcome);
         } else if (force) {
-          logger.warn(
-            `[Agent] overflow-compact did not compact sessionId=${handle.sessionId} reason=${compactOutcome.reason}`,
-          );
-          throw new OverflowRecoveryError(compactOutcome.reason);
+          // Degradation path: when overflow compaction cannot shrink the context
+          // (image-dominated tails upstream proxies bill as raw base64 text),
+          // persistently strip inline images from the session branch and let
+          // this request proceed with the shrunk context instead of failing the
+          // turn. The pre-strip file is archived; images stay re-readable.
+          if (isOmissibleCompactionFailure(compactOutcome.reason)) {
+            const stripOutcome = await handle.sessionManager.omitBranchImages({ reason: compactOutcome.reason }).catch((error) => {
+              logger.warn(`[Agent] image-omission recovery failed sessionId=${handle.sessionId}:`, error);
+              return null;
+            });
+            if (stripOutcome) {
+              logger.info(
+                `[Agent] omitted ${stripOutcome.omittedImages} image(s) from session branch to recover from overflow sessionId=${handle.sessionId} archive=${stripOutcome.archivePath}`,
+              );
+              handle.session.agent.state.messages = handle.sessionManager.buildSessionContext().messages;
+              await refreshSessionHandleFileSignature(handle);
+            } else {
+              logger.warn(
+                `[Agent] overflow-compact did not compact and no images to omit sessionId=${handle.sessionId} reason=${compactOutcome.reason}`,
+              );
+              throw new OverflowRecoveryError(compactOutcome.reason);
+            }
+          } else {
+            logger.warn(
+              `[Agent] overflow-compact did not compact sessionId=${handle.sessionId} reason=${compactOutcome.reason}`,
+            );
+            throw new OverflowRecoveryError(compactOutcome.reason);
+          }
         }
       } finally {
         compacting = false;

--- a/apps/agent/src/runtime/local-session-manager.ts
+++ b/apps/agent/src/runtime/local-session-manager.ts
@@ -686,6 +686,81 @@ export class SessionManager {
     return `archives/${archiveName}`;
   }
 
+  /**
+   * Overflow-recovery degradation: replace every inline image block on the
+   * visible branch with placeholder text, then rewrite the session file.
+   * The pre-strip file is archived first and the header archive pointer is
+   * updated, so fork recovery and later archive numbering stay consistent.
+   * Returns null when the branch carries no image payloads to strip.
+   */
+  async omitBranchImages(input: { reason: string }): Promise<{ omittedImages: number; archivePath: string } | null> {
+    if (!this.sessionFile || !this.header) return null;
+    await this.flush();
+
+    const branchIds = new Set(this.getBranch().map((entry) => entry.id));
+    const placeholder = "Image omitted from context to recover from overflow; re-read the source file if the image is needed again.";
+    let omittedImages = 0;
+    const nextEntries = this.entries.map((entry) => {
+      if (entry.type !== "message" || !branchIds.has(entry.id)) return entry;
+      const message = entry.message as { content?: unknown };
+      if (!Array.isArray(message.content)) return entry;
+      let changed = false;
+      const nextContent = (message.content as unknown[]).map((block) => {
+        const record = block as Record<string, unknown> | null;
+        if (record && typeof record === "object" && !Array.isArray(record)
+          && record.type === "image" && typeof record.data === "string" && record.data) {
+          changed = true;
+          omittedImages += 1;
+          return { type: "text", text: placeholder };
+        }
+        return block;
+      });
+      if (!changed) return entry;
+      return { ...entry, message: { ...entry.message, content: nextContent } } as SessionMessageEntry;
+    });
+
+    if (omittedImages === 0) return null;
+
+    // Archive the pre-strip file before rewriting so the images stay recoverable.
+    // Sanitize header.id to prevent path traversal (it comes from file parsing).
+    const safeId = this.header.id.replace(/[^a-zA-Z0-9-]/g, "");
+    const archiveName = `${safeId}.${this.nextArchiveNumber()}.jsonl`;
+    const archiveDir = join(this.sessionDir, "archives");
+    await mkdir(archiveDir, { recursive: true });
+    await copyFile(this.sessionFile, join(archiveDir, archiveName));
+
+    const savedHeader = this.header;
+    const savedEntries = this.entries;
+    this.header = { ...this.header, compactionArchive: `archives/${archiveName}` };
+    this.entries = nextEntries;
+    this.rebuildIndex();
+    this.fileReady = false;
+    this.rewriteFile();
+    try {
+      await this.flush();
+    } catch (flushError) {
+      this.header = savedHeader;
+      this.entries = savedEntries;
+      this.rebuildIndex();
+      this.fileReady = false;
+      this.writeError = null;
+      this.rewriteFile();
+      throw flushError;
+    }
+
+    this.appendCustomMessageEntry(
+      "cohub_image_omission",
+      [{
+        type: "text",
+        text: `[context recovery] ${omittedImages} inline image(s) removed from history after compaction could not recover from context overflow (${input.reason}). Images remain in the session archive; re-read the source files if needed.`,
+      }],
+      true,
+      { omittedImages, reason: input.reason, archivePath: `archives/${archiveName}` },
+    );
+
+    return { omittedImages, archivePath: `archives/${archiveName}` };
+  }
+
   private nextArchiveNumber(): number {
     const match = this.header?.compactionArchive?.match(/\.(\d+)\.jsonl$/);
     return match ? Number(match[1]) + 1 : 1;

--- a/apps/agent/src/runtime/session-runtime.ts
+++ b/apps/agent/src/runtime/session-runtime.ts
@@ -133,6 +133,39 @@ const LOCAL_OVERFLOW_PATTERNS = [
   /超过系统限制/, // Cohub proxy: "输入Tokens数量(N)超过系统限制(M)"
 ];
 
+// pi-ai OVERFLOW_PATTERNS mirrored for raw-string checks (see utils/overflow).
+const OVERFLOW_TEXT_PATTERNS = [
+  /prompt is too long/i,
+  /request_too_large/i,
+  /input is too long for requested model/i,
+  /exceeds the context window/i,
+  /exceeds (?:the )?(?:model'?s )?maximum context length/i,
+  /input token count.*exceeds the maximum/i,
+  /maximum prompt length is \d+/i,
+  /reduce the length of the messages/i,
+  /maximum context length is \d+ tokens/i,
+  /exceeds (?:the )?maximum allowed input length of [\d,]+ tokens?/i,
+  /exceeds the limit of \d+/i,
+  /exceeds the available context size/i,
+  /greater than the context length/i,
+  /context window exceeds limit/i,
+  /exceeded model token limit/i,
+  /too large for model with \d+ maximum context length/i,
+  /model_context_window_exceeded/i,
+  /prompt too long; exceeded (?:max )?context length/i,
+  /range of input length should be/i,
+  /context[_ ]length[_ ]exceeded/i,
+  /too many tokens/i,
+  /token limit exceeded/i,
+];
+
+/** Test a raw provider error string against all known overflow patterns. */
+export function isContextOverflowErrorText(errorMessage: string): boolean {
+  if (!errorMessage) return false;
+  if (LOCAL_OVERFLOW_PATTERNS.some((p) => p.test(errorMessage))) return true;
+  return OVERFLOW_TEXT_PATTERNS.some((p) => p.test(errorMessage));
+}
+
 /**
  * Explicit context-window overflow (provider error). Silent / length-stop overflow
  * is intentionally excluded so we never discard a successful-looking response.

--- a/apps/agent/src/tests/local-session-manager.test.ts
+++ b/apps/agent/src/tests/local-session-manager.test.ts
@@ -272,6 +272,92 @@ try {
   const c3 = multiCompact.appendCompaction("s3", cm8, 100);
   await multiCompact.archiveAndRewrite(c3, cm8);
   assert.deepEqual(compactContextTexts(), ["summary", "m8", "m9"]);
+
+  // ── omitBranchImages: overflow-recovery image strip ──
+  const stripFile = join(sessionsDir, "image-strip.jsonl");
+  const strip = SessionManager.create(root, sessionsDir);
+  strip.newSession({ id: "image-strip" });
+  strip.setSessionFile(stripFile);
+  strip.appendMessage({
+    role: "user",
+    content: [{ type: "text", text: "look at these" }, { type: "image", data: "aGVsbG8=", mimeType: "image/webp" }],
+    timestamp: Date.now(),
+  } as never);
+  strip.appendMessage({
+    role: "assistant",
+    content: [
+      { type: "thinking", thinking: "compare" },
+      { type: "toolCall", toolCallId: "t1", name: "read", arguments: { path: "/tmp/sheet_0.jpg" } },
+    ] as never,
+    timestamp: Date.now(),
+  } as never);
+  strip.appendMessage({
+    role: "toolResult",
+    content: [
+      { type: "text", text: "Read image file [image/jpeg]" },
+      { type: "image", data: "aGVsbG8=", mimeType: "image/jpeg" },
+    ] as never,
+    timestamp: Date.now(),
+  } as never);
+  strip.appendMessage({
+    role: "user",
+    content: [{ type: "text", text: "thanks" }],
+    timestamp: Date.now(),
+  } as never);
+  await strip.flush();
+
+  const stripResult = await strip.omitBranchImages({ reason: "nothing_to_summarize" });
+  assert.ok(stripResult);
+  assert.equal(stripResult.omittedImages, 2);
+
+  const stripContext = strip.buildSessionContext().messages;
+  const stripBlocks = stripContext.flatMap((message) => {
+    const content = (message as { content?: unknown }).content;
+    return Array.isArray(content) ? content as Array<Record<string, unknown>> : [];
+  });
+  assert.equal(stripBlocks.filter((block) => block.type === "image").length, 0);
+  assert.equal(stripBlocks.filter((block) => block.type === "text" && typeof block.text === "string" && block.text.includes("Image omitted")).length, 2);
+  // Non-image blocks (thinking, toolCall, original text) survive untouched.
+  assert.equal(stripBlocks.filter((block) => block.type === "thinking").length, 1);
+  assert.equal(stripBlocks.filter((block) => block.type === "toolCall").length, 1);
+  assert.equal(stripContext[0] && (stripContext[0] as { content?: Array<{ text?: string }> }).content?.[0]?.text, "look at these");
+
+  // Marker entry appended and visible in context.
+  const omissionEntries = strip.getBranchEntries().filter(
+    (entry) => entry.type === "custom_message" && entry.customType === "cohub_image_omission",
+  );
+  assert.equal(omissionEntries.length, 1);
+  const omissionEntry = omissionEntries[0];
+  assert.equal(omissionEntry && omissionEntry.type === "custom_message" && (omissionEntry.details as { omittedImages: number }).omittedImages, 2);
+
+  // Archive was written and contains the original images.
+  const stripArchivePath = join(sessionsDir, stripResult.archivePath);
+  const stripArchiveRaw = await readFile(stripArchivePath, "utf-8");
+  assert.equal((stripArchiveRaw.match(/"type":"image"/g) ?? []).length, 2);
+
+  // Reopened file keeps the stripped state; second strip is a no-op (null).
+  await strip.close();
+  const stripReopened = await SessionManager.open(stripFile, sessionsDir);
+  const reopenedBlocks = stripReopened.buildSessionContext().messages.flatMap((message) => {
+    const content = (message as { content?: unknown }).content;
+    return Array.isArray(content) ? content as Array<Record<string, unknown>> : [];
+  });
+  assert.equal(reopenedBlocks.filter((block) => block.type === "image").length, 0);
+  assert.equal(await stripReopened.omitBranchImages({ reason: "retry" }), null);
+
+  // Text-only branch returns null without touching the file.
+  const noImageFile = join(sessionsDir, "no-image.jsonl");
+  const noImage = SessionManager.create(root, sessionsDir);
+  noImage.newSession({ id: "no-image" });
+  noImage.setSessionFile(noImageFile);
+  noImage.appendMessage({
+    role: "user",
+    content: [{ type: "text", text: "plain" }],
+    timestamp: Date.now(),
+  } as never);
+  await noImage.flush();
+  assert.equal(await noImage.omitBranchImages({ reason: "nothing_to_summarize" }), null);
+  assert.equal((await readdir(sessionsDir)).filter((name) => name.startsWith("no-image")).length, 1);
 } finally {
   await rm(root, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Background

Follow-up to #175. Sessions that read many images into one turn (contact sheets, face crops) die permanently with `Context overflow recovery failed: nothing_to_summarize`:

1. Upstream reseller proxies (new-api variants) pre-flight-tokenize inline base64 images as raw text (~1.97 chars/token) while billing them as vision tokens — an ~85× discrepancy. A request the model side accounts at ~90k tokens gets rejected as `输入Tokens数量(1112905)超过系统限制(1000000)` (HTTP 413).
2. Force compaction summarizes the text but images always survive in the keep-recent tail → the retry still overflows.
3. pi's cut-point estimation counts images at flat 1,200 tokens, so `messagesToSummarize` is empty → `nothing_to_summarize` → `OverflowRecoveryError` fails the turn, and every subsequent "continue" repeats the cycle (with a ~1.1M-token request burned per retry).

Upstream harnesses (pi, codex) don't handle this because no official provider behaves this way; the upstream proxy is out of our control, so the agent needs a degradation path.

## Change

When force compaction fails for reasons image omission can plausibly recover from:

- `nothing_to_summarize`, `compaction_no_effect`, `compaction_still_over_budget`
- `compact_failed: <error>` where the error text matches known overflow patterns (including the cohub proxy's Chinese `超过系统限制` rejection)

…then **persistently strip all inline image blocks on the session branch** and let the request proceed with the shrunk context instead of failing the turn.

### Details

- `SessionManager.omitBranchImages()` (new): flushes pending writes, archives the pre-strip session file via the existing archive chain (images stay recoverable), rewrites every visible-branch `image` block with `data` into placeholder text, appends a `cohub_image_omission` custom_message marker so the timeline shows what happened. Returns `null` when the branch has no image payloads.
- `processor.ts`: the force-compaction failure branch calls the strip; on success rebuilds agent state and refreshes the file signature, on `null` keeps the existing `OverflowRecoveryError`. Infrastructure failures (`archive_rewrite_failed`, `db_persistence_failed`, …) still fail immediately — dropping images cannot rescue those.
- `session-runtime.ts`: exports `isContextOverflowErrorText()` — raw-string overflow classification mirroring pi-ai's patterns plus the local `超过系统限制` pattern.

### Semantics

- Images on the *current* turn are also strippable — the 413 scenarios had all images inside one turn. This path only runs after compaction already failed, so normal requests never touch it.
- Placeholder text tells the model the image was removed to recover from overflow and that it can re-read the source file if needed.
- Data safety: session file rewrite is archived first; images remain on disk and in the archive; no DB rows are modified.

## Validation

- New regression tests in `local-session-manager.test.ts`: strip replaces exactly the image blocks (thinking/toolCall/text untouched), marker entry appended, archive contains the original images, reopened file stays stripped, second strip is a no-op, text-only branch returns `null` and writes no archive.
- Test, typecheck, lint-staged (biome) all green against latest main.
- Failure-reason classification smoke-checked against real error strings (413 超过系统限制, `prompt is too long`, non-overflow 500 → no strip).

## Not in scope (tracked separately)

- Request-side URL-based images (would shrink payload ~85× on this proxy class)
- Upstream proxy pre-flight fix (out of our control)

Closes the recovery gap left by #175 for image-dominated contexts.