### PR TITLE
fix(sdk): recover stalled WebSocket handshakes

### DIFF
--- a/.changeset/stalled-websocket-handshake.md
+++ b/.changeset/stalled-websocket-handshake.md
@@ -1,0 +1,5 @@
+---
+"@neta-art/cohub": patch
+---
+
+Retry stalled WebSocket connection handshakes after a configurable timeout.

--- a/packages/sdk/src/websocket.ts
+++ b/packages/sdk/src/websocket.ts
@@ -41,6 +41,7 @@ export type WebsocketClientOptions = {
   autoReconnect?: boolean;
   reconnectBaseDelayMs?: number;
   reconnectMaxDelayMs?: number;
+  connectTimeoutMs?: number;
   pingIntervalMs?: number;
   pongTimeoutMs?: number;
   debug?: boolean;
@@ -112,6 +113,7 @@ const normalizeOptions = (options: WebsocketClientOptions = {}) => ({
   autoReconnect: options.autoReconnect !== false,
   reconnectBaseDelayMs: options.reconnectBaseDelayMs ?? 1000,
   reconnectMaxDelayMs: options.reconnectMaxDelayMs ?? 15000,
+  connectTimeoutMs: normalizeConnectTimeoutMs(options.connectTimeoutMs ?? 15000),
   pingIntervalMs: options.pingIntervalMs ?? 20000,
   pongTimeoutMs: options.pongTimeoutMs ?? 15000,
   debug: options.debug === true,
@@ -119,6 +121,13 @@ const normalizeOptions = (options: WebsocketClientOptions = {}) => ({
 
 const formatCloseMessage = (code?: number, reason?: string) =>
   `WebSocket closed: ${code ?? 0} ${reason || ""}`.trim();
+
+const normalizeConnectTimeoutMs = (value: number): number => {
+  if (!Number.isInteger(value) || value < 1 || value > 2_147_483_647) {
+    throw new Error("connectTimeoutMs must be an integer between 1 and 2147483647");
+  }
+  return value;
+};
 
 const AUTH_CLOSE_CODE = 4003;
 const AUTH_CLOSE_REASON = "authentication failed";
@@ -214,6 +223,7 @@ export class WebsocketClient {
   private readonly autoReconnect: boolean;
   private readonly reconnectBaseDelayMs: number;
   private readonly reconnectMaxDelayMs: number;
+  private readonly connectTimeoutMs: number;
   private readonly pingIntervalMs: number;
   private readonly pongTimeoutMs: number;
   private readonly debug: boolean;
@@ -230,6 +240,7 @@ export class WebsocketClient {
   private retryAuthClose = false;
   private manuallyClosed = false;
   private connectPromise: Promise<void> | null = null;
+  private pendingConnectReject: ((error: Error) => void) | null = null;
   private authWaiter: {
     promise: Promise<void>;
     resolve: () => void;
@@ -258,6 +269,7 @@ export class WebsocketClient {
     this.autoReconnect = normalized.autoReconnect;
     this.reconnectBaseDelayMs = normalized.reconnectBaseDelayMs;
     this.reconnectMaxDelayMs = normalized.reconnectMaxDelayMs;
+    this.connectTimeoutMs = normalized.connectTimeoutMs;
     this.pingIntervalMs = normalized.pingIntervalMs;
     this.pongTimeoutMs = normalized.pongTimeoutMs;
     this.debug = normalized.debug;
@@ -306,60 +318,50 @@ export class WebsocketClient {
       const ws = new this.WebSocketImpl(this.url);
       this.ws = ws;
       let settled = false;
+      let closed = false;
+      let connectTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const clearConnectTimer = () => {
+        if (connectTimer === null) return;
+        clearTimeout(connectTimer);
+        connectTimer = null;
+      };
 
       const rejectOnce = (error: Error) => {
         if (settled) return;
+        clearConnectTimer();
         settled = true;
         this.connectPromise = null;
+        if (this.pendingConnectReject === rejectOnce) {
+          this.pendingConnectReject = null;
+        }
         reject(error);
       };
 
       const resolveOnce = () => {
         if (settled) return;
+        clearConnectTimer();
         settled = true;
         this.connectPromise = null;
+        if (this.pendingConnectReject === rejectOnce) {
+          this.pendingConnectReject = null;
+        }
         resolve();
       };
 
-      ws.onopen = async () => {
-        try {
-          this.log("connected", { url: this.url, isReconnect, attempt: this.reconnectAttempt });
-          this.startPingLoop();
-          await this.authenticate();
-          this.state = "open";
-          this.restoreRoomSubscriptions();
-          this.reconnectAttempt = 0;
-          this.emit("open", { connectionId: this.connectionId });
-          resolveOnce();
-        } catch (error) {
-          const authError =
-            error instanceof Error ? error : new Error("authentication failed");
-          const recoverable = Boolean(
-            this.getAccessToken &&
-            this.autoReconnect &&
-            !this.manuallyClosed &&
-            !this.authReconnectAttempted
-          );
-          this.retryAuthClose = recoverable;
-          if (recoverable) {
-            this.authReconnectAttempted = true;
-            this.forceRefreshOnNextAuth = true;
-          }
-          this.emit("error", { error: authError, recoverable });
-          rejectOnce(authError);
-          ws.close(AUTH_CLOSE_CODE, AUTH_CLOSE_REASON);
-        }
+      const isCurrentConnection = () => this.ws === ws && !closed;
+
+      const cleanupSocket = () => {
+        ws.onopen = null;
+        ws.onmessage = null;
+        ws.onerror = null;
+        ws.onclose = null;
       };
 
-      ws.onmessage = (event) => {
-        this.handleMessage(event.data);
-      };
-
-      ws.onerror = (error) => {
-        this.emit("error", { error, recoverable: !this.manuallyClosed });
-      };
-
-      ws.onclose = (event) => {
+      const handleClose = (event: { code: number; reason: string }) => {
+        if (closed || this.ws !== ws) return;
+        closed = true;
+        clearConnectTimer();
         this.stopPingLoop();
         const wasConnecting = this.state === "connecting" || this.state === "reconnecting";
         this.state = "closed";
@@ -380,6 +382,7 @@ export class WebsocketClient {
           reason: event.reason,
           willReconnect,
         });
+        cleanupSocket();
         if (wasConnecting) {
           rejectOnce(closeError);
         }
@@ -387,6 +390,70 @@ export class WebsocketClient {
           void this.scheduleReconnect(event.code, event.reason);
         }
       };
+
+      ws.onopen = async () => {
+        if (!isCurrentConnection()) return;
+        clearConnectTimer();
+        try {
+          this.log("connected", { url: this.url, isReconnect, attempt: this.reconnectAttempt });
+          this.startPingLoop();
+          await this.authenticate();
+          if (!isCurrentConnection()) return;
+          this.state = "open";
+          this.restoreRoomSubscriptions();
+          this.reconnectAttempt = 0;
+          this.emit("open", { connectionId: this.connectionId });
+          resolveOnce();
+        } catch (error) {
+          if (!isCurrentConnection()) return;
+          const authError =
+            error instanceof Error ? error : new Error("authentication failed");
+          const recoverable = Boolean(
+            this.getAccessToken &&
+            this.autoReconnect &&
+            !this.manuallyClosed &&
+            !this.authReconnectAttempted
+          );
+          this.retryAuthClose = recoverable;
+          if (recoverable) {
+            this.authReconnectAttempted = true;
+            this.forceRefreshOnNextAuth = true;
+          }
+          this.emit("error", { error: authError, recoverable });
+          rejectOnce(authError);
+          ws.close(AUTH_CLOSE_CODE, AUTH_CLOSE_REASON);
+        }
+      };
+
+      ws.onmessage = (event) => {
+        if (!isCurrentConnection()) return;
+        this.handleMessage(event.data);
+      };
+
+      ws.onerror = (error) => {
+        if (!isCurrentConnection()) return;
+        this.emit("error", { error, recoverable: !this.manuallyClosed });
+      };
+
+      ws.onclose = (event) => {
+        handleClose(event);
+      };
+
+      this.pendingConnectReject = rejectOnce;
+      connectTimer = setTimeout(() => {
+        if (!isCurrentConnection() || settled) return;
+        const reason = "connect timeout";
+        const error = new Error(`WebSocket ${reason} after ${this.connectTimeoutMs}ms`);
+        this.emit("error", {
+          error,
+          recoverable: !this.manuallyClosed && this.autoReconnect,
+        });
+        try {
+          ws.close(4002, reason);
+        } finally {
+          handleClose({ code: 4002, reason });
+        }
+      }, this.connectTimeoutMs);
     });
 
     return this.connectPromise;
@@ -398,9 +465,19 @@ export class WebsocketClient {
     this.stopPingLoop();
     this.state = "closed";
     this.rejectAuthWaiter(new Error("disconnected"));
-    this.ws?.close(code, reason);
+    const ws = this.ws;
     this.ws = null;
+    ws?.close(code, reason);
+    this.pendingConnectReject?.(new Error(`WebSocket disconnected: ${reason}`));
+    this.pendingConnectReject = null;
     this.connectPromise = null;
+    if (ws) {
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onerror = null;
+      ws.onclose = null;
+      this.emit("close", { code, reason, willReconnect: false });
+    }
     this.authReconnectAttempted = false;
     this.forceRefreshOnNextAuth = false;
     this.retryAuthClose = false;

--- a/packages/sdk/tests/websocket-reconnect.test.ts
+++ b/packages/sdk/tests/websocket-reconnect.test.ts
@@ -76,6 +76,155 @@ const authError = {
 const sentTypes = (socket: FakeWebSocket) =>
   socket.sent.map((raw) => (JSON.parse(raw) as { type: string }).type);
 
+test("reconnects a stalled handshake without a close event and restores retained rooms", async (t) => {
+  FakeWebSocket.instances = [];
+  t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+  const closes: CloseSnapshot[] = [];
+  const client = new WebsocketClient({
+    url: "ws://localhost",
+    reconnectBaseDelayMs: 1000,
+    getAccessToken: () => "token",
+    WebSocketImpl: FakeWebSocket,
+  });
+  t.after(() => client.disconnect());
+  client.on("close", (snapshot) => closes.push(snapshot));
+
+  const connecting = client.connect();
+  const rejected = assert.rejects(connecting, /connect timeout/);
+  const release = client.subscribeSpace("space-1");
+  const releaseOther = client.subscribeSpace("space-2");
+  releaseOther();
+  const first = FakeWebSocket.instances[0];
+  assert.ok(first);
+  const lateClose = first.onclose;
+  const lateOpen = first.onopen;
+  const closeCalls: Array<{ code?: number; reason?: string }> = [];
+  first.close = (code, reason) => {
+    closeCalls.push({ code, reason });
+    first.readyState = WebSocket.CLOSING;
+  };
+
+  t.mock.timers.tick(14_999);
+  assert.equal(client.state, "connecting");
+  assert.equal(closeCalls.length, 0);
+  t.mock.timers.tick(1);
+  assert.equal(client.state, "reconnecting");
+  assert.equal(closeCalls.length, 1);
+  assert.match(closeCalls[0].reason ?? "", /connect timeout/);
+  assert.deepEqual(closes.map(({ willReconnect }) => willReconnect), [true]);
+  await rejected;
+
+  t.mock.timers.tick(1000);
+  await Promise.resolve();
+  assert.equal(FakeWebSocket.instances.length, 2);
+  const second = FakeWebSocket.instances[1];
+  assert.ok(second);
+  second.open();
+  await waitFor(() => sentTypes(second).includes("auth"), "expected authentication after timeout");
+  second.receive(authOk("connection-2"));
+  await waitFor(() => sentTypes(second).includes("subscribe"), "expected retained rooms after timeout");
+  assert.equal(client.state, "open");
+  const subscription = second.sent.map((raw) => JSON.parse(raw)).find((event) => event.type === "subscribe");
+  assert.deepEqual(subscription.payload.rooms, ["space:space-1"]);
+  second.receive({
+    id: "subscribe-connection-2",
+    timestamp: Date.now(),
+    domain: "system",
+    type: "system.subscribe.ok",
+    payload: { rooms: ["space:space-1"] },
+  });
+
+  lateClose?.({ code: 1006, reason: "late close" } as CloseEvent);
+  lateOpen?.(new Event("open"));
+  await Promise.resolve();
+  assert.equal(client.state, "open");
+  assert.equal(client.connectionId, "connection-2");
+  assert.deepEqual(sentTypes(second), ["auth", "subscribe"]);
+  assert.equal(closes.length, 1);
+
+  release();
+  assert.deepEqual(sentTypes(second), ["auth", "subscribe", "unsubscribe"]);
+});
+
+test("cancels the handshake timeout once the socket opens", async (t) => {
+  FakeWebSocket.instances = [];
+  t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+  const client = new WebsocketClient({
+    url: "ws://localhost",
+    getAccessToken: () => "token",
+    WebSocketImpl: FakeWebSocket,
+  });
+  t.after(() => client.disconnect());
+  const connecting = client.connect();
+  const first = FakeWebSocket.instances[0];
+  assert.ok(first);
+  t.mock.timers.tick(14_999);
+  first.open();
+  await waitFor(() => sentTypes(first).includes("auth"), "expected authentication");
+  first.receive(authOk("connection-1"));
+  await connecting;
+
+  t.mock.timers.tick(15_000);
+  assert.equal(client.state, "open");
+  assert.equal(FakeWebSocket.instances.length, 1);
+  assert.equal(first.readyState, WebSocket.OPEN);
+});
+
+test("rejects a stalled handshake without reconnecting when autoReconnect is disabled", async (t) => {
+  FakeWebSocket.instances = [];
+  t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+  const client = new WebsocketClient({
+    url: "ws://localhost",
+    autoReconnect: false,
+    connectTimeoutMs: 1234,
+    getAccessToken: () => "token",
+    WebSocketImpl: FakeWebSocket,
+  });
+  t.after(() => client.disconnect());
+  const rejected = assert.rejects(client.connect(), /connect timeout/);
+  t.mock.timers.tick(1233);
+  assert.equal(client.state, "connecting");
+  t.mock.timers.tick(1);
+  assert.equal(client.state, "closed");
+  await rejected;
+  t.mock.timers.tick(60_000);
+  assert.equal(FakeWebSocket.instances.length, 1);
+});
+
+test("disconnect cancels and settles a pending handshake without waiting for close", async (t) => {
+  FakeWebSocket.instances = [];
+  t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+  const client = new WebsocketClient({
+    url: "ws://localhost",
+    getAccessToken: () => "token",
+    WebSocketImpl: FakeWebSocket,
+  });
+  t.after(() => client.disconnect());
+  const closes: CloseSnapshot[] = [];
+  client.on("close", (snapshot) => closes.push(snapshot));
+  const connecting = client.connect();
+  const rejected = assert.rejects(connecting, /manual/);
+  const first = FakeWebSocket.instances[0];
+  assert.ok(first);
+  first.close = () => { first.readyState = WebSocket.CLOSING; };
+
+  await client.disconnect();
+  await rejected;
+  assert.deepEqual(closes, [{ code: 1000, reason: "manual", willReconnect: false }]);
+  t.mock.timers.tick(60_000);
+  assert.equal(client.state, "closed");
+  assert.equal(FakeWebSocket.instances.length, 1);
+});
+
+test("rejects invalid handshake timeout values", () => {
+  for (const connectTimeoutMs of [0, -1, 0.5, NaN, Infinity, 2_147_483_648]) {
+    assert.throws(
+      () => new WebsocketClient({ connectTimeoutMs, WebSocketImpl: FakeWebSocket }),
+      /connectTimeoutMs must be an integer between 1 and 2147483647/,
+    );
+  }
+});
+
 test("retries authentication with a forced token refresh and restores rooms", async () => {
   FakeWebSocket.instances = [];
   const tokenOptions: Array<{ forceRefresh?: boolean } | undefined> = [];


### PR DESCRIPTION
A WebSocket handshake that never emits `open`, `error`, or `close` leaves the SDK in `connecting` indefinitely, preventing retained room subscriptions from reaching the gateway. Add a configurable `connectTimeoutMs` (15 seconds by default) that closes the stalled socket and enters the existing reconnect backoff without waiting for a browser close event.

The change restores retained rooms after reconnect, ignores late events from old sockets, and settles pending connection promises on manual disconnect. It includes a patch changeset for `@neta-art/cohub`. Scope is limited to the SDK connection lifecycle and its tests.

Validation:

- Seven focused reconnect tests pass, covering stalled handshakes, room restoration, late events, successful open, disabled auto-reconnect, manual disconnect, and timeout validation.
- SDK suite: 297 tests pass.
- SDK build, lint, and typecheck pass.
- Commit hook: SDK, CLI, and web typechecks pass; Svelte reports zero errors or warnings.
