### PR TITLE
chore(deps): upgrade generation SDK to 0.1.27

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -35,7 +35,7 @@
     "@hono/node-server": "2.1.1",
     "@hono/otel": "^1.1.2",
     "@kubernetes/client-node": "^2.0.0",
-    "@neta-art/generation": "^0.1.26",
+    "@neta-art/generation": "^0.1.27",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.222.0",
     "@opentelemetry/instrumentation": "^0.222.0",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -28,7 +28,7 @@
     "@cohub/sandbox-controller": "workspace:*",
     "@earendil-works/pi-ai": "0.81.1",
     "@kubernetes/client-node": "^2.0.0",
-    "@neta-art/generation": "^0.1.26",
+    "@neta-art/generation": "^0.1.27",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.222.0",
     "@opentelemetry/instrumentation": "^0.222.0",

--- a/docs/examples/generations/gpt-image-2.yaml
+++ b/docs/examples/generations/gpt-image-2.yaml
@@ -44,6 +44,22 @@ parameters:
       - medium
       - high
     description: Image quality.
+  background:
+    type: string
+    optional: true
+    enum:
+      - auto
+      - opaque
+      - transparent
+    description: Requested background. Transparent output requires png or webp.
+  output_format:
+    type: string
+    optional: true
+    enum:
+      - png
+      - jpeg
+      - webp
+    description: Requested output file format. JPEG cannot preserve a transparent background.
 examples:
   - title: Basic image
     request:
@@ -54,3 +70,14 @@ examples:
       parameters:
         size: 1024x1024
         quality: auto
+  - title: Transparent background
+    request:
+      model: gpt-image-2
+      content:
+        - type: text
+          text: a ceramic cup isolated on a transparent background
+      parameters:
+        size: 1024x1024
+        quality: high
+        background: transparent
+        output_format: png

--- a/docs/generations.md
+++ b/docs/generations.md
@@ -176,6 +176,11 @@ cohub generate "a cyberpunk cat in neon rain" \
   --param size=1024x1024 \
   --param quality=high
 
+cohub generate "a ceramic cup isolated on a transparent background" \
+  --model gpt-image-2 \
+  --param background=transparent \
+  --param output_format=png
+
 cohub generate "same character, smiling" \
   --model gpt-image-2 \
   --image ./character.png \

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@neta-art/cohub": "workspace:*",
-    "@neta-art/generation": "^0.1.26",
+    "@neta-art/generation": "^0.1.27",
     "commander": "^15.0.0",
     "pixi.js": "^8.20.1",
     "sharp": "^0.35.4"

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -89,7 +89,7 @@
   "dependencies": {
     "@cohub/protocol": "workspace:*",
     "@kubiks/otel-drizzle": "^2.1.0",
-    "@neta-art/generation": "^0.1.26",
+    "@neta-art/generation": "^0.1.27",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.222.0",
     "@opentelemetry/instrumentation": "^0.222.0",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -162,7 +162,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@neta-art/generation": "^0.1.26",
+    "@neta-art/generation": "^0.1.27",
     "zod": "^4.5.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,8 +182,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       '@neta-art/generation':
-        specifier: ^0.1.26
-        version: 0.1.26
+        specifier: ^0.1.27
+        version: 0.1.27
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -549,8 +549,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       '@neta-art/generation':
-        specifier: ^0.1.26
-        version: 0.1.26
+        specifier: ^0.1.27
+        version: 0.1.27
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -639,8 +639,8 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       '@neta-art/generation':
-        specifier: ^0.1.26
-        version: 0.1.26
+        specifier: ^0.1.27
+        version: 0.1.27
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -728,8 +728,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.1)(kysely@0.28.17)(postgres@3.4.9))
       '@neta-art/generation':
-        specifier: ^0.1.26
-        version: 0.1.26
+        specifier: ^0.1.27
+        version: 0.1.27
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -799,8 +799,8 @@ importers:
   packages/protocol:
     dependencies:
       '@neta-art/generation':
-        specifier: ^0.1.26
-        version: 0.1.26
+        specifier: ^0.1.27
+        version: 0.1.27
       zod:
         specifier: ^4.5.4
         version: 4.5.4
@@ -2932,11 +2932,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@lix-js/sdk-linux-x64@0.12.3':
-    resolution: {integrity: sha512-PiQL4h1FJXbxnZx/PgenI5grgpFtYlS/ZtPtTYh638YHVu+6J0cqGY/pLVqP8CKv1dWAKsZ2YgftLd+1j2+WKA==}
-    cpu: [x64]
-    os: [linux]
-
   '@lix-js/sdk-win32-x64@0.12.3':
     resolution: {integrity: sha512-hnxMI7kPS4ngXs0ZVnOve5CmtC4+vaNIyNDi/yWU0rSvxj7mqw/1RCegTrCB7LjxlX4DG+eg9HruXurk9NDjGg==}
     cpu: [x64]
@@ -3092,8 +3087,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@neta-art/generation@0.1.26':
-    resolution: {integrity: sha512-iLy+HIDmEftybsbeJ0jwXy+fAFViQtmcYiTycoC07uFIAbS0CJMRuou38eYsQbAzDReqaUkB/2mzuJIcRjQC3Q==}
+  '@neta-art/generation@0.1.27':
+    resolution: {integrity: sha512-bB6qBFDZutLP6McbGoqm2OK4wE6yFdz+EOIS5pEnc+9eiQw71sFqgPQ3t/gSyc9th0xBHNVFyptPDOi9XnQw4Q==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -5236,7 +5231,6 @@ packages:
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globalthis@1.0.4:
@@ -8233,7 +8227,7 @@ snapshots:
     dependencies:
       '@cohub/protocol': file:packages/protocol
       '@kubiks/otel-drizzle': 2.1.0(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.1)(kysely@0.28.17)(postgres@3.4.9))
-      '@neta-art/generation': 0.1.26
+      '@neta-art/generation': 0.1.27
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/exporter-trace-otlp-proto': 0.222.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.222.0(@opentelemetry/api@1.9.1)
@@ -8256,7 +8250,7 @@ snapshots:
 
   '@cohub/protocol@file:packages/protocol':
     dependencies:
-      '@neta-art/generation': 0.1.26
+      '@neta-art/generation': 0.1.27
       zod: 4.5.4
 
   '@cspotcode/source-map-support@0.8.1':
@@ -9111,9 +9105,6 @@ snapshots:
   '@lix-js/sdk-linux-arm64@0.12.3':
     optional: true
 
-  '@lix-js/sdk-linux-x64@0.12.3':
-    optional: true
-
   '@lix-js/sdk-win32-x64@0.12.3':
     optional: true
 
@@ -9123,7 +9114,6 @@ snapshots:
     optionalDependencies:
       '@lix-js/sdk-darwin-arm64': 0.12.3
       '@lix-js/sdk-linux-arm64': 0.12.3
-      '@lix-js/sdk-linux-x64': 0.12.3
       '@lix-js/sdk-win32-x64': 0.12.3
 
   '@logto/browser@3.0.13':
@@ -9245,7 +9235,7 @@ snapshots:
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
-  '@neta-art/generation@0.1.26':
+  '@neta-art/generation@0.1.27':
     dependencies:
       yaml: 2.9.0
 


### PR DESCRIPTION
## Summary

- Upgrade `@neta-art/generation` from `^0.1.26` to `^0.1.27` in api, worker, CLI, infra, and protocol.
- 0.1.27 exposes GPT Image 2 `background` / `output_format`, defaults transparent output to png, and rejects jpeg + transparent.
- Update the gpt-image-2 declaration example and CLI docs so the new parameters are visible.

Web and CLI still render generation parameters from platform YAML, not SDK builtins. After this lands, `platform/.cohub/generations/gpt-image-2.yaml` still needs those two fields before the picker can show them.

## Test plan

- [x] `pnpm --filter @cohub/protocol test` — 104 tests
- [x] `pnpm --filter @cohub/infra typecheck` + test — 39 tests
- [x] `parseGenerationModelDeclaration` on `docs/examples/generations/gpt-image-2.yaml` accepts `background` and `output_format`
- [ ] CI lint / typecheck / test
- [ ] After merge + deploy, confirm worker uses 0.1.27; add the two params to live platform YAML if the picker should expose them


Made with [Cursor](https://cursor.com)